### PR TITLE
release: v0.4.7, the sublayer-removal release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@ has no attention, and the loader that reads it.
   key presence and now refuses on a non-zero value, as the loader does. The
   gemma4-hetero fixture carries both keys at 0.
 
+- **The compat harness tells "did not execute" from "failed" on a shared
+  device.** A CUDA side refused for a stated VRAM reason (`error: ... of
+  VRAM requested ... but only ... is available`) is recorded as
+  `not_executed` / `insufficient_vram` with the line, never as a failed
+  identity; `cpu_cuda_check.py` now surfaces the backend log's error lines
+  when the server dies during startup. A CPU-only matrix (`--gpu off`) runs
+  the chat smoke on the CPU path even where the row pins `auto`, instead of
+  waiting 300 s for VRAM and timing out without asking the question. Both
+  found on the 2026-09-04 Blackwell matrix, whose MIG slice was shared with
+  a running study.
+
 ## v0.4.6 - 2026-09-02
 
 - **The compat harness classifies an unbuilt tokenizer tool as `not_executed`**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ change between releases (the `-alpha` suffix was retired at v0.2.0 — the 0.x
 version already says what it needs to). Entries below the rename keep the
 names that were true when they were written.
 
-## Unreleased
+## v0.4.7 - 2026-09-04
+
+The sublayer-removal release: the first artifact whose header says a block
+has no attention, and the loader that reads it.
+
 
 - **`--remove-sublayer attn:N[,mlp:M,...]`: a block's attention or dense-FFN
   tensors are physically dropped from the file, and the absence is declared
@@ -21,6 +25,20 @@ names that were true when they were written.
   fixture. CPU path and dense blocks only; MoE FFNs, hybrid families,
   E-series, fused-QKV, NextN heads, `--lora` and `--train` are declined by
   name. Norms stay (kilobytes; the residual plumbing is unchanged).
+  Measured on the real Gemma 4 31B Q4_0 (`docs/sublayer-removal.md`): the
+  `attn:48` cut drops 74,319,872 bytes of tensor data, frees 64 MiB of KV at
+  ctx 4,096 and 512 MiB at 32,768, scores bit-identically to the same cut as
+  a zeroed-weights file over 4,562 positions, and passes the raw-protocol
+  bar at KLD 0.0239; stock llama.cpp refuses the file by name, the intended
+  failure. The artifact is published as
+  `Joakimpalm-Zen/gemma-4-31B-it-attn48-removed-Q4_0-GGUF` and needs this
+  release or later to load.
+
+- **Gemma-4 E-series is a value, not a key.** Every gemma-4 export carries
+  `embedding_length_per_layer_input` and `attention.shared_kv_layers`; the
+  dense 12B/26B/31B files publish them as 0. The writer refused the 31B on
+  key presence and now refuses on a non-zero value, as the loader does. The
+  gemma4-hetero fixture carries both keys at 0.
 
 ## v0.4.6 - 2026-09-02
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ for Linux, macOS, or Windows, or build from source:
 git clone https://github.com/Joakimpalm-Zen/xyntetik-runner
 cd xyntetik-runner
 make
-./runner --version   # -> runner 0.4.6
+./runner --version   # -> runner 0.4.7
 ```
 
 CUDA builds and releases need only an NVIDIA driver at runtime. The CUDA
@@ -198,7 +198,7 @@ Run a GGUF:
 ./runner -m qwen3.5-4b-mtp.gguf --mtp --gpu off -p "Continue this code"
 ```
 
-> **Pre-1.0 (`0.4.6`).** APIs, model coverage and certification envelopes may
+> **Pre-1.0 (`0.4.7`).** APIs, model coverage and certification envelopes may
 > change between releases. CI builds and smoke-tests Linux, macOS, and
 > Windows, but the project still has limited hardware coverage. Include
 > `runner --version`, `runner --caps`, the model's exact filename, and the load
@@ -366,7 +366,7 @@ shell, then run `make`.
 
 Each release publishes a CPU image - the same binary on a distroless glibc base,
 nothing else - to `ghcr.io/joakimpalm-zen/xyntetik-runner:v<version>` (the
-tag carries the `v`, e.g. `:v0.4.6`) and `:latest`. Build it yourself with `docker build -t runner .`.
+tag carries the `v`, e.g. `:v0.4.7`) and `:latest`. Build it yourself with `docker build -t runner .`.
 
 The server binds **loopback only** by design (there is no `--host`/`0.0.0.0`
 flag), so it never exposes itself to a network, even in a container - which

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-Runner is **pre-1.0** (`0.4.6`). Only the latest release is
+Runner is **pre-1.0** (`0.4.7`). Only the latest release is
 supported; there are no backports.
 
 ## Threat model

