### PR TITLE
xyntetik.com: static site generated from the repository

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,47 @@
+name: xyntetik.com
+
+# Builds the static site from repository content (site/build_pages.py) and
+# publishes it to GitHub Pages at https://xyntetik.com. No secrets: the
+# deploy uses the repository's own Pages token.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - "docs/**"
+      - "README.md"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - run: python3 site/build_pages.py
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+      - uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.13
+        with:
+          source: ./site
+          destination: ./_site
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: ./_site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,8 @@ test-ed25519
 test-ed25519.exe
 test-ecdsa
 test-ecdsa.exe
+
+# xyntetik.com is generated at build time (site/build_pages.py)
+site/runner/
+site/_includes/build.html
+site/_site/

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,12 @@
+# xyntetik.com
+
+The public site is generated from this repository: `build_pages.py` copies
+README sections and selected `docs/` pages into `runner/` at build time,
+rewriting relative links to site pages where they exist and to GitHub
+otherwise. The workflow `.github/workflows/pages.yml` runs the generator,
+builds the Jekyll source in this directory and publishes it to GitHub Pages
+on every push to `main` that touches `site/`, `docs/` or the README.
+
+Nothing here may claim more than the repository does: the pages are copies.
+Layout and the umbrella `index.md` are the only hand-written files. Generated
+output (`runner/`, `_includes/build.html`) is ignored by git.

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -1,0 +1,14 @@
+title: Xyntetik
+url: https://xyntetik.com
+description: Runner, a single-binary GGUF inference and LoRA training engine in C. Every claim carries its measurement.
+markdown: kramdown
+kramdown:
+  input: GFM
+  hard_wrap: false
+  syntax_highlighter: rouge
+exclude:
+  - build_pages.py
+  - README.md
+  - Gemfile
+  - Gemfile.lock
+  - vendor

