### PR TITLE
README lead and three search-intent pages (train LoRA on quantized GGUF, reproducible training with receipts, truncation-safe tool calling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
 # Xyntetik Runner
 
-One binary is the whole model runtime: it **serves, verifies, scores,
-adapts and trains** GGUF models - deterministically, with every claim tied
-to a measurement you can re-run. Written from scratch in plain C. No
-Python, no pip, no third-party runtime, no ggml. CPU (x86 AVX2/FMA, ARM
-NEON), CUDA, and Metal.
+Xyntetik Runner is a single-binary GGUF inference and LoRA training engine
+written from scratch in plain C: one binary **serves, verifies, scores,
+adapts and trains** GGUF models on CPU (x86 AVX2/FMA, ARM NEON), CUDA and
+Metal. It trains LoRA adapters directly through the same quantized GGUF
+weights it serves, with no separate FP16 training copy, and two runs with
+the same data, seed and config write a byte-identical adapter file. Every
+claim is tied to a measurement you can re-run, and every recorded run is a
+signed receipt that replays. No Python, no pip, no third-party runtime, no
+ggml. One caveat travels with the training claim: a quantized merge rounds
+the delta, and merging an adapter into a 4-bit base erases the fine-tune
+(8-bit and F16 keep it), so serve adapters with `--lora` or merge into
+Q8_0 or better.
+
+Three questions this engine answers, one page each:
+[train a LoRA on the quantized GGUF you serve](docs/train-lora-on-quantized-gguf.md),
+[reproducible LoRA training with receipts](docs/reproducible-lora-training-receipts.md),
+[tool calls that survive the token limit](docs/truncation-safe-tool-calling.md).
 
 ![Two independent training runs producing byte-identical adapters](docs/assets/deterministic-training.gif)
 

--- a/docs/reproducible-lora-training-receipts.md
+++ b/docs/reproducible-lora-training-receipts.md
@@ -1,0 +1,55 @@
+# Reproducible LoRA training with receipts
+
+**Question.** Is LoRA training reproducible, and can I prove which adapter
+came from which run, which data and which base?
+
+**Answer.** On the same build, yes, byte for byte: `--train` with the same
+data, seed and configuration writes the same adapter file, verified by
+sha256 in CI. Every adapter is written with a `.train.json` sidecar that
+records the base, data and adapter sha256, the seed, the full configuration,
+and the binary sha, compiler, OS and architecture that produced it. That
+sidecar is the receipt for the training run.
+
+## What "reproducible" means here, exactly
+
+Runner's contract is written down with named edges in
+[docs/determinism-scope.md](determinism-scope.md). The short form:
+
+- **Claimed and gated in CI.** Same executable, same inputs, same sampled
+  tokens. Training byte-determinism on the same build. Quantization and
+  merge write the same output bytes for the same inputs on the same build.
+- **Not claimed.** Independent rebuilds (another compiler, version or ISA)
+  are not byte-identical; cross-engine token identity is not promised;
+  numerical identity of hidden states is never promised.
+
+Page titles elsewhere say "deterministic". The claim Runner makes is the
+narrower one above: reproducible on the same build, and receipted so that
+a later reader can check what ran.
+
+## Receipts for inference runs
+
+Recorded runs carry the same discipline. `--transcript FILE` records a
+one-shot run as a signed record: model, adapter and binary hashes, the
+effective execution profile, the exact seed and sampling configuration,
+prompt and output token ids, and the exact streamed output bytes.
+`--verify FILE` replays it and exits with one of three verdicts:
+`VERIFIED` (0), `DIVERGED` at a token or output byte (2), or
+`UNVERIFIABLE` for an invalid record or an artifact mismatch (3).
+
+- **T1, same binary.** Bit-exact replay of the recorded run.
+- **T2, cross-ISA.** Token-level replay on another machine or architecture;
+  floating-point internals may differ, and the boundary is libm.
+
+Receipts chain (`--transcript-prev`), are signed with an Ed25519 key you
+generate (`--keygen`, `--sign-key`), and the loaded model can be verified
+against an OpenSSF Model Signing bundle (`--model-sig`, `--model-pubkey`).
+Flag rows are in the [command-line reference](../README.md#command-line-reference).
+
+## Measured
+
+The public artifact
+[Qwen3-4B-Runner-ToolUse-Q4_K_M](https://huggingface.co/Joakimpalm-Zen/Qwen3-4B-Runner-ToolUse-Q4_K_M)
+was produced twice, independently, with the same sha256 on the adapter file
+(measured 2026-08-22). Its card carries the sidecar and the training
+command. Training runs on the CPU path; the dominant matvec of the backward
+runs on CUDA behind a flag, and CUDA training end to end is open work.

--- a/docs/train-lora-on-quantized-gguf.md
+++ b/docs/train-lora-on-quantized-gguf.md
@@ -1,0 +1,55 @@
+# Train a LoRA directly on the quantized GGUF you serve
+
+**Question.** Can I train a LoRA adapter on a quantized GGUF (Q4, Q8) without
+keeping a separate FP16 copy of the model?
+
+**Answer.** Yes. Runner trains LoRA adapters through the frozen quantized GGUF
+used for inference. The serving forward pass is the training forward pass,
+so there is no second numerical path for the policy to drift across, and the
+adapter is written beside a provenance record (base, data and adapter sha256,
+seed, full config).
+
+## The measured claim
+
+Measured 2026-08-22 on a public artifact you can download and reproduce,
+[Qwen3-4B-Runner-ToolUse-Q4_K_M](https://huggingface.co/Joakimpalm-Zen/Qwen3-4B-Runner-ToolUse-Q4_K_M):
+
+| | result |
+|---|---|
+| base | Qwen3-4B Q4_K_M, the frozen 4-bit serving weights |
+| training path | directly through the quantized inference artifact, CPU |
+| held-out tool calling, exact call | 0.69 before, 1.00 after |
+| reproducibility | two independent runs, same sha256 on the adapter file |
+| precision study | adapters trained through BF16 and Q8_0: cosine 0.9998; through Q4_K_M: 0.9926, a measurably different object that is capability-equivalent on this task's supervised decisions |
+| neutral-corpus drift | nll per token 4.063 to 4.026, unrelated text left alone |
+| interop | the adapter scores the same 1.00 served by stock llama.cpp |
+
+The claim scope is one base and one task. The 8B and 14B ladder is open
+work, and the numbers above are not a promise about other families.
+
+## The caveat that travels with the claim
+
+`--merge-lora` folds an adapter into the base to produce a standalone GGUF.
+Merging into Q8_0 or F16 keeps the 1.00 (verified in stock llama.cpp).
+Merging into the 4-bit base erases the fine-tune: the score returns to 0.69
+because most of the delta rounds back to the base's own quantization grid.
+Serve adapters with `--lora` (the exact form) or merge into 8-bit or better.
+
+## Commands
+
+```sh
+./runner -m base-Q4_K_M.gguf --train data.jsonl --train-steps 200 \
+  --lora-rank 8 --train-out adapter.gguf
+./runner -m base-Q4_K_M.gguf --lora adapter.gguf --serve
+./runner -m base-Q4_K_M.gguf --lora adapter.gguf --merge-lora merged-Q8_0.gguf --quant q8_0
+```
+
+Flag reference: `--train`, `--train-steps`, `--lr`, `--train-ctx`,
+`--train-out`, `--save-every`, `--lora-rank`, `--lora`, `--lora-scale`,
+`--merge-lora`, `--score` in the [command-line reference](../README.md#command-line-reference).
+
+## Where the numbers come from
+
+Design, gates, failure modes and every number above:
+[docs/adaptation-engine.md](adaptation-engine.md). Reproducibility scope,
+with what is and is not claimed: [docs/determinism-scope.md](determinism-scope.md).

--- a/docs/truncation-safe-tool-calling.md
+++ b/docs/truncation-safe-tool-calling.md
@@ -1,0 +1,61 @@
+# Tool calls that survive the token limit
+
+**Question.** What happens to a tool call when `max_tokens` runs out in the
+middle of the JSON arguments?
+
+**Answer.** In most engines the caller gets `finish_reason: "length"` with
+nothing usable, or truncated JSON to repair or retry. Runner closes the call
+to the smallest schema-legal document instead, so the arguments still parse
+and the agent loop continues. This is forced-truncation recovery, a property
+of the runtime, not ordinary JSON-Schema constrained decoding.
+
+## Measured
+
+Same box, same tool schema, same prompt, `tool_choice: "required"`,
+temperature 0, budgets from 1 to 64 tokens. What each engine hands the
+caller when the budget cuts the call short:
+
+| engine | budget too small (1 to 16 tokens) | enough budget (64, control) |
+|---|---|---|
+| Runner | executable `tool_calls`, arguments parse | completes |
+| vLLM 0.27.1 | no call; protocol framing leaks into `content` | completes |
+| llama.cpp b10488 | no call; leak, then `tool_calls` with unparseable arguments | completes |
+| Ollama 0.32.14 | no call; empty content, then HTTP 500 | completes |
+| TensorRT-LLM 1.2.1 | no call; `<tool_call>` leak, then empty content | completes |
+| SGLang 0.5.17 | no call; `<tool_call>` leak, then empty content | completes |
+
+The control rung proves the failure is truncation, not misconfiguration:
+every engine completes at 64. TensorRT-LLM and SGLang were measured on a
+Qwen3-1.7B substitute because their registries did not carry the
+granite-4.1-3b used for the other four; recovery is a property of the
+engine, so the substitution measures the engine, not the model. The claim
+covers the engines and versions measured, not engines that were not.
+
+The recipe, the raw responses and the date of the measurement are in the
+[truncation benchmark](truncation-benchmark.md), which pins Runner's column
+as a per-release regression gate (`make test-truncation`). The
+[agent-torture gate](agent-torture.md) tests the same failure mode inside
+multi-turn agent loops.
+
+## Under quantization
+
+Tool-call fidelity was also measured across a full quant ladder: constrained
+decoding held schema conformance and tool selection at 100% down to Q4_0,
+while argument agreement decayed to 50%. Constrained decoding guarantees the
+shape of a call at any quantization, not its contents. Numbers and method:
+[docs/quant-fidelity.md](quant-fidelity.md).
+
+## Try it
+
+```sh
+./runner -m model.gguf --serve
+curl localhost:8080/v1/chat/completions -d '{
+  "messages":[{"role":"user","content":"Book a table for two at 19:00."}],
+  "tools":[{"type":"function","function":{"name":"book_table",
+    "parameters":{"type":"object","properties":{"people":{"type":"integer"},
+    "time":{"type":"string"}},"required":["people","time"]}}}],
+  "tool_choice":"required","max_tokens":8}'
+```
+
+The response carries a `tool_calls` entry whose `arguments` parse, and the
+usual `finish_reason: "length"` so the caller knows the budget was hit.


### PR DESCRIPTION
Docs only. The README's first paragraph now names what the engine does in the words people search for: a single-binary GGUF inference and LoRA training engine in C that trains adapters through the same quantized weights it serves, with the merge caveat in the same paragraph. Three new pages under docs/ answer one question each with the measured claim, its scope, the date and the links to the evidence pages:

- docs/train-lora-on-quantized-gguf.md
- docs/reproducible-lora-training-receipts.md
- docs/truncation-safe-tool-calling.md

Every number is taken from the README's existing measured sections (adaptation engine, truncation benchmark, quant fidelity) and the determinism scope page; no new claims. The reproducibility page states the same-build scope explicitly and says what is not claimed.

For the owner to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)