--- a/docs/compat-reports/0.4.7-2026-09-04-blackwell-gemma4.json
+++ b/docs/compat-reports/0.4.7-2026-09-04-blackwell-gemma4.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "xyntetik.runner.model-compat-report.v1",
+  "generated_utc": "2026-09-04T10:45:34Z",
+  "host": {
+    "os": "Linux",
+    "machine": "x86_64"
+  },
+  "runner": {
+    "path": "runner",
+    "version": "runner 0.4.7"
+  },
+  "reference": {
+    "path": null,
+    "version": null
+  },
+  "models": [
+    {
+      "id": "gemma-4-e4b-it-q4_k_m",
+      "architecture": "gemma4",
+      "file": "models/gemma-4-E4B-it-Q4_K_M.gguf",
+      "expected_sha256": "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87",
+      "checks": {
+        "load": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 218.9,
+          "stderr_tail": "gemma4: E-series (per-layer embeddings + shared KV) \u2014 verified against llama.cpp at the Q4_K noise floor rather than token-identically\nrope: using model frequency factors (rope_freqs.weight)\nloaded /home/lab/workspace/models/gemma-4-E4B-it-Q4_K_M/gemma-4-E4B-it-Q4_K_M.gguf | gemma4 | 42 layers | ctx 4096 | 32 threads | 0.04s\nsampling: gemma3 (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\n\nprompt: 4 tok, 36.17 tok/s | gen: 1 tok, 24.00 tok/s\n"
+        },
+        "cpu_cuda": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 71547.46,
+          "pins": {
+            "RUNNER_CUDA_TC": "0",
+            "RUNNER_MOE_EAGER": "1"
+          },
+          "min_prompt_tokens": 85,
+          "cpu_cuda_identity": {
+            "result": "pass",
+            "exact": "9/9",
+            "near_tie_tolerated": 0
+          },
+          "identical": "9/9",
+          "failed_prompts": [],
+          "report": "/home/lab/workspace/.r41-runner/rel047/cpu_cuda/gemma-4-e4b-it-q4_k_m.json",
+          "output_tail": "'\nok  : 'Q: What is 17 * 23?\\nA:'\nok  : 'The lighthouse keeper recorded the weather every morning: wind direction, cloud cover, and the hour the fog lifted.'\nok  : 'In 1929 the observatory published a revised catalogue listing 4218 objects, of which roughly one in nine turned out on later inspection to be a duplicate entry under a second designation. The correction'\nok  : \"def parse_header(buf, size):\\n    if size < 8:\\n        raise ValueError('short header')\\n    magic, version = struct.unpack('<II', buf[:8])\\n    if magic != GGUF_MAGIC:\\n        raise ValueError('not a gguf file')\\n    return magic, version\\n\\n# The loader above rejects a truncated header before unpacking it, which\"\nok  : 'The city of Lisbon sits on seven hills above the Tagus estuary, and its oldest quarter survived the 1755 earthquake largely intact because the bedrock there is firmer than the reclaimed ground downriver. Rebuilding the lower town took decades, and the grid of streets laid out afterwards was among the first in Europe designed with seismic loads in mind, which is why the district still reads as unusually regular to a visitor who'\n\ncpu_cuda: pass \u2014 9/9 exact, 0 near-tie tolerated (eager routing)\n"
+        },
+        "chat": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 547.15,
+          "prompt": "What is 2+2?",
+          "gpu": "off",
+          "failure_reasons": [],
+          "output_tail": "2 + 2 equals **4**.\n"
+        }
+      },
+      "resolved_file": "models/gemma-4-E4B-it-Q4_K_M.gguf",
+      "actual_sha256": "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87",
+      "file_status": "pass",
+      "complete": true
+    }
+  ],
+  "complete": true,
+  "summary": {
+    "models": 1,
+    "files": {
+      "pass": 1
+    },
+    "checks": {
+      "load": {
+        "pass": 1
+      },
+      "cpu_cuda": {
+        "pass": 1
+      },
+      "chat": {
+        "pass": 1
+      }
+    }
+  }
+}

