### PR TITLE
README: the attn:48 artifact loads from v0.4.7 on

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,9 +598,8 @@ reported beside it).
   4k context and 512 MiB at 32k, plus 74.3 MB of file, and tracks its parent
   at clean KLD 0.0223 on 44,413 held-out positions (measured 2026-08-30 on
   the identical zeroed form, carried over by bit identity 2026-09-04). It
-  loads only in this runner built from `main` after 2026-09-04 (the next
-  release carries it), CPU path, and llama.cpp refuses it by name; the card
-  says so beside the numbers.
+  loads only in this runner from v0.4.7 on, CPU path, and llama.cpp refuses
+  it by name; the card says so beside the numbers.
 - Measurement reports over third-party artifacts, no weights republished,
   every measured file bound by SHA:
   [Hermes-4-14B quant fidelity](https://huggingface.co/Joakimpalm-Zen/Hermes-4-14B-quant-fidelity-report)


### PR DESCRIPTION
Doc-only: the published-artifacts bullet names v0.4.7 instead of "the next release".

🤖 Generated with [Claude Code](https://claude.com/claude-code)