### PR TITLE
R10.1: cached prompt tokens in usage, and a Prometheus /metrics endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ change between releases (the `-alpha` suffix was retired at v0.2.0 — the 0.x
 version already says what it needs to). Entries below the rename keep the
 names that were true when they were written.
 
+## Unreleased
+
+- **`usage.prompt_tokens_details.cached_tokens`: the prefix-cache figure in
+  the field a standard client reads.** Runner has always counted, per request,
+  how many prompt rows it did not have to prefill, and reported it as
+  `runner_telemetry.prompt_cached_tokens`, which no OpenAI-shaped client looks
+  at. It is now also carried where OpenAI carries it: on Chat Completions and
+  legacy Completions (buffered and in the `stream_options.include_usage`
+  chunk), and as `usage.input_tokens_details.cached_tokens` on Responses. The
+  three renderings come from one function, so a client that flips `stream` on
+  and off sees one shape. `prompt_tokens` keeps its meaning, cached tokens
+  included, as at OpenAI, so no caller's total moves. Anthropic Messages does
+  not gain it: `cache_read_input_tokens` describes Anthropic's product with
+  Anthropic's semantics, and that decision stays pinned by its own test.
+
+- **`GET /metrics`: Prometheus text exposition 0.0.4.** The counters `/health`
+  and `/v1/runner/prefix-cache` already answer, in the format a monitoring
+  stack ingests without a translator: requests, prompt/generated/cached
+  tokens, generation seconds, microbatch steps and sequences, the
+  prefix-cache hit/miss/store/eviction/reuse counters and its byte and entry
+  gauges, the speculation round/drafted/accepted counters, and the two RSS
+  gauges. Names carry the `runner_` prefix, each sample is preceded by its own
+  `# HELP` and `# TYPE`, and a body that would not fit its buffer is refused
+  rather than truncated - a half-written exposition reads to a scraper as
+  metrics that reset. On whenever `--serve` is, no flag, answered from the
+  accept thread with atomic loads only, and it does not count its own
+  requests. Advertised as `features.prometheus_metrics`.
+
 ## v0.4.7 - 2026-09-04
 
 The sublayer-removal release: the first artifact whose header says a block

--- a/README.md
+++ b/README.md
@@ -1120,6 +1120,7 @@ non-loopback authorities.
 | `GET /v1/runner/prefix-cache` | Prefix-cache size, limits, and counters. Takes no request body and remains available while inference is active. |
 | `POST /v1/runner/prefix-cache/clear` | Release cached prefixes without unloading the model. Takes no request body and remains available while inference is active. |
 | `GET /health` | Server and resident-model health, plus this process's `rss_bytes`/`peak_rss_bytes` and cumulative `tokens_prompt`, `tokens_generated`, `generate_seconds`, `batch_steps` and `batch_sequences`. |
+| `GET /metrics` | The same process counters in Prometheus text exposition 0.0.4 (`text/plain; version=0.0.4`), under the `runner_` prefix, with the prefix-cache and speculation counters alongside. Always on with `--serve`, takes no request body, and remains available while inference is active. |
 | `POST /unload` | Release resident model, draft and prefix-cache memory; the next request reloads on demand. Deferred to the next safe point while a load or generation is in flight (the reply says `"deferred":true`). Needs the registry: a server without one refuses with `409` rather than reporting a success it cannot deliver - see the residency note below. |
 
 `GET /unload` is deliberately refused with `405`; unloading is a state change.
@@ -1136,6 +1137,18 @@ adjacent text is processed.
 Legacy Completions accepts neutral `echo:false` and `prompt_logprobs:null`, but
 rejects `echo:true` and non-null `prompt_logprobs` with HTTP 400 until Runner can
 return the requested prompt-side output. These controls are never ignored.
+
+The `usage` object carries OpenAI's cached-prompt breakdown:
+`usage.prompt_tokens_details.cached_tokens` on Chat Completions and legacy
+Completions (buffered, and in the `stream_options.include_usage` chunk), and
+`usage.input_tokens_details.cached_tokens` on Responses. It counts the prompt
+tokens served from a reused KV prefix, and it is INCLUDED in `prompt_tokens`
+exactly as OpenAI includes it, so a caller billing on `prompt_tokens` sees no
+change. Anthropic Messages deliberately does not carry it: `cache_read_input_tokens`
+describes Anthropic's own caching product, whose `input_tokens` EXCLUDES what
+it covers, so reporting Runner's figure there would misstate a client's
+accounting. Every surface reports the same number as
+`runner_telemetry.prompt_cached_tokens`.
 
 Buffered generation responses include `runner_telemetry` with prompt tokens
 reused/evaluated, generation timing, paging counters, and structured or
@@ -1698,6 +1711,21 @@ rate needs an averaging window, and the runner has no business choosing one for
 a consumer whose window differs. Difference them over your own interval. The
 endpoint does not count its own requests, so polling it on a timer does not
 show up as work.
+
+`GET /metrics` answers the same facts in Prometheus text exposition 0.0.4, so a
+monitoring stack ingests them without a translator. Every name carries the
+`runner_` prefix and every sample is preceded by its own `# HELP` and `# TYPE`:
+`runner_requests_total`, `runner_prompt_tokens_total`,
+`runner_prompt_cached_tokens_total`, `runner_generated_tokens_total`,
+`runner_generate_seconds_total`, `runner_batch_steps_total`,
+`runner_batch_sequences_total`, the six `runner_prefix_cache_*` counters and
+their three gauges, the three `runner_speculation_*` counters, and the gauges
+`runner_active_requests`, `runner_resident_memory_bytes` and
+`runner_peak_resident_memory_bytes`. It is on whenever `--serve` is, needs no
+flag, and computes nothing: there is no hit-rate and no tokens-per-second here
+for the same reason `/health` has none. Like `/health` it does not count its
+own requests, so a scraper on a timer does not measure itself.
+`GET /v1/capabilities` reports it as `features.prometheus_metrics`.
 
 "Loaded" and "running" are told apart by `active_requests` from `/health`,
 polled on the same 5-second timer that refreshes the icon - so a request