--- a/docs/compat-reports/0.4.7-2026-09-04-blackwell-moe.json
+++ b/docs/compat-reports/0.4.7-2026-09-04-blackwell-moe.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "xyntetik.runner.model-compat-report.v1",
+  "generated_utc": "2026-09-04T10:44:25Z",
+  "host": {
+    "os": "Linux",
+    "machine": "x86_64"
+  },
+  "runner": {
+    "path": "runner",
+    "version": "runner 0.4.7"
+  },
+  "reference": {
+    "path": null,
+    "version": null
+  },
+  "models": [
+    {
+      "id": "qwen3-30b-a3b-q4_k_m",
+      "architecture": "qwen3moe",
+      "file": "models/Qwen3-30B-A3B-Q4_K_M.gguf",
+      "expected_sha256": "0d003f6662faee786ed5da3e31b29c978de5ae5d275c8794c606a7f3c01aa8f5",
+      "checks": {
+        "load": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 217.1,
+          "stderr_tail": "loaded /home/lab/workspace/models/Qwen3-30B-A3B-Q4_K_M/Qwen3-30B-A3B-Q4_K_M.gguf | qwen3moe | 48 layers | ctx 4096 | 32 threads | 0.01s\nsampling: qwen3 (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\n\nprompt: 3 tok, 20.74 tok/s | gen: 1 tok, 27.86 tok/s\n"
+        },
+        "cpu_cuda": {
+          "status": "not_executed",
+          "reason": "insufficient_vram",
+          "detail": "error: 19.3GB of VRAM requested on GPU-399aa5c7-bb47-5ccb-b688-54fefec06647, but only 16.2GB is available",
+          "elapsed_ms": 35644.17,
+          "pins": {
+            "RUNNER_CUDA_TC": "0",
+            "RUNNER_MOE_EAGER": "1"
+          },
+          "report": "/home/lab/workspace/.r41-runner/rel047/cpu_cuda/qwen3-30b-a3b-q4_k_m.json"
+        },
+        "chat": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 724.4,
+          "prompt": "What is 2+2?",
+          "gpu": "off",
+          "failure_reasons": [],
+          "output_tail": "2 + 2 = 4.\n"
+        },
+        "tool": {
+          "status": "fail",
+          "returncode": 1,
+          "elapsed_ms": 23304.03,
+          "scenario_matrix": "agent-torture",
+          "totals": {
+            "requests": 8,
+            "passed": 2,
+            "failed": 6
+          },
+          "report": "/home/lab/workspace/.r41-runner/rel047/tool/qwen3-30b-a3b-q4_k_m.json",
+          "output_tail": "report: /home/lab/workspace/.r41-runner/rel047/tool/qwen3-30b-a3b-q4_k_m/report.json\nraw: /home/lab/workspace/.r41-runner/rel047/tool/qwen3-30b-a3b-q4_k_m/raw.jsonl\nruntime=runner requests=8 passed=2 failed=6\n"
+        },
+        "greedy_reference": {
+          "status": "not_executed",
+          "reason": "reference_binary_not_provided"
+        },
+        "long_context": {
+          "status": "not_executed",
+          "reason": "check_class_not_executable"
+        }
+      },
+      "resolved_file": "models/Qwen3-30B-A3B-Q4_K_M.gguf",
+      "actual_sha256": "0d003f6662faee786ed5da3e31b29c978de5ae5d275c8794c606a7f3c01aa8f5",
+      "file_status": "pass",
+      "complete": false
+    }
+  ],
+  "complete": false,
+  "summary": {
+    "models": 1,
+    "files": {
+      "pass": 1
+    },
+    "checks": {
+      "load": {
+        "pass": 1
+      },
+      "cpu_cuda": {
+        "not_executed": 1
+      },
+      "chat": {
+        "pass": 1
+      },
+      "tool": {
+        "fail": 1
+      },
+      "greedy_reference": {
+        "not_executed": 1
+      },
+      "long_context": {
+        "not_executed": 1
+      }
+    }
+  }
+}

