### PR TITLE
remove-sublayer: gemma-4 E-series is a value, not a key

### DIFF
--- a/scripts/make-test-model.py
+++ b/scripts/make-test-model.py
@@ -484,6 +484,11 @@ if ARCH == "gemma4" and not (ESERIES_SHARED_KV or ESERIES_PLE or G4HETERO):
 if G4HETERO:
     pattern = [g4_swa(i) for i in range(N_LAYER)]
     meta_kvs += [
+        # every gemma-4 export carries both E-series keys; the dense 12B/26B/
+        # 31B files publish them with value 0 (only a non-zero value makes a
+        # file E-series, and a loader or writer keying on presence is wrong)
+        kv_u32(f"{ARCH}.embedding_length_per_layer_input", 0),
+        kv_u32(f"{ARCH}.attention.shared_kv_layers", 0),
         kv_u32(f"{ARCH}.attention.key_length", 32),
         kv_u32(f"{ARCH}.attention.key_length_swa", 32 if G4_HD32 else 16),
         kv_arr_u32(f"{ARCH}.attention.head_count_kv",

--- a/src/quantize.c
+++ b/src/quantize.c
@@ -1540,9 +1540,14 @@ static int quantize_gguf_plan_inner(const char *in_path, const char *out_path, i
             (snprintf(key, sizeof key, "%s.ssm.conv_kernel", rarch),
              gguf_get(&g, key) != NULL))
             why = "hybrid or recurrent block typing";
+        // gemma-4 exports carry both E-series keys on every model, with 0
+        // on the dense ones (the 31B has embedding_length_per_layer_input
+        // = 0); it is the VALUE that makes a file E-series, as in the loader.
         else if ((snprintf(key, sizeof key, "%s.embedding_length_per_layer_input",
-                           rarch), gguf_get(&g, key) != NULL))
-            why = "gemma-4 E-series per-layer embeddings";
+                           rarch), gguf_get_u32(&g, key, 0) > 0) ||
+                 (snprintf(key, sizeof key, "%s.attention.shared_kv_layers",
+                           rarch), gguf_get_u32(&g, key, 0) > 0))
+            why = "gemma-4 E-series per-layer embeddings or shared KV";
         else if ((snprintf(key, sizeof key, "%s.nextn_predict_layers", rarch),
                   gguf_get_u32(&g, key, 0) > 0))
             why = "a declared NextN/MTP head";

--- a/tests/test_remove_sublayer.py
+++ b/tests/test_remove_sublayer.py
@@ -398,3 +398,41 @@ def test_gpu_path_is_refused_for_now(runner_bin, parent, tmp_path):
     p = _run(runner_bin, ["-m", a, "-p", "hi", "-n", "1", "--gpu", "auto"])
     assert p.returncode != 0
     assert b"--gpu off" in p.stderr
+
+
+# ---------------------------------------------------- the gemma-4 file shape
+@pytest.fixture(scope="module")
+def gemma4_hetero(tmp_path_factory):
+    """gemma4 with the real 26B/12B/31B header shape: head_count scalar,
+    head_count_kv already a per-layer ARRAY, sliding pattern, V-less full
+    layers (tied V), sandwich norms, and the two E-series keys present with
+    value 0 (every gemma-4 export carries them; only a non-zero value makes
+    a file E-series)."""
+    out = tmp_path_factory.mktemp("rm-g4") / "g4.gguf"
+    subprocess.run([sys.executable, ROOT / "scripts/make-test-model.py",
+                    "--gemma4-hetero", str(out)], check=True, cwd=ROOT,
+                   stdout=subprocess.DEVNULL)
+    return out
+
+
+@pytest.mark.parametrize("layer", [1, 2])  # 1 slides (has V); 2 is full and V-less
+def test_gemma4_shape_removal_matches_zeroed_output(runner_bin, gemma4_hetero,
+                                                    tmp_path, layer):
+    kv = _parse(gemma4_hetero)["kvs"]
+    assert isinstance(kv["gemma4.attention.head_count_kv"], list)
+    assert kv.get("gemma4.embedding_length_per_layer_input") == 0
+    out = tmp_path / f"g4-attn{layer}.gguf"
+    p = _remove(runner_bin, gemma4_hetero, out, f"attn:{layer}")
+    assert p.returncode == 0, p.stderr.decode(errors="replace")
+    zeroed = tmp_path / "z.gguf"
+    _zero_tensor(gemma4_hetero, zeroed, f"blk.{layer}.attn_output.weight")
+    assert _score(runner_bin, out) == _score(runner_bin, zeroed)
+    assert _score(runner_bin, out) != _score(runner_bin, gemma4_hetero)
+    ok = _parse(out)["kvs"]
+    hc = ok["gemma4.attention.head_count"]
+    assert isinstance(hc, list) and hc[layer] == 0 and all(hc[i] == kv["gemma4.attention.head_count"] for i in range(len(hc)) if i != layer)
+    hk = ok["gemma4.attention.head_count_kv"]
+    assert hk[layer] == 0
+    assert [v for i, v in enumerate(hk) if i != layer] == \
+        [v for i, v in enumerate(kv["gemma4.attention.head_count_kv"]) if i != layer]
+    assert f"blk.{layer}.attn_q.weight" not in _parse(out)["tensors"]


### PR DESCRIPTION
Every gemma-4 export carries `embedding_length_per_layer_input` and `attention.shared_kv_layers`; the dense 12B/26B/31B files publish them as 0. The writer refused the 31B on key presence; it now refuses on a non-zero value, as the loader does. The gemma4-hetero fixture gains both keys at 0 (the real header shape) and the removal suite gains the gemma-4 case: attention removed on a sliding and on a V-less full block, bit-identical to the zeroed output projection, with the existing `head_count_kv` array re-authored entry by entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)