--- a/scripts/template-conformance-render.c
+++ b/scripts/template-conformance-render.c
@@ -109,15 +109,10 @@ bool request_keep_alive(jv *req, bool *present, int *seconds) {
 
 jv *request_schema(jv *req) { (void)req; return NULL; }
 
-void server_record_work(int n_prompt, int n_gen, double gen_seconds) {
-    (void)n_prompt; (void)n_gen; (void)gen_seconds;
-}
+void server_record_work(const work_record *w) { (void)w; }
 
-void server_work_totals(unsigned long long *prompt_tokens,
-                        unsigned long long *gen_tokens, double *gen_seconds) {
-    if (prompt_tokens) *prompt_tokens = 0;
-    if (gen_tokens)    *gen_tokens = 0;
-    if (gen_seconds)   *gen_seconds = 0;
+void server_work_totals(work_totals *out) {
+    if (out) memset(out, 0, sizeof(*out));
 }
 
 // The other two inbound protocol adapters. Referenced only from server.c's

--- a/src/completion.c
+++ b/src/completion.c
@@ -688,23 +688,38 @@ typedef struct {
 // needs summing and one division at read time.
 static atomic_ullong g_total_prompt_tokens;
 static atomic_ullong g_total_gen_tokens;
+static atomic_ullong g_total_cached_tokens;
 static atomic_ullong g_total_gen_micros;
+static atomic_ullong g_total_spec_rounds;
+static atomic_ullong g_total_spec_drafted;
+static atomic_ullong g_total_spec_accepted;
 
-void server_record_work(int n_prompt, int n_gen, double gen_seconds) {
-    if (n_prompt > 0)
-        atomic_fetch_add(&g_total_prompt_tokens, (unsigned long long)n_prompt);
-    if (n_gen > 0)
-        atomic_fetch_add(&g_total_gen_tokens, (unsigned long long)n_gen);
-    if (gen_seconds > 0)
+void server_record_work(const work_record *w) {
+    if (w->n_prompt > 0)
+        atomic_fetch_add(&g_total_prompt_tokens, (unsigned long long)w->n_prompt);
+    if (w->n_gen > 0)
+        atomic_fetch_add(&g_total_gen_tokens, (unsigned long long)w->n_gen);
+    if (w->n_cached > 0)
+        atomic_fetch_add(&g_total_cached_tokens, (unsigned long long)w->n_cached);
+    if (w->gen_seconds > 0)
         atomic_fetch_add(&g_total_gen_micros,
-                         (unsigned long long)(gen_seconds * 1e6));
+                         (unsigned long long)(w->gen_seconds * 1e6));
+    if (w->spec_rounds > 0)
+        atomic_fetch_add(&g_total_spec_rounds, (unsigned long long)w->spec_rounds);
+    if (w->spec_drafted > 0)
+        atomic_fetch_add(&g_total_spec_drafted, (unsigned long long)w->spec_drafted);
+    if (w->spec_accepted > 0)
+        atomic_fetch_add(&g_total_spec_accepted, (unsigned long long)w->spec_accepted);
 }
 
-void server_work_totals(unsigned long long *prompt_tokens,
-                        unsigned long long *gen_tokens, double *gen_seconds) {
-    *prompt_tokens = atomic_load(&g_total_prompt_tokens);
-    *gen_tokens    = atomic_load(&g_total_gen_tokens);
-    *gen_seconds   = (double)atomic_load(&g_total_gen_micros) / 1e6;
+void server_work_totals(work_totals *out) {
+    out->prompt_tokens = atomic_load(&g_total_prompt_tokens);
+    out->gen_tokens    = atomic_load(&g_total_gen_tokens);
+    out->cached_tokens = atomic_load(&g_total_cached_tokens);
+    out->spec_rounds   = atomic_load(&g_total_spec_rounds);
+    out->spec_drafted  = atomic_load(&g_total_spec_drafted);
+    out->spec_accepted = atomic_load(&g_total_spec_accepted);
+    out->gen_seconds   = (double)atomic_load(&g_total_gen_micros) / 1e6;
 }
 
 // One rendering of runner_telemetry for every surface that carries it — chat,
@@ -728,6 +743,31 @@ static void telemetry_json(sbuf *r, const resp_doc *d) {
     // ordinary turns are byte-for-byte what they were before.
     if (d->finish_detail) sb_fmt(r, ",\"finish_detail\":\"%s\"", d->finish_detail);
     sb_lit(r, "}");
+}
+
+// The OpenAI `usage` object, rendered in one place for every surface that
+// speaks the chat dialect: the buffered chat body, the buffered legacy
+// completion body, and the opt-in `stream_options.include_usage` chunk. Three
+// copies of one token-accounting object is how two of them come to disagree,
+// and a client that flips `stream` on and off must see one shape.
+//
+// `cached` is this request's prefix-cache reuse, reported the way OpenAI
+// reports it: nested under prompt_tokens_details and INCLUDED in
+// prompt_tokens. The inclusion is the load-bearing half -- a caller billing
+// on prompt_tokens must not see its total move because the prompt happened to
+// be cheap to serve -- and it is why this is a breakdown of prompt_tokens
+// rather than a fourth number beside it. The Responses surface spells the
+// same fact `input_tokens_details.cached_tokens` (resp_body, its own
+// vocabulary); the Anthropic surface deliberately spells it nowhere, because
+// `cache_read_input_tokens` describes Anthropic's product with Anthropic's
+// semantics and reporting an unrelated figure there would misstate a client's
+// accounting rather than inform it. Every surface still carries the same
+// number as `runner_telemetry.prompt_cached_tokens`.
+static void openai_usage_json(sbuf *r, int n_prompt, int n_gen, int cached) {
+    sb_fmt(r, "\"usage\":{\"prompt_tokens\":%d,"
+              "\"prompt_tokens_details\":{\"cached_tokens\":%d},"
+              "\"completion_tokens\":%d,\"total_tokens\":%d}",
+           n_prompt, cached, n_gen, n_prompt + n_gen);
 }
 
 static void resp_echo(sbuf *r, jv *req, const char *key, const char *dflt) {
@@ -2084,8 +2124,17 @@ void run_completion(slot_t *s, sock_t fd, const char *prompt, int api,
     int n_gen = sched_generate(s, logits, max_tokens, gen_collect, &g, &gtime,
                                req_deadline);
     // The one place every surface's generation passes through, so /health's
-    // cumulative counters see chat, completions, responses and messages alike.
-    server_record_work(n_prompt, n_gen, gtime);
+    // and /metrics' cumulative counters see chat, completions, responses and
+    // messages alike. The speculation counters are read only when this request
+    // actually took the speculative walk (see work_record).
+    work_record work = { .n_prompt = n_prompt, .n_gen = n_gen,
+                         .n_cached = keep, .gen_seconds = gtime };
+    if (spec_used) {
+        work.spec_rounds   = e->spec_st.rounds;
+        work.spec_drafted  = e->spec_st.drafted;
+        work.spec_accepted = e->spec_st.accepted;
+    }
+    server_record_work(&work);
     // The socket probe and the streaming write path share g.dead. Whichever
     // learned the verdict first takes this same cleanup exit: no terminal
     // frame is owed to a peer already proven gone, and buffered responses must
@@ -2277,10 +2326,9 @@ void run_completion(slot_t *s, sock_t fd, const char *prompt, int api,
                        chat ? "chat.completion.chunk" : "text_completion",
                        g.created);
                 sb_esc(&u, SV.model_name, strlen(SV.model_name));
-                sb_fmt(&u, "\",\"choices\":[],"
-                           "\"usage\":{\"prompt_tokens\":%d,"
-                           "\"completion_tokens\":%d,\"total_tokens\":%d}}",
-                       n_prompt, n_gen, n_prompt + n_gen);
+                sb_lit(&u, "\",\"choices\":[],");
+                openai_usage_json(&u, n_prompt, n_gen, keep);
+                sb_lit(&u, "}");
                 ok = chunk_send(&g, &u) == 0;
             }
             if (ok) send_all(fd, "data: [DONE]\n\n", 14);
@@ -2481,10 +2529,9 @@ void run_completion(slot_t *s, sock_t fd, const char *prompt, int api,
             }
             sb_lit(&r, "],");
         }
-        sb_fmt(&r, "\"finish_reason\":\"%s\"}],"
-                   "\"usage\":{\"prompt_tokens\":%d,\"completion_tokens\":%d,"
-                   "\"total_tokens\":%d},",
-               openai_finish(finish), n_prompt, n_gen, n_prompt + n_gen);
+        sb_fmt(&r, "\"finish_reason\":\"%s\"}],", openai_finish(finish));
+        openai_usage_json(&r, n_prompt, n_gen, keep);
+        sb_lit(&r, ",");
         resp_doc td = { .n_prompt = n_prompt, .n_gen = n_gen, .cached = keep,
                         .forked = reuse.forked, .saved_s = reuse.saved_s,
                         .gtime = gtime, .major_faults = plat_major_faults() - faults_at_start,

--- a/src/server.c
+++ b/src/server.c
@@ -7,6 +7,7 @@
 //   GET  /v1/models             the loaded model
 //   GET  /v1/capabilities       registry + feature discovery
 //   GET  /health                liveness
+//   GET  /metrics               the same counters in Prometheus text format
 //
 // Swap-mode request bodies may carry "keep_alive" (seconds of idle before
 // the model unloads; 0 = unload now, negative = keep forever).
@@ -785,8 +786,8 @@ static void send_health(sock_t fd) {
     // allocator overhead -- which is the number a machine is sized against and
     // which no mapping-level measure accounts for. The token and second totals
     // are monotonic so a dashboard can difference them over its own window.
-    unsigned long long wp, wg; double ws;
-    server_work_totals(&wp, &wg, &ws);
+    work_totals wt;
+    server_work_totals(&wt);
     // How much of that work was batched. The scheduler already counts its
     // microbatch steps and the sequences cut into them; batch_sequences over
     // batch_steps is the mean batch size, and it is the only wire-visible
@@ -813,7 +814,7 @@ static void send_health(sock_t fd) {
              "\"batch_steps\":%llu,\"batch_sequences\":%llu",
              (unsigned long long)cur_rss,
              (unsigned long long)peak_rss,
-             wp, wg, ws, bs, bq);
+             wt.prompt_tokens, wt.gen_tokens, wt.gen_seconds, bs, bq);
 
     if (SV.n_reg > 0 && res >= 0) {
         // Registry names are char[64]. Match /v1/models' exact worst-case
@@ -881,6 +882,139 @@ static void send_prefix_cache(sock_t fd) {
         (unsigned long long)st.tokens_reused,
         st.saved_prefill_s, st.cost_per_token_s);
     send_response(fd, 200, "application/json", b, n);
+}
+
+// ------------------------------------------------------------------ /metrics
+//
+// The same facts /health and /v1/runner/prefix-cache already answer, in the
+// one format a monitoring stack ingests without a translator. Prometheus text
+// exposition 0.0.4: every sample is preceded by its own `# HELP` and `# TYPE`,
+// names carry the `runner_` prefix, and a counter's name ends in `_total`.
+//
+// It reports; it does not compute. There is no hit-RATE and no tokens-per-
+// SECOND here for the same reason /health has none: a rate needs an averaging
+// window, and the scraper owns that window. Every number below is either a
+// monotonic counter to be differenced or an instantaneous gauge.
+//
+// Read-only and lock-free apart from the prefix cache's own mutex, which
+// `GET /v1/runner/prefix-cache` already takes from the accept thread. Nothing
+// here reads the resident model, so unlike /v1/capabilities it needs no
+// swap_mu (see the note there) and is answered on the accept path with
+// atomic loads only.
+
+typedef struct { char *p; size_t cap, n; bool over; } mbuf;
+
+static void m_fmt(mbuf *b, const char *fmt, ...)
+    __attribute__((format(printf, 2, 3)));
+
+static void m_fmt(mbuf *b, const char *fmt, ...) {
+    if (b->over) return;
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(b->p + b->n, b->cap - b->n, fmt, ap);
+    va_end(ap);
+    // A truncated exposition is not a smaller exposition: a scraper reads a
+    // missing metric as one that reset, and a half-written line as a parse
+    // error for the whole scrape. Refuse the body instead.
+    if (n < 0 || (size_t)n >= b->cap - b->n) b->over = true;
+    else b->n += (size_t)n;
+}
+
+static void metric_u64(mbuf *b, const char *name, const char *type,
+                       const char *help, unsigned long long v) {
+    m_fmt(b, "# HELP %s %s\n# TYPE %s %s\n%s %llu\n", name, help, name, type,
+          name, v);
+}
+
+static void metric_f64(mbuf *b, const char *name, const char *type,
+                       const char *help, double v) {
+    m_fmt(b, "# HELP %s %s\n# TYPE %s %s\n%s %.6f\n", name, help, name, type,
+          name, v);
+}
+
+static void send_metrics(sock_t fd) {
+    work_totals wt;
+    server_work_totals(&wt);
+    unsigned long long bs = 0, bq = 0;
+    sched_batch_totals(&bs, &bq);
+    prefix_cache_stats st;
+    prefix_cache_stats_get(&st);
+    // Same self-consistency fix /health applies, and for the same reason: the
+    // two readings come from different kernel counters whose split-RSS
+    // accounting can lag each other, and a peak below the current reading is
+    // an impossible pair to publish.
+    uint64_t cur_rss = plat_proc_rss_bytes();
+    uint64_t peak_rss = plat_proc_peak_rss_bytes();
+    if (peak_rss < cur_rss) peak_rss = cur_rss;
+
+    char buf[8192];
+    mbuf b = { buf, sizeof(buf), 0, false };
+
+    metric_u64(&b, "runner_requests_total", "counter",
+               "Inference requests admitted since start. Management and "
+               "telemetry routes are not counted.",
+               atomic_load(&SV.total_requests));
+    metric_u64(&b, "runner_prompt_tokens_total", "counter",
+               "Prompt tokens accepted across every API surface.",
+               wt.prompt_tokens);
+    metric_u64(&b, "runner_prompt_cached_tokens_total", "counter",
+               "Prompt tokens served from a reused KV prefix, included in "
+               "runner_prompt_tokens_total.", wt.cached_tokens);
+    metric_u64(&b, "runner_generated_tokens_total", "counter",
+               "Tokens generated across every API surface.", wt.gen_tokens);
+    metric_f64(&b, "runner_generate_seconds_total", "counter",
+               "Seconds spent in generation, for differencing against "
+               "runner_generated_tokens_total.", wt.gen_seconds);
+    metric_u64(&b, "runner_batch_steps_total", "counter",
+               "Scheduler microbatch steps.", bs);
+    metric_u64(&b, "runner_batch_sequences_total", "counter",
+               "Sequences cut into those microbatch steps.", bq);
+    metric_u64(&b, "runner_prefix_cache_hits_total", "counter",
+               "Shared prefix-cache lookups that forked a snapshot.", st.hits);
+    metric_u64(&b, "runner_prefix_cache_misses_total", "counter",
+               "Shared prefix-cache lookups that found nothing to fork.",
+               st.misses);
+    metric_u64(&b, "runner_prefix_cache_stores_total", "counter",
+               "Prefixes published to the shared store.", st.stores);
+    metric_u64(&b, "runner_prefix_cache_evictions_total", "counter",
+               "Prefixes dropped for budget or age.", st.evictions);
+    metric_u64(&b, "runner_prefix_cache_tokens_reused_total", "counter",
+               "Prompt tokens forked out of the shared store.",
+               st.tokens_reused);
+    metric_f64(&b, "runner_prefix_cache_saved_prefill_seconds_total", "counter",
+               "Prefill seconds those forks avoided, priced at this process's "
+               "measured seconds per token.", st.saved_prefill_s);
+    metric_u64(&b, "runner_speculation_rounds_total", "counter",
+               "Speculative verify rounds. Zero on a server with no draft, "
+               "no MTP head and no grammar fast-forward.", wt.spec_rounds);
+    metric_u64(&b, "runner_speculation_drafted_tokens_total", "counter",
+               "Tokens proposed by a draft source.", wt.spec_drafted);
+    metric_u64(&b, "runner_speculation_accepted_tokens_total", "counter",
+               "Proposed tokens the target model accepted.", wt.spec_accepted);
+    metric_u64(&b, "runner_active_requests", "gauge",
+               "Inference requests in flight right now.",
+               (unsigned long long)(long long)atomic_load(&SV.active_requests));
+    metric_u64(&b, "runner_resident_memory_bytes", "gauge",
+               "Resident set of this process: weights, KV cache, activations "
+               "and allocator overhead together.",
+               (unsigned long long)cur_rss);
+    metric_u64(&b, "runner_peak_resident_memory_bytes", "gauge",
+               "High-water mark of that resident set.",
+               (unsigned long long)peak_rss);
+    metric_u64(&b, "runner_prefix_cache_bytes", "gauge",
+               "Host memory the shared prefix store holds.",
+               (unsigned long long)st.bytes);
+    metric_u64(&b, "runner_prefix_cache_budget_bytes", "gauge",
+               "Its configured ceiling; 0 disables the shared tier.",
+               (unsigned long long)st.budget);
+    metric_u64(&b, "runner_prefix_cache_entries", "gauge",
+               "Snapshots currently held.", (unsigned long long)st.entries);
+
+    if (b.over) {
+        send_error(fd, 500, "metrics exposition did not fit its buffer");
+        return;
+    }
+    send_response(fd, 200, "text/plain; version=0.0.4", buf, b.n);
 }
 
 static void send_capabilities(sock_t fd) {
@@ -1003,6 +1137,15 @@ static void send_capabilities(sock_t fd) {
                // 2026-08-08 and still deferred; this fixes the CLAIM.
                "\"request_telemetry\":{\"buffered\":true,"
                                      "\"streamed\":false},"
+               // GET /metrics, in Prometheus text exposition 0.0.4. Named as
+               // a feature rather than assumed from the version, because a
+               // scraper's alternative is to poll /health and translate, and
+               // it needs to know which of the two it is talking to.
+               "\"prometheus_metrics\":true,"
+               // usage.prompt_tokens_details.cached_tokens on the OpenAI
+               // surfaces, usage.input_tokens_details.cached_tokens on
+               // Responses. Not on Messages: see the note in completion.c.
+               "\"usage_cached_tokens\":true,"
                "\"prefix_cache\":true,"
                "\"prefix_cache_controls\":true,"
                "\"shared_prefix_cache\":true,"
@@ -1121,7 +1264,7 @@ static void handle_conn(slot_t *s, sock_t fd) {
            !strcmp(path, "/v1/runner/prefix-cache/clear"))) ||
          (!strcmp(method, "GET") &&
           (!strcmp(path, "/health") || !strcmp(path, "/v1/models") ||
-           !strcmp(path, "/v1/capabilities") ||
+           !strcmp(path, "/v1/capabilities") || !strcmp(path, "/metrics") ||
            !strcmp(path, "/v1/runner/prefix-cache"))));
     if (bodyless_route) {
         // These routes are normally served by accept_fastpath. A declared body
@@ -1161,6 +1304,8 @@ static void handle_conn(slot_t *s, sock_t fd) {
         send_health(fd);
     } else if (!strcmp(method, "GET") && !strcmp(path, "/v1/models")) {
         send_models(fd);
+    } else if (!strcmp(method, "GET") && !strcmp(path, "/metrics")) {
+        send_metrics(fd);
     } else if (!strcmp(method, "GET") && !strcmp(path, "/v1/capabilities")) {
         send_capabilities(fd);
     } else if (!strcmp(method, "POST") &&
@@ -1223,6 +1368,7 @@ static void handle_conn(slot_t *s, sock_t fd) {
                 return;
             }
             atomic_fetch_add(&SV.active_requests, 1);
+            atomic_fetch_add(&SV.total_requests, 1);
             bool ok = true;
             if (SV.n_reg > 0) {
                 int sw = swap_to(jv_str(jv_get(req, "model"), NULL));
@@ -1351,11 +1497,13 @@ static bool accept_fastpath(sock_t fd) {
                               sizeof("GET /v1/runner/prefix-cache ") - 1);
     bool pfx_clear = !strncmp(hdr, "POST /v1/runner/prefix-cache/clear ",
                               sizeof("POST /v1/runner/prefix-cache/clear ") - 1);
+    bool metrics = !strncmp(hdr, "GET /metrics ", 13);
     // The old spelling still has to reach a handler, or an operator's script
     // gets a 404 that says nothing. It is not answered here — it falls through
     // to the slot path, which replies 405 with the reason.
     if (!strncmp(hdr, "GET /unload ", 12)) return false;
-    if (!health && !models && !caps && !unload && !pfx_stats && !pfx_clear)
+    if (!health && !models && !caps && !unload && !pfx_stats && !pfx_clear &&
+        !metrics)
         return false;
     // Keep the request untouched until framing says it is bodyless. A partial
     // header, an oversized header, malformed framing, and every declared body
@@ -1386,6 +1534,7 @@ static bool accept_fastpath(sock_t fd) {
     }
     if (health)          send_health(fd);
     else if (models)     send_models(fd);
+    else if (metrics)    send_metrics(fd);
     else if (unload)     handle_unload(fd);
     else if (pfx_stats)  send_prefix_cache(fd);
     else if (pfx_clear) {
@@ -1906,7 +2055,7 @@ int server_run(model_t *base, tokenizer *tok, const char *model_path,
                 batched ? ", continuous batching" : "");
     fputs("  POST /v1/chat/completions | POST /v1/responses | POST /v1/completions\n"
           "  POST /v1/embeddings | POST /v1/messages | POST /v1/messages/count_tokens\n"
-          "  GET /v1/models | GET /v1/capabilities | GET /health\n"
+          "  GET /v1/models | GET /v1/capabilities | GET /health | GET /metrics\n"
           "  GET /v1/runner/prefix-cache | POST /v1/runner/prefix-cache/clear"
           " | POST /unload\n", stderr);
 

--- a/src/server_int.h
+++ b/src/server_int.h
@@ -62,6 +62,13 @@ typedef struct {
     model_params mp;
     pthread_mutex_t swap_mu;
     atomic_int  active_requests;
+    // Inference requests admitted since start, the monotonic counterpart of
+    // active_requests: incremented and decremented at the same two points, so
+    // "how many are running" and "how many have run" cannot describe different
+    // sets of requests. The management and telemetry routes are not counted,
+    // for the reason /health already documents about itself -- a dashboard
+    // polling on a timer must not measure its own polling.
+    atomic_ullong total_requests;
     // Loading state machine: swap_to releases swap_mu for the duration of the
     // actual model load (minutes for big files, up to --wait-for-vram longer),
     // so /unload and shutdown are never blocked behind a load. `loading` and
@@ -116,9 +123,32 @@ extern server_state SV;
 // Raw monotonic totals on purpose: a tok/s field would bake in an averaging
 // window the runner has no business choosing, and would be wrong for every
 // consumer whose window differs. The engine measures; the suite presents.
-void server_record_work(int n_prompt, int n_gen, double gen_seconds);
-void server_work_totals(unsigned long long *prompt_tokens,
-                        unsigned long long *gen_tokens, double *gen_seconds);
+//
+// One record per finished request, passed as a value rather than a widening
+// parameter list: every field here is a fact about the SAME turn, and a
+// six-argument call is how a caller comes to pass the cached count where the
+// generated one belongs.
+typedef struct {
+    int    n_prompt, n_gen;
+    // prompt rows this request did not have to prefill, from either cache
+    // tier. The same number the wire reports as cached_tokens.
+    int    n_cached;
+    // The speculative walk's own counters, and only when the walk actually
+    // ran: engine.spec_st is reset by engine_generate_spec, so a solo turn on
+    // a slot that speculated earlier still holds the earlier numbers and
+    // reading them unconditionally would count one walk many times.
+    int    spec_rounds, spec_drafted, spec_accepted;
+    double gen_seconds;
+} work_record;
+
+typedef struct {
+    unsigned long long prompt_tokens, gen_tokens, cached_tokens;
+    unsigned long long spec_rounds, spec_drafted, spec_accepted;
+    double gen_seconds;
+} work_totals;
+
+void server_record_work(const work_record *w);
+void server_work_totals(work_totals *out);
 
 // swap_to results below 0: the name matched no registry entry (a caller
 // typo -- 400) vs the entry exists but its model failed to load (a broken

--- a/tests/conformance/fixtures/capabilities.json
+++ b/tests/conformance/fixtures/capabilities.json
@@ -13,6 +13,7 @@
     "messages_api": true,
     "prefix_cache": true,
     "prefix_cache_controls": true,
+    "prometheus_metrics": true,
     "repeat_penalty": true,
     "request_telemetry": {
       "buffered": true,
@@ -23,7 +24,8 @@
     "schema_integer_bounds": true,
     "schema_string_bounds": true,
     "shared_prefix_cache": true,
-    "stop_sequences": true
+    "stop_sequences": true,
+    "usage_cached_tokens": true
   },
   "models": [
     {

--- a/tests/conformance/fixtures/chat_buffered.json
+++ b/tests/conformance/fixtures/chat_buffered.json
@@ -28,6 +28,9 @@
   "usage": {
     "completion_tokens": "<number>",
     "prompt_tokens": "<number>",
+    "prompt_tokens_details": {
+      "cached_tokens": "<number>"
+    },
     "total_tokens": "<number>"
   }
 }

--- a/tests/conformance/fixtures/chat_json_object.json
+++ b/tests/conformance/fixtures/chat_json_object.json
@@ -28,6 +28,9 @@
   "usage": {
     "completion_tokens": "<number>",
     "prompt_tokens": "<number>",
+    "prompt_tokens_details": {
+      "cached_tokens": "<number>"
+    },
     "total_tokens": "<number>"
   }
 }

--- a/tests/conformance/fixtures/chat_json_schema.json
+++ b/tests/conformance/fixtures/chat_json_schema.json
@@ -28,6 +28,9 @@
   "usage": {
     "completion_tokens": "<number>",
     "prompt_tokens": "<number>",
+    "prompt_tokens_details": {
+      "cached_tokens": "<number>"
+    },
     "total_tokens": "<number>"
   }
 }

--- a/tests/conformance/fixtures/completion_buffered.json
+++ b/tests/conformance/fixtures/completion_buffered.json
@@ -25,6 +25,9 @@
   "usage": {
     "completion_tokens": "<number>",
     "prompt_tokens": "<number>",
+    "prompt_tokens_details": {
+      "cached_tokens": "<number>"
+    },
     "total_tokens": "<number>"
   }
 }

--- a/tests/conformance/test_http_framing.py
+++ b/tests/conformance/test_http_framing.py
@@ -112,6 +112,7 @@ def test_fastpath_also_rejects_invalid_framing(server):
     b"GET /health HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
     b"GET /v1/models HTTP/1.1\r\nHost: [::1]\r\n\r\n",
     b"GET /v1/capabilities HTTP/1.1\r\nHost: localhost\r\n\r\n",
+    b"GET /metrics HTTP/1.1\r\nHost: localhost\r\n\r\n",
 ])
 def test_compact_fastpath_request_closes_cleanly(server, request_bytes):
     """A whole request that fits inside the accept loop's peek must still be
@@ -144,6 +145,7 @@ def test_compact_fastpath_request_closes_cleanly(server, request_bytes):
     "/v1/models",
     "/v1/capabilities",
     "/v1/runner/prefix-cache",
+    "/metrics",
 ])
 def test_fastpath_get_with_body_is_rejected_without_reset(server, path):
     """A fast-path GET with a body must reach a clean HTTP refusal.

--- a/tests/conformance/test_process_metrics.py
+++ b/tests/conformance/test_process_metrics.py
@@ -105,3 +105,199 @@ def test_batch_counters_report_the_work_the_scheduler_did(client):
     assert after["batch_steps"] > before["batch_steps"], (before, after)
     # every step batches at least the one sequence that woke it
     assert after["batch_sequences"] >= after["batch_steps"], after
+
+
+# --------------------------------------------------------------------- /metrics
+#
+# The same facts in Prometheus text exposition 0.0.4, because that is what a
+# monitoring stack ingests without a translator in front of it. The parsing
+# here is deliberately strict and hand-written rather than borrowed from a
+# client library: the point of these tests is that a stock scraper can read
+# the body, and a lenient parser of our own would hide exactly the mistakes
+# that would break one.
+
+METRICS_CONTENT_TYPE = "text/plain; version=0.0.4"
+
+# Prometheus' own naming rules, restated here rather than derived from the
+# server's output: a counter's name ends in `_total`, a gauge's does not, and
+# every name in this exposition carries the `runner_` prefix. Deriving the
+# expectation from the response would make this test agree with whatever the
+# server said.
+EXPECTED_COUNTERS = {
+    "runner_requests_total",
+    "runner_prompt_tokens_total",
+    "runner_prompt_cached_tokens_total",
+    "runner_generated_tokens_total",
+    "runner_generate_seconds_total",
+    "runner_batch_steps_total",
+    "runner_batch_sequences_total",
+    "runner_prefix_cache_hits_total",
+    "runner_prefix_cache_misses_total",
+    "runner_prefix_cache_stores_total",
+    "runner_prefix_cache_evictions_total",
+    "runner_prefix_cache_tokens_reused_total",
+    "runner_prefix_cache_saved_prefill_seconds_total",
+    "runner_speculation_rounds_total",
+    "runner_speculation_drafted_tokens_total",
+    "runner_speculation_accepted_tokens_total",
+}
+EXPECTED_GAUGES = {
+    "runner_active_requests",
+    "runner_resident_memory_bytes",
+    "runner_peak_resident_memory_bytes",
+    "runner_prefix_cache_bytes",
+    "runner_prefix_cache_budget_bytes",
+    "runner_prefix_cache_entries",
+}
+
+
+def parse_exposition(text):
+    """Parse Prometheus text exposition, refusing anything a scraper would.
+
+    Returns {name: (type, value)}. Every sample must be preceded by its own
+    HELP and TYPE lines, each name may appear once, and nothing else is
+    allowed on a line.
+    """
+    helps, types, samples = {}, {}, {}
+    for lineno, line in enumerate(text.split("\n"), 1):
+        if line == "":
+            continue
+        if line.startswith("# HELP "):
+            name, _, doc = line[len("# HELP "):].partition(" ")
+            assert name not in helps, (lineno, "duplicate HELP", name)
+            assert doc, (lineno, "HELP with no text", name)
+            helps[name] = doc
+            continue
+        if line.startswith("# TYPE "):
+            name, _, kind = line[len("# TYPE "):].partition(" ")
+            assert name not in types, (lineno, "duplicate TYPE", name)
+            assert kind in ("counter", "gauge"), (lineno, kind)
+            types[name] = kind
+            continue
+        assert not line.startswith("#"), (lineno, "unknown comment line", line)
+        parts = line.split(" ")
+        assert len(parts) == 2, (lineno, "not one sample per line", line)
+        name, raw = parts
+        assert name in helps, (lineno, "sample before its HELP", name)
+        assert name in types, (lineno, "sample before its TYPE", name)
+        assert name not in samples, (lineno, "duplicate sample", name)
+        samples[name] = (types[name], float(raw))
+    assert set(helps) == set(samples), (sorted(set(helps) ^ set(samples)),)
+    assert set(types) == set(samples), (sorted(set(types) ^ set(samples)),)
+    return samples
+
+
+def metrics(client):
+    r = client.get("/metrics", name="metrics")
+    assert r.status == 200, r.status
+    ctype = r.headers.get("content-type")
+    assert ctype == METRICS_CONTENT_TYPE, ctype
+    declared = r.headers.get("content-length")
+    assert declared is not None and int(declared) == len(r.body), (
+        declared, len(r.body))
+    return parse_exposition(r.body.decode("utf-8"))
+
+
+def test_metrics_exposition_parses_and_names_are_prometheus_shaped(client):
+    m = metrics(client)
+    missing = (EXPECTED_COUNTERS | EXPECTED_GAUGES) - set(m)
+    assert not missing, sorted(missing)
+    for name, (kind, value) in m.items():
+        assert name.startswith("runner_"), name
+        assert value >= 0, (name, value)
+        if kind == "counter":
+            assert name.endswith("_total"), f"{name} is a counter but is not _total"
+            assert name in EXPECTED_COUNTERS, f"{name} is an undeclared counter"
+        else:
+            assert not name.endswith("_total"), f"{name} is a gauge named _total"
+            assert name in EXPECTED_GAUGES, f"{name} is an undeclared gauge"
+
+
+def test_metrics_counters_advance_with_the_work(client):
+    """Counters must count, and must only ever go up.
+
+    Two generations, so the delta is a fact about this test rather than about
+    whatever the suite ran before it."""
+    before = metrics(client)
+    body = {"model": "test",
+            "messages": [{"role": "user", "content": "count to three"}],
+            "temperature": 0, "max_tokens": 8}
+    a = client.chat(body, name="metrics-prom-1").expect_status(200)
+    b = client.chat(body, name="metrics-prom-2").expect_status(200)
+    after = metrics(client)
+
+    for name in EXPECTED_COUNTERS:
+        assert after[name][1] >= before[name][1], (
+            f"{name} went backwards", before[name], after[name])
+
+    used = [a.usage, b.usage]
+    assert after["runner_requests_total"][1] - \
+        before["runner_requests_total"][1] == 2, (before, after)
+    assert after["runner_generated_tokens_total"][1] - \
+        before["runner_generated_tokens_total"][1] == \
+        sum(u["completion_tokens"] for u in used)
+    assert after["runner_prompt_tokens_total"][1] - \
+        before["runner_prompt_tokens_total"][1] == \
+        sum(u["prompt_tokens"] for u in used)
+    # The counter and the per-request wire field are the same measurement,
+    # which is the whole reason both exist: a dashboard differencing the
+    # counter and a client reading its own usage must not disagree.
+    assert after["runner_prompt_cached_tokens_total"][1] - \
+        before["runner_prompt_cached_tokens_total"][1] == \
+        sum(u["prompt_tokens_details"]["cached_tokens"] for u in used)
+
+
+def test_metrics_agrees_with_health_and_the_prefix_cache_route(client):
+    """Three routes, one set of counters.
+
+    The independent anchor for this endpoint: /health and
+    /v1/runner/prefix-cache have their own tests and their own callers, so a
+    /metrics that disagrees with them is wrong no matter how well it parses.
+    Read /metrics between two identical reads of the others, so ordinary
+    concurrent traffic cannot make an equality fail.
+    """
+    h_before = health(client)
+    pfx_before = json.loads(client.get("/v1/runner/prefix-cache",
+                                       name="metrics-pfx-before").body)
+    m = metrics(client)
+    h_after = health(client)
+    pfx_after = json.loads(client.get("/v1/runner/prefix-cache",
+                                      name="metrics-pfx-after").body)
+
+    pairs = [("runner_prompt_tokens_total", "tokens_prompt", h_before, h_after),
+             ("runner_generated_tokens_total", "tokens_generated",
+              h_before, h_after),
+             ("runner_batch_steps_total", "batch_steps", h_before, h_after),
+             ("runner_batch_sequences_total", "batch_sequences",
+              h_before, h_after),
+             ("runner_prefix_cache_hits_total", "hits", pfx_before, pfx_after),
+             ("runner_prefix_cache_misses_total", "misses",
+              pfx_before, pfx_after),
+             ("runner_prefix_cache_bytes", "bytes", pfx_before, pfx_after),
+             ("runner_prefix_cache_entries", "entries", pfx_before, pfx_after)]
+    for metric, field, before, after in pairs:
+        # sorted, not (before, after): two of these are gauges, and a gauge is
+        # allowed to fall (an eviction) between the two reads.
+        low, high = sorted((before[field], after[field]))
+        assert low <= m[metric][1] <= high, (
+            metric, field, before[field], m[metric][1], after[field])
+
+
+def test_metrics_does_not_count_itself(client):
+    """Scraping is not work. A scraper polls this on a timer, and a request
+    counter that included the scrape would report the monitoring instead of
+    the model."""
+    a = metrics(client)
+    for _ in range(3):
+        metrics(client)
+    b = metrics(client)
+    for name in ("runner_requests_total", "runner_prompt_tokens_total",
+                 "runner_generated_tokens_total"):
+        assert a[name] == b[name], (name, a[name], b[name])
+
+
+def test_metrics_is_advertised_in_capabilities(client):
+    """A scraper's alternative is polling /health and translating, so it has
+    to be able to tell which server it is pointed at without guessing."""
+    caps = json.loads(client.get("/v1/capabilities", name="metrics-caps").body)
+    assert caps["features"]["prometheus_metrics"] is True, caps["features"]

--- a/tests/conformance/test_usage_cached_tokens.py
+++ b/tests/conformance/test_usage_cached_tokens.py
@@ -1,0 +1,227 @@
+"""Cached prompt tokens in the standard `usage` object, seen from the wire.
+
+Runner has always counted, per request, how many prompt rows it did not have
+to prefill: `runner_telemetry.prompt_cached_tokens`. That is a Runner
+extension, and a client that reads OpenAI's schema never looks at it. OpenAI
+carries the same fact as `usage.prompt_tokens_details.cached_tokens`, and the
+cost dashboards, SDK helper properties and agent frameworks that report
+"cache hit rate" all read it from there.
+
+Two invariants hold everywhere it appears:
+
+* `prompt_tokens` keeps its meaning. Cached tokens are INCLUDED in it, as
+  they are at OpenAI, so no caller's total moves because this field arrived.
+* `cached_tokens <= prompt_tokens`. Reuse cannot cover rows the prompt does
+  not have.
+
+The cold case is expressed as `cache_prompt: false` rather than "a prompt
+nobody sent before". A conformance session sends hundreds of requests through
+the same chat template, so every later prompt shares its opening tokens with
+an earlier one and a genuinely cold prompt is not something this suite can
+construct. `cache_prompt: false` is the documented full opt-out and makes the
+zero a fact about the server rather than about the ordering of the suite.
+
+The Anthropic surface is deliberately excluded, and stays excluded: see
+test_messages.test_cache_usage_fields_are_not_claimed. `cache_read_input_tokens`
+means something specific about Anthropic's product (their `input_tokens`
+EXCLUDES it), so reporting Runner's unrelated figure there would misstate a
+client's accounting. Messages reports the same number under `runner_telemetry`,
+as every other surface does.
+"""
+
+import json
+
+from _errors import ProtocolError
+
+# Comfortably past the 16-token floor the shared prefix tier requires, so the
+# warm case is reusable whether the repeat lands on the slot that already
+# holds it or has to fork the shared snapshot into the other one.
+SYSTEM = ("You are a usage-accounting fixture. " +
+          " ".join(f"clause {i}: stay brief." for i in range(8)))
+
+
+def _chat_payload(user, **kw):
+    body = {"model": "test",
+            "messages": [{"role": "system", "content": SYSTEM},
+                         {"role": "user", "content": user}],
+            "temperature": 0, "max_tokens": 8}
+    body.update(kw)
+    return body
+
+
+def _completion_payload(prompt, **kw):
+    body = {"model": "test", "prompt": SYSTEM + "\n" + prompt,
+            "temperature": 0, "max_tokens": 8}
+    body.update(kw)
+    return body
+
+
+def _cached(usage, request, details="prompt_tokens_details"):
+    """The cached-token figure, checked for shape before it is believed."""
+    d = usage.get(details)
+    if not isinstance(d, dict):
+        raise ProtocolError("usage carries no cached-token details object",
+                            request=request, field=details, usage=usage)
+    c = d.get("cached_tokens")
+    if not isinstance(c, int) or isinstance(c, bool):
+        raise ProtocolError("cached_tokens is not an integer",
+                            request=request, got=repr(c), usage=usage)
+    if c < 0 or c > usage.get("prompt_tokens", usage.get("input_tokens", 0)):
+        raise ProtocolError("cached_tokens outside [0, prompt_tokens]",
+                            request=request, usage=usage)
+    return c
+
+
+def _stream_usage(stream, request):
+    """The one chunk `stream_options.include_usage` adds, and only it."""
+    stream.expect_sse()
+    carrying = [c for c in stream.chunks if c.get("usage") is not None]
+    if len(carrying) != 1:
+        raise ProtocolError("expected exactly one usage chunk",
+                            request=request, got=len(carrying))
+    return carrying[0]["usage"]
+
+
+# ------------------------------------------------------------------ buffered
+def test_chat_reports_cached_prompt_tokens(client):
+    cold = client.chat(_chat_payload("first question", cache_prompt=False),
+                       name="cached-chat-cold").expect_status(200)
+    u = cold.usage
+    if _cached(u, "cached-chat-cold") != 0:
+        raise ProtocolError("cache_prompt:false still reported reuse", usage=u)
+
+    warm_body = _chat_payload("second question")
+    client.chat(warm_body, name="cached-chat-warm-1").expect_status(200)
+    warm = client.chat(warm_body, name="cached-chat-warm-2").expect_status(200)
+    u = warm.usage
+    n = _cached(u, "cached-chat-warm-2")
+    if n <= 0:
+        raise ProtocolError("a repeated prompt reported no cached tokens",
+                            usage=u, telemetry=warm.telemetry)
+    # The extension field and the standard field are the same measurement,
+    # so a client reading either gets the same answer.
+    if warm.telemetry.get("prompt_cached_tokens") != n:
+        raise ProtocolError("usage and runner_telemetry disagree about reuse",
+                            usage=u, telemetry=warm.telemetry)
+
+
+def test_chat_prompt_tokens_still_include_the_cached_ones(client):
+    """OpenAI's semantics: the detail breaks `prompt_tokens` down, it does not
+    subtract from it. A client that bills on `prompt_tokens` must not see its
+    total move because the prompt was cheap to serve."""
+    body = _chat_payload("billing semantics")
+    a = client.chat(body, name="cached-chat-sum-1").expect_status(200)
+    b = client.chat(body, name="cached-chat-sum-2").expect_status(200)
+    if a.usage["prompt_tokens"] != b.usage["prompt_tokens"]:
+        raise ProtocolError("prompt_tokens changed when the prompt was reused",
+                            cold=a.usage, warm=b.usage)
+    for r, name in ((a, "cached-chat-sum-1"), (b, "cached-chat-sum-2")):
+        u = r.usage
+        _cached(u, name)
+        if u["prompt_tokens"] + u["completion_tokens"] != u["total_tokens"]:
+            raise ProtocolError("usage does not add up", usage=u)
+
+
+def test_completions_reports_cached_prompt_tokens(client):
+    cold = client.completion(
+        _completion_payload("first", cache_prompt=False),
+        name="cached-completion-cold").expect_status(200)
+    if _cached(cold.usage, "cached-completion-cold") != 0:
+        raise ProtocolError("cache_prompt:false still reported reuse",
+                            usage=cold.usage)
+
+    body = _completion_payload("second")
+    client.completion(body, name="cached-completion-warm-1").expect_status(200)
+    warm = client.completion(body,
+                             name="cached-completion-warm-2").expect_status(200)
+    if _cached(warm.usage, "cached-completion-warm-2") <= 0:
+        raise ProtocolError("a repeated prompt reported no cached tokens",
+                            usage=warm.usage, telemetry=warm.telemetry)
+
+
+def test_responses_reports_cached_input_tokens(client):
+    """The Responses surface spells the same fact `input_tokens_details`."""
+    cold = client.responses({"model": "test", "input": "first question",
+                             "max_output_tokens": 8, "temperature": 0,
+                             "cache_prompt": False},
+                            name="cached-responses-cold").expect_status(200)
+    if _cached(cold.json["usage"], "cached-responses-cold",
+               "input_tokens_details") != 0:
+        raise ProtocolError("cache_prompt:false still reported reuse",
+                            usage=cold.json["usage"])
+
+    body = {"model": "test", "input": SYSTEM + " repeated input",
+            "max_output_tokens": 8, "temperature": 0}
+    client.responses(body, name="cached-responses-warm-1").expect_status(200)
+    warm = client.responses(body,
+                            name="cached-responses-warm-2").expect_status(200)
+    if _cached(warm.json["usage"], "cached-responses-warm-2",
+               "input_tokens_details") <= 0:
+        raise ProtocolError("a repeated input reported no cached tokens",
+                            usage=warm.json["usage"])
+
+
+# ----------------------------------------------------------------- streamed
+def test_chat_stream_usage_chunk_reports_cached_tokens(client):
+    """`stream_options.include_usage` must carry the same object the buffered
+    reply does: a client that flips `stream` on and off gets one shape."""
+    body = _chat_payload("streamed question",
+                         stream_options={"include_usage": True})
+    client.chat(dict(body), name="cached-stream-warm-1").expect_status(200)
+    st = client.chat_stream(body, name="cached-stream-usage")
+    u = _stream_usage(st, "cached-stream-usage")
+    if _cached(u, "cached-stream-usage") <= 0:
+        raise ProtocolError("streamed usage chunk reported no cached tokens",
+                            usage=u)
+    if u["prompt_tokens"] + u["completion_tokens"] != u["total_tokens"]:
+        raise ProtocolError("streamed usage does not add up", usage=u)
+
+
+def test_completion_stream_usage_chunk_reports_cached_tokens(client):
+    body = _completion_payload("streamed",
+                               stream_options={"include_usage": True})
+    client.completion(dict(body),
+                      name="cached-cstream-warm-1").expect_status(200)
+    st = client.completion_stream(body, name="cached-cstream-usage")
+    u = _stream_usage(st, "cached-cstream-usage")
+    if _cached(u, "cached-cstream-usage") <= 0:
+        raise ProtocolError("streamed usage chunk reported no cached tokens",
+                            usage=u)
+
+
+# ------------------------------------------------------------------ excluded
+def test_messages_usage_keeps_the_anthropic_vocabulary(client):
+    """Messages does NOT gain the OpenAI detail object.
+
+    Its `usage` is Anthropic-shaped, and the cache decision there is pinned by
+    test_cache_usage_fields_are_not_claimed. Adding an OpenAI-spelled field to
+    an Anthropic body would give a typed SDK a member its schema does not have
+    while still not answering the question it would ask (`cache_read_input_tokens`).
+    """
+    r = client.messages({"model": "local", "max_tokens": 8, "temperature": 0,
+                         "messages": [{"role": "user", "content": "hello"}]},
+                        name="cached-messages-vocabulary").expect_status(200)
+    usage = r.json["usage"]
+    if "prompt_tokens_details" in usage or "input_tokens_details" in usage:
+        raise ProtocolError(
+            "the Anthropic body gained an OpenAI-spelled usage detail; the "
+            "prefix-cache figure belongs in runner_telemetry on this surface",
+            usage=usage)
+    if not isinstance(r.telemetry.get("prompt_cached_tokens"), int):
+        raise ProtocolError("Messages lost its runner_telemetry reuse figure",
+                            telemetry=r.telemetry)
+
+
+def test_streamed_usage_chunk_is_valid_json_for_the_sdk(client):
+    """The chunk is parsed by the official SDK elsewhere; this pins the bytes.
+
+    An extra nested object inside `usage` is exactly the kind of change that
+    can be emitted with a comma in the wrong place and still look right in a
+    log, because the SSE framing hides it until something parses the payload.
+    """
+    body = _chat_payload("json shape", stream_options={"include_usage": True})
+    st = client.chat_stream(body, name="cached-stream-json")
+    st.expect_sse()
+    for data in st.events:
+        if data and data != "[DONE]":
+            json.loads(data)

--- a/tests/test_prompt_budget.c
+++ b/tests/test_prompt_budget.c
@@ -72,15 +72,10 @@ bool request_keep_alive(jv *req, bool *present, int *seconds) {
 
 jv *request_schema(jv *req) { (void)req; return NULL; }
 
-void server_record_work(int n_prompt, int n_gen, double gen_seconds) {
-    (void)n_prompt; (void)n_gen; (void)gen_seconds;
-}
+void server_record_work(const work_record *w) { (void)w; }
 
-void server_work_totals(unsigned long long *prompt_tokens,
-                        unsigned long long *gen_tokens, double *gen_seconds) {
-    if (prompt_tokens) *prompt_tokens = 0;
-    if (gen_tokens)    *gen_tokens = 0;
-    if (gen_seconds)   *gen_seconds = 0;
+void server_work_totals(work_totals *out) {
+    if (out) memset(out, 0, sizeof(*out));
 }
 
 #include "../src/server.c"

--- a/tests/test_prompt_oom.c
+++ b/tests/test_prompt_oom.c
@@ -120,15 +120,10 @@ bool request_keep_alive(jv *req, bool *present, int *seconds) {
 
 jv *request_schema(jv *req) { (void)req; return NULL; }
 
-void server_record_work(int n_prompt, int n_gen, double gen_seconds) {
-    (void)n_prompt; (void)n_gen; (void)gen_seconds;
-}
+void server_record_work(const work_record *w) { (void)w; }
 
-void server_work_totals(unsigned long long *prompt_tokens,
-                        unsigned long long *gen_tokens, double *gen_seconds) {
-    if (prompt_tokens) *prompt_tokens = 0;
-    if (gen_tokens)    *gen_tokens = 0;
-    if (gen_seconds)   *gen_seconds = 0;
+void server_work_totals(work_totals *out) {
+    if (out) memset(out, 0, sizeof(*out));
 }
 
 // ------------------------------------------------------------------ fixture

--- a/tests/test_server_banner.py
+++ b/tests/test_server_banner.py
@@ -24,6 +24,7 @@ PUBLIC_ROUTES = {
     ("GET", "/v1/runner/prefix-cache"),
     ("POST", "/v1/runner/prefix-cache/clear"),
     ("GET", "/health"),
+    ("GET", "/metrics"),
     ("POST", "/unload"),
 }
 

--- a/tests/test_tool_attribution.c
+++ b/tests/test_tool_attribution.c
@@ -87,15 +87,10 @@ bool request_keep_alive(jv *req, bool *present, int *seconds) {
 
 jv *request_schema(jv *req) { (void)req; return NULL; }
 
-void server_record_work(int n_prompt, int n_gen, double gen_seconds) {
-    (void)n_prompt; (void)n_gen; (void)gen_seconds;
-}
+void server_record_work(const work_record *w) { (void)w; }
 
-void server_work_totals(unsigned long long *prompt_tokens,
-                        unsigned long long *gen_tokens, double *gen_seconds) {
-    if (prompt_tokens) *prompt_tokens = 0;
-    if (gen_tokens)    *gen_tokens = 0;
-    if (gen_seconds)   *gen_seconds = 0;
+void server_work_totals(work_totals *out) {
+    if (out) memset(out, 0, sizeof(*out));
 }
 
 #include "../src/server.c"


### PR DESCRIPTION
## What

**R10.1.1 `usage.prompt_tokens_details.cached_tokens`.** Runner has always
counted, per request, how many prompt rows it did not have to prefill, and has
always reported it as `runner_telemetry.prompt_cached_tokens`, a field no
OpenAI-shaped client reads. It is now also carried where OpenAI carries it:
`usage.prompt_tokens_details.cached_tokens` on Chat Completions and legacy
Completions, both buffered and in the `stream_options.include_usage` chunk.
Responses already spelled the same fact `input_tokens_details.cached_tokens`.
The three chat-dialect renderings now come from one function
(`openai_usage_json` in `src/completion.c`), so a client that flips `stream` on
and off cannot be handed two shapes.

`prompt_tokens` keeps its meaning: cached tokens are INCLUDED in it, exactly as
at OpenAI, so no caller's total moves. Anthropic Messages deliberately does not
gain the field, and its existing test still pins that.

**R10.1.2 `GET /metrics`.** Prometheus text exposition 0.0.4
(`text/plain; version=0.0.4`), advertised as
`features.prometheus_metrics`. It exposes the counters `/health` and
`/v1/runner/prefix-cache` already answer, under the `runner_` prefix: requests,
prompt / cached / generated tokens, generation seconds, microbatch steps and
sequences, the prefix-cache hit/miss/store/eviction/reuse counters plus saved
prefill seconds, the three speculation counters, and gauges for active
requests, prefix-cache bytes/budget/entries and the two RSS readings. Every
sample is preceded by its own `# HELP` and `# TYPE`. On whenever `--serve` is,
no flag.

Three counters had no server-wide home and gained one at the single
once-per-request recording point, not on any hot path: cached prompt tokens,
the speculation totals, and admitted requests. `server_record_work` and
`server_work_totals` now take a record and a totals struct instead of a
widening argument list.

## Why

A cache-hit figure a standard client cannot see is a figure nobody reads: the
cost dashboards, SDK helper properties and agent frameworks that report cache
hit rate all read `prompt_tokens_details.cached_tokens`. And an operator
running Runner next to anything else has to translate `/health` JSON by hand
before a scraper can see it; `/metrics` removes that step.

Two deliberate refusals, both documented in the code:

- Messages does not get the field. `cache_read_input_tokens` describes
  Anthropic's own caching product, whose `input_tokens` EXCLUDES what it
  covers, so putting Runner's unrelated number there would misstate a client's
  accounting rather than inform it.
- `/metrics` computes nothing. No hit rate, no tokens per second: a rate needs
  an averaging window and the scraper owns that window, which is the same rule
  `/health` already follows.

A receipts-issued counter was wanted and is ABSENT: receipts are written by the
one-shot `--transcript` path, and the server keeps no counter for them. No new
hot-path counter was invented for it.

## Tests

New conformance file `tests/conformance/test_usage_cached_tokens.py`: per
surface, `cached_tokens` is present, an integer, within `[0, prompt_tokens]`,
0 under `cache_prompt: false` and above 0 on a repeated prompt; `prompt_tokens`
unchanged between the cold and warm run; the streamed usage chunk carries the
same object and still parses; Messages keeps the Anthropic vocabulary.

`/metrics` tests in `tests/conformance/test_process_metrics.py`: a strict
hand-written exposition parser (one sample per line, HELP/TYPE pairs, no
duplicates, counters named `_total` and gauges not), the declared metric
roster, counters monotonic and matching the two requests' own `usage`, equality
against `/health` and `/v1/runner/prefix-cache` as the external anchor,
self-exclusion under repeated scrapes, and the capability flag. `/metrics` was
also added to the fast-path framing parametrizations and the startup-banner
route set.

The `/metrics` gate was mutation-checked: renaming one metric in `src/server.c`,
rebuilding and rerunning turned it red, and the restore was confirmed by a
changed binary hash and a live scrape.

`make test`: 479 passed, 15 skipped (plus the C gates), exit 0.
`scripts/conformance.sh`: 433 passed, 17 skipped, exit 0.
`help-parity.py`: ok, 74 options in parity (no flag added).
Five conformance fixtures re-recorded; the diff is the added field and the two
new capability flags, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)