--- a/docs/compat-reports/0.4.7-2026-09-04-blackwell.json
+++ b/docs/compat-reports/0.4.7-2026-09-04-blackwell.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "xyntetik.runner.model-compat-report.v1",
+  "generated_utc": "2026-09-04T10:41:31Z",
+  "host": {
+    "os": "Linux",
+    "machine": "x86_64"
+  },
+  "runner": {
+    "path": "runner",
+    "version": "runner 0.4.7"
+  },
+  "reference": {
+    "path": null,
+    "version": null
+  },
+  "models": [
+    {
+      "id": "granite-4.1-8b-q4_0",
+      "architecture": "granite",
+      "file": "models/granite-4.1-8b-Q4_0.gguf",
+      "expected_sha256": "5adf9b6b78921093bd4a805e1060f85d7f744c3eafc14d1ca449364d1e721a1a",
+      "checks": {
+        "load": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 212.1,
+          "stderr_tail": "loaded /home/lab/workspace/models/granite-4.1-8b-Q4_0/granite-4.1-8b-Q4_0.gguf | granite | 40 layers | ctx 4096 | 32 threads | 0.01s\nsampling: generic (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\n\nprompt: 3 tok, 32.16 tok/s | gen: 1 tok, 19.56 tok/s\n"
+        },
+        "tokenizer": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 2949.8,
+          "stdout_tail": "\n0/721 strings differ (0 of them begin with whitespace)\nOK\n",
+          "stderr_tail": "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+        },
+        "cpu_cuda": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 166360.95,
+          "pins": {
+            "RUNNER_CUDA_TC": "0"
+          },
+          "min_prompt_tokens": 85,
+          "cpu_cuda_identity": {
+            "result": "pass",
+            "exact": "9/9",
+            "near_tie_tolerated": 0
+          },
+          "identical": "9/9",
+          "failed_prompts": [],
+          "report": "/home/lab/workspace/.r41-runner/rel047/cpu_cuda/granite-4.1-8b-q4_0.json",
+          "output_tail": "'\nok  : 'Q: What is 17 * 23?\\nA:'\nok  : 'The lighthouse keeper recorded the weather every morning: wind direction, cloud cover, and the hour the fog lifted.'\nok  : 'In 1929 the observatory published a revised catalogue listing 4218 objects, of which roughly one in nine turned out on later inspection to be a duplicate entry under a second designation. The correction'\nok  : \"def parse_header(buf, size):\\n    if size < 8:\\n        raise ValueError('short header')\\n    magic, version = struct.unpack('<II', buf[:8])\\n    if magic != GGUF_MAGIC:\\n        raise ValueError('not a gguf file')\\n    return magic, version\\n\\n# The loader above rejects a truncated header before unpacking it, which\"\nok  : 'The city of Lisbon sits on seven hills above the Tagus estuary, and its oldest quarter survived the 1755 earthquake largely intact because the bedrock there is firmer than the reclaimed ground downriver. Rebuilding the lower town took decades, and the grid of streets laid out afterwards was among the first in Europe designed with seismic loads in mind, which is why the district still reads as unusually regular to a visitor who'\n\ncpu_cuda: pass \u2014 9/9 exact, 0 near-tie tolerated (eager routing)\n"
+        },
+        "chat": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 1065.12,
+          "prompt": "What is 2+2?",
+          "gpu": "off",
+          "failure_reasons": [],
+          "output_tail": "The answer to the mathematical expression 2 + 2 is 4.\n"
+        },
+        "greedy_reference": {
+          "status": "not_executed",
+          "reason": "reference_binary_not_provided"
+        }
+      },
+      "resolved_file": "models/granite-4.1-8b-Q4_0.gguf",
+      "actual_sha256": "5adf9b6b78921093bd4a805e1060f85d7f744c3eafc14d1ca449364d1e721a1a",
+      "file_status": "pass",
+      "complete": false
+    }
+  ],
+  "complete": false,
+  "summary": {
+    "models": 1,
+    "files": {
+      "pass": 1
+    },
+    "checks": {
+      "load": {
+        "pass": 1
+      },
+      "tokenizer": {
+        "pass": 1
+      },
+      "cpu_cuda": {
+        "pass": 1
+      },
+      "chat": {
+        "pass": 1
+      },
+      "greedy_reference": {
+        "not_executed": 1
+      }
+    }
+  }
+}