--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{ page.title }}{% if page.title != site.title %} · {{ site.title }}{% endif %}</title>
+<meta name="description" content="{{ page.description | default: site.description }}">
+<link rel="canonical" href="{{ page.url | absolute_url }}">
+<style>
+:root{--fg:#111;--bg:#fff;--mute:#555;--line:#ddd;--code:#f4f4f4;--link:#0044aa}
+@media (prefers-color-scheme:dark){:root{--fg:#e6e6e6;--bg:#111;--mute:#aaa;--line:#333;--code:#1c1c1c;--link:#7fb0ff}}
+html{color-scheme:light dark}
+body{margin:0;background:var(--bg);color:var(--fg);font:16px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+header,main,footer{max-width:78ch;margin:0 auto;padding:0 1rem}
+header{padding-top:1rem;border-bottom:1px solid var(--line)}
+header nav a{margin-right:1rem;white-space:nowrap}
+header nav{display:flex;flex-wrap:wrap;gap:.25rem 0;padding-bottom:.75rem}
+main{padding:1.5rem 1rem 3rem}
+footer{border-top:1px solid var(--line);padding:1rem;color:var(--mute);font-size:.9em}
+a{color:var(--link)}
+h1,h2,h3{line-height:1.25}
+h1{font-size:1.6em;margin-top:0}
+code,pre{background:var(--code);font-family:inherit}
+code{padding:.05em .3em}
+pre{padding:.75rem;overflow-x:auto}
+pre code{padding:0;background:none}
+table{border-collapse:collapse;display:block;overflow-x:auto;max-width:100%}
+th,td{border:1px solid var(--line);padding:.3rem .6rem;text-align:left;vertical-align:top}
+img{max-width:100%;height:auto}
+blockquote{border-left:3px solid var(--line);margin:0;padding-left:1rem;color:var(--mute)}
+</style>
+</head>
+<body>
+<header>
+<nav>
+<a href="/">Xyntetik</a>
+<a href="/runner/">Runner</a>
+<a href="/runner/what-it-adds/">What it adds</a>
+<a href="/runner/benchmarks/">Benchmarks</a>
+<a href="/runner/train-lora-on-quantized-gguf/">Train LoRA on GGUF</a>
+<a href="/runner/reproducible-lora-training-receipts/">Receipts</a>
+<a href="/runner/truncation-safe-tool-calling/">Tool calling</a>
+<a href="/runner/models/">Models</a>
+<a href="/runner/support-matrix/">Support matrix</a>
+<a href="/runner/docs/">Docs</a>
+<a href="https://github.com/Joakimpalm-Zen/xyntetik-runner">GitHub</a>
+</nav>
+</header>
+<main>
+{{ content }}
+</main>
+<footer>
+Apache 2.0. Built in Sweden, runs on your hardware. Every number on this
+site carries the date it was measured; the source of every page is the
+<a href="https://github.com/Joakimpalm-Zen/xyntetik-runner">repository</a>.
+{% include build.html %}
+</footer>
+</body>
+</html>

--- a/site/build_pages.py
+++ b/site/build_pages.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Generate the Runner pages of xyntetik.com from repository content.
+
+Standard library only. Reads README.md sections and selected docs/ pages,
+rewrites relative links to GitHub URLs (or to site pages where one exists),
+and writes Jekyll sources under site/runner/. The site cannot say anything
+the repository does not: every page is a copy made at build time.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SITE = ROOT / "site"
+OUT = SITE / "runner"
+REPO = "https://github.com/Joakimpalm-Zen/xyntetik-runner"
+BLOB = REPO + "/blob/main/"
+RAW = "https://raw.githubusercontent.com/Joakimpalm-Zen/xyntetik-runner/main/"
+
+# docs pages that become site pages: docs file -> site slug
+DOC_PAGES = {
+    "train-lora-on-quantized-gguf.md": "train-lora-on-quantized-gguf",
+    "reproducible-lora-training-receipts.md": "reproducible-lora-training-receipts",
+    "truncation-safe-tool-calling.md": "truncation-safe-tool-calling",
+    "benchmarks.md": "benchmarks",
+}
+# README sections that become site pages: heading -> (slug, title)
+README_PAGES = {
+    "What Runner adds": ("what-it-adds", "What Runner adds"),
+    "Models and conversion": ("models", "Models and published artifacts"),
+    "Support matrix": ("support-matrix", "Support matrix"),
+}
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def readme_sections(text: str) -> dict[str, str]:
+    """Top-level '## ' sections of the README, body without the heading."""
+    out: dict[str, str] = {}
+    parts = re.split(r"(?m)^## ", text)
+    for part in parts[1:]:
+        title, _, body = part.partition("\n")
+        out[title.strip()] = body
+    return out
+
+
+def readme_lead(text: str) -> str:
+    """Everything before the first '## ' heading, minus the H1."""
+    head = text.split("\n## ", 1)[0]
+    return re.sub(r"(?m)^# .*\n", "", head, count=1)
+
+
+def rewrite_links(md: str, *, base: str) -> str:
+    """Point relative links at site pages when they exist, else at GitHub.
+
+    base is 'docs' for a docs page and 'root' for README content.
+    """
+    def fix(m: re.Match[str]) -> str:
+        pre, target = m.group(1), m.group(2)
+        if re.match(r"^(https?:|mailto:|#)", target) and not target.startswith("#"):
+            return m.group(0)
+        if target.startswith("#"):
+            # anchors inside README content point back at the README on GitHub
+            return f"{pre}{BLOB}README.md{target})" if base == "root" else m.group(0)
+        path, _, anchor = target.partition("#")
+        anchor = f"#{anchor}" if anchor else ""
+        if base == "docs":
+            rel = path[3:] if path.startswith("../") else path
+            if not path.startswith("../"):
+                rel = "docs/" + path
+        else:
+            rel = path
+        rel = rel.lstrip("./")
+        name = os.path.basename(rel)
+        if rel.startswith("docs/") and name in DOC_PAGES and not rel.startswith("docs/assets"):
+            return f"{pre}/runner/{DOC_PAGES[name]}/{anchor})"
+        if rel.startswith("docs/assets/") or re.search(r"\.(png|gif|jpg|jpeg|svg)$", rel):
+            return f"{pre}{RAW}{rel})"
+        return f"{pre}{BLOB}{rel}{anchor})"
+    return re.sub(r"(\]\()([^)\s]+)\)", fix, md)
+
+
+def front(title: str, slug: str, description: str = "") -> str:
+    desc = description.replace('"', "'")
+    lines = ["---", "layout: default", f'title: "{title}"',
+             f"permalink: /runner/{slug}/" if slug else "permalink: /runner/"]
+    if desc:
+        lines.append(f'description: "{desc}"')
+    lines.append("---\n")
+    return "\n".join(lines)
+
+
+def first_paragraph(md: str) -> str:
+    for block in md.split("\n\n"):
+        b = block.strip()
+        if b and not b.startswith(("#", "!", "|", "```", "<", "-", "*")):
+            return re.sub(r"\s+", " ", re.sub(r"[*`\[\]]", "", b))[:200]
+    return ""
+
+
+def write(slug: str, title: str, body: str, description: str = "") -> None:
+    OUT.mkdir(parents=True, exist_ok=True)
+    (OUT / f"{slug or 'index'}.md").write_text(front(title, slug, description) + body, encoding="utf-8")
+
+
+def build_revision() -> str:
+    sha = os.environ.get("GITHUB_SHA")
+    if not sha:
+        try:
+            sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=ROOT, capture_output=True,
+                                 text=True, check=True).stdout.strip()
+        except Exception:
+            sha = "unknown"
+    return sha
+
+
+def main() -> int:
+    readme = read(ROOT / "README.md")
+    sections = readme_sections(readme)
+    lead = rewrite_links(readme_lead(readme), base="root")
+    # Runner landing: lead + sixty seconds + why
+    parts = ["# Xyntetik Runner\n", lead]
+    for h in ("Sixty seconds to a served model", "Why this and not llama.cpp?"):
+        parts.append(f"\n## {h}\n" + rewrite_links(sections[h], base="root"))
+    parts.append("\nThe rest of the README, from the command-line reference to the compatibility "
+                 f"evidence, is [on GitHub]({BLOB}README.md).\n")
+    write("", "Xyntetik Runner", "".join(parts),
+          "A single-binary GGUF inference and LoRA training engine in C for CPU, CUDA and Metal.")
+    for heading, (slug, title) in README_PAGES.items():
+        body = rewrite_links(sections[heading], base="root")
+        write(slug, title, f"# {title}\n" + body +
+              f"\n\nThis page is the README section of the same name, copied at build time; "
+              f"the [README on GitHub]({BLOB}README.md) is the source.\n",
+              first_paragraph(body))
+    for fname, slug in DOC_PAGES.items():
+        text = read(ROOT / "docs" / fname)
+        m = re.match(r"(?m)^# (.+)$", text)
+        title = m.group(1).strip() if m else slug
+        body = rewrite_links(text, base="docs")
+        body += (f"\n\nSource: [docs/{fname}]({BLOB}docs/{fname}) in the repository, "
+                 "copied at build time.\n")
+        write(slug, title, body, first_paragraph(text))
+    # docs index
+    rows = []
+    for p in sorted((ROOT / "docs").glob("*.md")):
+        t = read(p)
+        m = re.match(r"(?m)^# (.+)$", t)
+        title = (m.group(1).strip() if m else p.stem).replace("|", "\\|")
+        target = f"/runner/{DOC_PAGES[p.name]}/" if p.name in DOC_PAGES else f"{BLOB}docs/{p.name}"
+        rows.append(f"| [{p.name}]({target}) | {title} |")
+    write("docs", "Runner documentation",
+          "# Runner documentation\n\nEvery page under `docs/` in the repository, by file name. "
+          "Pages that exist on this site link here; the rest link to GitHub.\n\n"
+          "| file | title |\n|---|---|\n" + "\n".join(rows) + "\n",
+          "Index of every documentation page in the Runner repository.")
+    (SITE / "_includes").mkdir(exist_ok=True)
+    sha = build_revision()
+    (SITE / "_includes" / "build.html").write_text(
+        f'Generated from <a href="{REPO}/commit/{sha}">{sha[:12]}</a>.\n', encoding="utf-8")
+    # the templates this script owns carry no em dashes (public-prose rule)
+    for p in (SITE / "index.md", SITE / "_layouts" / "default.html", Path(__file__)):
+        if "\u2014" in read(p):
+            print(f"em dash in {p}", file=sys.stderr)
+            return 1
+    print(f"wrote {len(list(OUT.glob('*.md')))} pages under {OUT.relative_to(ROOT)} at {sha[:12]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/index.md
+++ b/site/index.md
@@ -1,0 +1,35 @@
+---
+layout: default
+title: Xyntetik
+permalink: /
+description: Local models on hardware you own. Runner is the engine, free forever under Apache 2.0.
+---
+
+# Xyntetik
+
+Local models on hardware you own. Xyntetik is independent and
+bootstrapped: **the engine is free forever under Apache 2.0**, and
+consulting and enterprise work fund the hardware. Built in Sweden. Your
+data never leaves the building.
+
+## Runner
+
+A single-binary GGUF inference and LoRA training engine written from
+scratch in plain C, for CPU, CUDA and Metal. It trains LoRA adapters
+through the same quantized weights it serves, closes tool calls that run
+out of tokens so they still parse, and records every run as a receipt that
+replays. Every claim on these pages is tied to a measurement you can re-run.
+
+- [Runner](/runner/): what it is, sixty seconds to a served model, why this and not llama.cpp
+- [Train a LoRA on the quantized GGUF you serve](/runner/train-lora-on-quantized-gguf/)
+- [Reproducible LoRA training with receipts](/runner/reproducible-lora-training-receipts/)
+- [Tool calls that survive the token limit](/runner/truncation-safe-tool-calling/)
+- [Benchmarks](/runner/benchmarks/), [models and published artifacts](/runner/models/), [support matrix](/runner/support-matrix/), [all docs](/runner/docs/)
+- [Source, releases and issues on GitHub](https://github.com/Joakimpalm-Zen/xyntetik-runner)
+
+## Research
+
+Measured reports and artifacts are published on
+[Hugging Face](https://huggingface.co/Joakimpalm-Zen): quantization fidelity
+ladders, pruned and surgically reduced models with their envelopes, and the
+adapters the training claims are measured on.


### PR DESCRIPTION
Adds site/ (Jekyll source: config, one layout, the umbrella index) and site/build_pages.py, a standard-library generator that copies README sections and the docs pages that answer one question each into site/runner/ at build time, rewriting links to site pages where they exist and to GitHub otherwise. A Pages workflow (pinned actions) builds and deploys on pushes to main that touch site/, docs/ or the README.

The site cannot claim more than the repository: every page is a copy made at build time, and the footer names the commit it was generated from.

Pages: /, /runner/, /runner/what-it-adds/, /runner/benchmarks/, /runner/train-lora-on-quantized-gguf/, /runner/reproducible-lora-training-receipts/, /runner/truncation-safe-tool-calling/, /runner/models/, /runner/support-matrix/, /runner/docs/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)