--- a/docs/compat-reports/cuda-smoke-0.4.7-2026-09-04-rtx3070.json
+++ b/docs/compat-reports/cuda-smoke-0.4.7-2026-09-04-rtx3070.json
@@ -1,0 +1,103 @@
+{
+  "checks": [
+    {
+      "check": "cuda_backend_present",
+      "detail": "caps.gpu.backend = 'cuda' (expected 'cuda'; absent means the CUDA driver never initialised)",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "version_matches",
+      "detail": "caps.version = '0.4.7', expected '0.4.7'",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_memory_is_boolean",
+      "detail": "caps.gpu.unified_memory = False",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_memory_agrees_with_pool_sizes",
+      "detail": "unified_memory=False with vram_bytes=8589279232 and ram_bytes=17109143552 (vram/ram = 0.502, one pool expected >= 0.85)",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_flag_not_suspiciously_false",
+      "detail": "unified_memory=False with vram/ram = 0.502",
+      "ok": true,
+      "severity": "warn"
+    },
+    {
+      "check": "vram_reported",
+      "detail": "vram_bytes = 8589279232",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "gpu_quants_present",
+      "detail": "gpu_quants has 16 entries",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "gpu_quants_subset_of_quants",
+      "detail": "every gpu_quant is loadable",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "generation_exit_zero",
+      "detail": "runner exited 0",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "gpu_engaged_for_generation",
+      "detail": "load output carries the CUDA backend line",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "tokens_generated",
+      "detail": "generated 24 tokens",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "layers_offloaded",
+      "detail": "gpu-split G=28/28",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_notice_matches_caps",
+      "detail": "load output omits the unified-memory notice while caps said False",
+      "ok": true,
+      "severity": "fail"
+    }
+  ],
+  "generation_output": "gpu-split: budget=7.46GB fixed=0.72GB G=28/28 full=1 used=1.66GB\r\ngpu: CUDA backend on NVIDIA GeForce RTX 3070 (0.6 GB weights in VRAM)\r\ngpu: VRAM 6.32 GB free of 8.59 GB after init (kv 0.47 GB + scratch 0.02 GB this instance)\r\nloaded C:/Users/zen/qwen3-0.6b-q8_0.gguf | qwen3 | 28 layers | ctx 4096 | 4 threads | 0.51s\r\nsampling: qwen3 (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\r\nThe capital of France is Paris. The capital of France is also the capital of the Republic of France. The capital of France is also the capital\r\nprompt: 5 tok, 190.79 tok/s | gen: 24 tok, 274.71 tok/s\r\n\r\n",
+  "gpu": {
+    "backend": "cuda",
+    "eseries": true,
+    "kv_q8": true,
+    "min_compute_capability": "7.5",
+    "min_gpu": "NVIDIA Turing / compute capability 7.5 or newer",
+    "moe": true,
+    "name": "NVIDIA GeForce RTX 3070",
+    "ptx_target": "sm_75",
+    "unified_memory": false,
+    "vram_bytes": 8589279232,
+    "vram_free_bytes": 7459569664
+  },
+  "host": {
+    "arch": "x86_64",
+    "os": "windows",
+    "ram_bytes": 17109143552
+  },
+  "passed": true,
+  "runner_version": "0.4.7"
+}

--- a/docs/moe-support.md
+++ b/docs/moe-support.md
@@ -1,7 +1,7 @@
 # Sparse-MoE support — implementation and test report
 
 Date: 2026-07-24
-Runner: v0.4.6 (core support plus the follow-ups at the end of this doc)
+Runner: v0.4.7 (core support plus the follow-ups at the end of this doc)
 Hardware: NVIDIA RTX PRO 6000 Blackwell, **24 GB MIG slice** (`MIG 1g.24gb`),
 CPU fallback on the same host (64 threads).
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xyntetik-runner-client"
-version = "0.4.6"
+version = "0.4.7"
 description = "Python client and process boundary for Xyntetik Runner"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/compat_matrix.py
+++ b/scripts/compat_matrix.py
@@ -137,6 +137,18 @@ def run_cpu_cuda(runner, model, params, timeout, report_dir=None, model_id=None)
     verdict = re.search(r"cpu_cuda: (pass_margin_qualified|pass|fail) — "
                         r"(\d+)/(\d+) exact, (\d+) near-tie", out)
     failed_prompts = re.findall(r"^FAIL: (.+)$", out, re.M)
+    # A device that refused the load for a stated resource reason compared
+    # nothing: on 2026-09-04 the Qwen3-30B-A3B row read "fail" because the
+    # shared MIG slice had 16.2 GB free against 19.3 GB requested (another
+    # study held it). That is not_executed with the reason, never a failure
+    # of the identity, and never a pass.
+    vram = re.search(r"error: [^\n]*of VRAM requested[^\n]*", out) if not verdict else None
+    if vram:
+        return {"status": "not_executed", "reason": "insufficient_vram",
+                "detail": vram.group(0)[:300],
+                "elapsed_ms": round((time.time() - started) * 1000, 2),
+                "pins": params.get("pins") or {},
+                "report": str(report_path) if report_path else None}
     if verdict:
         status = verdict.group(1)          # pass | pass_margin_qualified | fail
         identity = {"result": status, "exact": f"{verdict.group(2)}/{verdict.group(3)}",
@@ -158,12 +170,19 @@ def run_cpu_cuda(runner, model, params, timeout, report_dir=None, model_id=None)
             "output_tail": out[-1200:]}
 
 
-def run_chat(runner, model, params, timeout):
-    """One-shot chat smoke: the model must answer, stop, and not leak markup."""
+def run_chat(runner, model, params, timeout, gpu_mode="auto"):
+    """One-shot chat smoke: the model must answer, stop, and not leak markup.
+
+    gpu_mode is the harness's own --gpu: a CPU-only matrix (--gpu off) runs the
+    smoke on the CPU path regardless of the row's pinned "auto". Before this the
+    pinned auto plus --wait-for-vram turned a shared, full device into a
+    300-second wait and a "chat_timeout" that had asked the model nothing
+    (2026-09-04)."""
     prompt = params.get("prompt", "What is 2+2?")
+    gpu = "off" if gpu_mode == "off" else params.get("gpu", "auto")
     cmd = [str(runner), "-m", str(model), "-i", "--no-tray", "--temp", "0",
-           "--gpu", params.get("gpu", "auto"), "-n",
-           str(params.get("max_tokens", 200)), "--wait-for-vram", "300"]
+           "--gpu", gpu, "-n", str(params.get("max_tokens", 200))] + \
+          (["--wait-for-vram", "300"] if gpu == "auto" else [])
     # The smoke asks whether the model answers and stops through its
     # template. A thinking family left to its default spends the whole
     # ceiling deliberating whether 2+2 might be in another base (Qwen3-30B,
@@ -194,7 +213,7 @@ def run_chat(runner, model, params, timeout):
     return {"status": "pass" if not reasons and proc.returncode == 0 else "fail",
             "returncode": proc.returncode,
             "elapsed_ms": round((time.time() - started) * 1000, 2),
-            "prompt": prompt, "failure_reasons": reasons,
+            "prompt": prompt, "gpu": gpu, "failure_reasons": reasons,
             "output_tail": out[-300:]}
 
 
@@ -499,7 +518,8 @@ def main(argv=None):
                     # hand them the ledger's directory and this model's id so it
                     # is written and referenced rather than truncated to a tail.
                     extra = ({"report_dir": report_dir, "model_id": entry["id"]}
-                             if fn in (run_cpu_cuda, run_tool) else {})
+                             if fn in (run_cpu_cuda, run_tool)
+                             else {"gpu_mode": args.gpu} if fn is run_chat else {})
                     item["checks"][cls] = fn(args.runner.resolve(), path.resolve(),
                                              cp, args.timeout, **extra)
                     failed |= item["checks"][cls]["status"] == "fail"

--- a/scripts/cpu_cuda_check.py
+++ b/scripts/cpu_cuda_check.py
@@ -211,7 +211,20 @@ def wait_ready(base, process, timeout):
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if process.poll() is not None:
-            raise SystemExit(f"server exited during startup (rc={process.returncode})")
+            # The reason is in the backend log, not the exit code: a VRAM
+            # refusal on a shared device and a real crash both return 1, and
+            # the ledger needs to tell them apart. Surface the log's error
+            # line(s) in the message the harness reads.
+            why = ""
+            try:
+                log_path = getattr(process, "_runner_log_path", None)
+                if log_path:
+                    text = pathlib.Path(log_path).read_text(encoding="utf-8", errors="replace")
+                    errs = [ln for ln in text.splitlines() if ln.startswith("error:")]
+                    why = ": " + " | ".join(errs[-3:]) if errs else ""
+            except OSError:
+                pass
+            raise SystemExit(f"server exited during startup (rc={process.returncode}){why}")
         try:
             urllib.request.urlopen(base + "/health", timeout=2).read()
             return
@@ -249,6 +262,7 @@ def generate_all(runner, model, gpu, tokens, ctx, env, extra, timeout, log_path)
     log = open(log_path, "w", encoding="utf-8")
     proc = subprocess.Popen(cmd, stdout=log, stderr=subprocess.STDOUT, env=env)
     try:
+        proc._runner_log_path = str(log_path)
         wait_ready(base, proc, timeout)
         out = []
         for prompt in PROMPTS:

--- a/src/runner.h
+++ b/src/runner.h
@@ -2,7 +2,7 @@
 #ifndef RUNNER_H
 #define RUNNER_H
 
-#define RUNNER_VERSION "0.4.6"
+#define RUNNER_VERSION "0.4.7"
 #define RUNNER_CUDA_NVCC_ARCH "compute_75"
 #define RUNNER_CUDA_PTX_TARGET "sm_75"
 #define RUNNER_CUDA_MIN_CC "7.5"

--- a/tests/test_compat_matrix.py
+++ b/tests/test_compat_matrix.py
@@ -670,3 +670,47 @@ def test_chat_smoke_asks_for_the_non_thinking_prompt_shape(monkeypatch, tmp_path
     assert "--no-think" in seen["cmd"]
     module.run_chat(tmp_path / "runner", tmp_path / "m.gguf", {"thinking": True}, 10)
     assert "--no-think" not in seen["cmd"]
+
+
+def test_cpu_cuda_vram_refusal_is_not_executed_with_the_reason(monkeypatch, tmp_path):
+    """A shared device that refused the load compared nothing. On 2026-09-04
+    the Qwen3-30B-A3B row read "fail" because the MIG slice had 16.2 GB free
+    against 19.3 GB requested by the CUDA side; the identity was never run."""
+    module = load_module()
+
+    class Proc:
+        returncode = 1
+        stdout = "[off] 'prompt one' -> ' answer'\nloading CUDA backend...\n"
+        stderr = ("server exited during startup (rc=1): error: 19.3GB of VRAM "
+                  "requested on GPU-399a, but only 16.2GB is available\n")
+
+    monkeypatch.setattr(module, "run_group", lambda cmd, timeout, **kw: Proc())
+    r = module.run_cpu_cuda(tmp_path / "runner", tmp_path / "m.gguf",
+                            {"tokens": 128, "pins": {"RUNNER_MOE_EAGER": "1"}}, 60)
+    assert r["status"] == "not_executed"
+    assert r["reason"] == "insufficient_vram"
+    assert "16.2GB" in r["detail"]
+
+
+def test_chat_smoke_follows_a_cpu_only_matrix(monkeypatch, tmp_path):
+    """--gpu off on the harness means the smoke runs on the CPU path even when
+    the row pins "auto"; a pinned auto on a full shared device waited 300 s
+    for VRAM and timed out without asking the question (2026-09-04)."""
+    module = load_module()
+    seen = {}
+
+    class Proc:
+        returncode = 0
+        stdout = "4\n"
+        stderr = ""
+
+    monkeypatch.setattr(module, "run_group",
+                        lambda cmd, timeout, **kw: seen.__setitem__("cmd", cmd) or Proc())
+    r = module.run_chat(tmp_path / "runner", tmp_path / "m.gguf", {"gpu": "auto"}, 10,
+                        gpu_mode="off")
+    assert r["status"] == "pass" and r["gpu"] == "off"
+    assert seen["cmd"][seen["cmd"].index("--gpu") + 1] == "off"
+    assert "--wait-for-vram" not in seen["cmd"]
+    module.run_chat(tmp_path / "runner", tmp_path / "m.gguf", {"gpu": "auto"}, 10)
+    assert seen["cmd"][seen["cmd"].index("--gpu") + 1] == "auto"
+    assert "--wait-for-vram" in seen["cmd"]


### PR DESCRIPTION
Version pins to 0.4.7, the changelog retitled, the compat-harness classification fix (a VRAM refusal on a shared device is not_executed with the reason; a CPU-only matrix runs the chat smoke on the CPU path), and the release evidence: the CUDA smoke gate on the RTX 3070 (13 checks, PASS) and the Blackwell compat matrix on three pinned models. Tag v0.4.7 follows main CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)