### PR TITLE
v0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ change between releases (the `-alpha` suffix was retired at v0.2.0 — the 0.x
 version already says what it needs to). Entries below the rename keep the
 names that were true when they were written.
 
-## Unreleased
+## v0.4.8 - 2026-09-05
+
+The E-series and contraction release: Gemma 4's current shared-KV exports
+load, the CPU prefill dot gives one answer whatever the batch shape, and the
+serving surface gains `cached_tokens`, `GET /metrics` and a fourth draft
+source that needs no weights.
+
 
 - **Batched prefill dot: blocking-independence by construction, not by
   codegen luck.** The CPU prefill kernel (`vec_dot_f32_multi` and the 4x4

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ for Linux, macOS, or Windows, or build from source:
 git clone https://github.com/Joakimpalm-Zen/xyntetik-runner
 cd xyntetik-runner
 make
-./runner --version   # -> runner 0.4.7
+./runner --version   # -> runner 0.4.8
 ```
 
 CUDA builds and releases need only an NVIDIA driver at runtime. The CUDA
@@ -211,7 +211,7 @@ Run a GGUF:
 ./runner -m model.gguf --draft-lookup -f transcript.txt -p "Summarize the text above"
 ```
 
-> **Pre-1.0 (`0.4.7`).** APIs, model coverage and certification envelopes may
+> **Pre-1.0 (`0.4.8`).** APIs, model coverage and certification envelopes may
 > change between releases. CI builds and smoke-tests Linux, macOS, and
 > Windows, but the project still has limited hardware coverage. Include
 > `runner --version`, `runner --caps`, the model's exact filename, and the load
@@ -379,7 +379,7 @@ shell, then run `make`.
 
 Each release publishes a CPU image - the same binary on a distroless glibc base,
 nothing else - to `ghcr.io/joakimpalm-zen/xyntetik-runner:v<version>` (the
-tag carries the `v`, e.g. `:v0.4.7`) and `:latest`. Build it yourself with `docker build -t runner .`.
+tag carries the `v`, e.g. `:v0.4.8`) and `:latest`. Build it yourself with `docker build -t runner .`.
 
 The server binds **loopback only** by design (there is no `--host`/`0.0.0.0`
 flag), so it never exposes itself to a network, even in a container - which
@@ -611,8 +611,8 @@ reported beside it).
   4k context and 512 MiB at 32k, plus 74.3 MB of file, and tracks its parent
   at clean KLD 0.0223 on 44,413 held-out positions (measured 2026-08-30 on
   the identical zeroed form, carried over by bit identity 2026-09-04). It
-  loads only in this runner from v0.4.7 on, CPU path, and llama.cpp refuses
-  it by name; the card says so beside the numbers.
+  loads only in this runner from the 0.4.7 release on, CPU path, and
+  llama.cpp refuses it by name; the card says so beside the numbers.
 - Measurement reports over third-party artifacts, no weights republished,
   every measured file bound by SHA:
   [Hermes-4-14B quant fidelity](https://huggingface.co/Joakimpalm-Zen/Hermes-4-14B-quant-fidelity-report)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-Runner is **pre-1.0** (`0.4.7`). Only the latest release is
+Runner is **pre-1.0** (`0.4.8`). Only the latest release is
 supported; there are no backports.
 
 ## Threat model

--- a/docs/compat-reports/0.4.8-2026-09-05-blackwell-gemma4.json
+++ b/docs/compat-reports/0.4.8-2026-09-05-blackwell-gemma4.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "xyntetik.runner.model-compat-report.v1",
+  "generated_utc": "2026-09-05T07:42:18Z",
+  "host": {
+    "os": "Linux",
+    "machine": "x86_64"
+  },
+  "runner": {
+    "path": "runner",
+    "version": "runner 0.4.8"
+  },
+  "reference": {
+    "path": null,
+    "version": null
+  },
+  "models": [
+    {
+      "id": "gemma-4-e4b-it-q4_k_m",
+      "architecture": "gemma4",
+      "file": "models/gemma-4-E4B-it-Q4_K_M.gguf",
+      "expected_sha256": "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87",
+      "checks": {
+        "load": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 164.9,
+          "stderr_tail": "gemma4: E-series (per-layer embeddings + shared KV) \u2014 verified against llama.cpp at the Q4_K noise floor rather than token-identically\nrope: using model frequency factors (rope_freqs.weight)\nloaded /home/lab/workspace/models/gemma-4-E4B-it-Q4_K_M/gemma-4-E4B-it-Q4_K_M.gguf | gemma4 | 42 layers | ctx 4096 | 32 threads | 0.04s\nsampling: gemma3 (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\n\nprompt: 4 tok, 53.39 tok/s | gen: 1 tok, 34.63 tok/s\n"
+        },
+        "cpu_cuda": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 71761.42,
+          "pins": {
+            "RUNNER_CUDA_TC": "0",
+            "RUNNER_MOE_EAGER": "1"
+          },
+          "min_prompt_tokens": 85,
+          "cpu_cuda_identity": {
+            "result": "pass",
+            "exact": "9/9",
+            "near_tie_tolerated": 0
+          },
+          "identical": "9/9",
+          "failed_prompts": [],
+          "report": "/home/lab/workspace/.r41-runner/rel048/cpu_cuda/gemma-4-e4b-it-q4_k_m.json",
+          "output_tail": "'\nok  : 'Q: What is 17 * 23?\\nA:'\nok  : 'The lighthouse keeper recorded the weather every morning: wind direction, cloud cover, and the hour the fog lifted.'\nok  : 'In 1929 the observatory published a revised catalogue listing 4218 objects, of which roughly one in nine turned out on later inspection to be a duplicate entry under a second designation. The correction'\nok  : \"def parse_header(buf, size):\\n    if size < 8:\\n        raise ValueError('short header')\\n    magic, version = struct.unpack('<II', buf[:8])\\n    if magic != GGUF_MAGIC:\\n        raise ValueError('not a gguf file')\\n    return magic, version\\n\\n# The loader above rejects a truncated header before unpacking it, which\"\nok  : 'The city of Lisbon sits on seven hills above the Tagus estuary, and its oldest quarter survived the 1755 earthquake largely intact because the bedrock there is firmer than the reclaimed ground downriver. Rebuilding the lower town took decades, and the grid of streets laid out afterwards was among the first in Europe designed with seismic loads in mind, which is why the district still reads as unusually regular to a visitor who'\n\ncpu_cuda: pass \u2014 9/9 exact, 0 near-tie tolerated (eager routing)\n"
+        },
+        "chat": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 474.86,
+          "prompt": "What is 2+2?",
+          "gpu": "off",
+          "failure_reasons": [],
+          "output_tail": "2 + 2 equals **4**.\n"
+        }
+      },
+      "resolved_file": "models/gemma-4-E4B-it-Q4_K_M.gguf",
+      "actual_sha256": "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87",
+      "file_status": "pass",
+      "complete": true
+    }
+  ],
+  "complete": true,
+  "summary": {
+    "models": 1,
+    "files": {
+      "pass": 1
+    },
+    "checks": {
+      "load": {
+        "pass": 1
+      },
+      "cpu_cuda": {
+        "pass": 1
+      },
+      "chat": {
+        "pass": 1
+      }
+    }
+  }
+}

--- a/docs/compat-reports/0.4.8-2026-09-05-blackwell-moe.json
+++ b/docs/compat-reports/0.4.8-2026-09-05-blackwell-moe.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "xyntetik.runner.model-compat-report.v1",
+  "generated_utc": "2026-09-05T07:40:45Z",
+  "host": {
+    "os": "Linux",
+    "machine": "x86_64"
+  },
+  "runner": {
+    "path": "runner",
+    "version": "runner 0.4.8"
+  },
+  "reference": {
+    "path": null,
+    "version": null
+  },
+  "models": [
+    {
+      "id": "qwen3-30b-a3b-q4_k_m",
+      "architecture": "qwen3moe",
+      "file": "models/Qwen3-30B-A3B-Q4_K_M.gguf",
+      "expected_sha256": "0d003f6662faee786ed5da3e31b29c978de5ae5d275c8794c606a7f3c01aa8f5",
+      "checks": {
+        "load": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 186.0,
+          "stderr_tail": "loaded /home/lab/workspace/models/Qwen3-30B-A3B-Q4_K_M/Qwen3-30B-A3B-Q4_K_M.gguf | qwen3moe | 48 layers | ctx 4096 | 32 threads | 0.02s\nsampling: qwen3 (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\n\nprompt: 3 tok, 23.17 tok/s | gen: 1 tok, 34.60 tok/s\n"
+        },
+        "cpu_cuda": {
+          "status": "not_executed",
+          "reason": "insufficient_vram",
+          "detail": "error: 19.3GB of VRAM requested on GPU-399aa5c7-bb47-5ccb-b688-54fefec06647, but only 9.6GB is available",
+          "elapsed_ms": 35588.94,
+          "pins": {
+            "RUNNER_CUDA_TC": "0",
+            "RUNNER_MOE_EAGER": "1"
+          },
+          "report": "/home/lab/workspace/.r41-runner/rel048/cpu_cuda/qwen3-30b-a3b-q4_k_m.json"
+        },
+        "chat": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 567.31,
+          "prompt": "What is 2+2?",
+          "gpu": "off",
+          "failure_reasons": [],
+          "output_tail": "2 + 2 = 4.\n"
+        },
+        "tool": {
+          "status": "fail",
+          "returncode": 1,
+          "elapsed_ms": 20177.37,
+          "scenario_matrix": "agent-torture",
+          "totals": {
+            "requests": 8,
+            "passed": 2,
+            "failed": 6
+          },
+          "report": "/home/lab/workspace/.r41-runner/rel048/tool/qwen3-30b-a3b-q4_k_m.json",
+          "output_tail": "report: /home/lab/workspace/.r41-runner/rel048/tool/qwen3-30b-a3b-q4_k_m/report.json\nraw: /home/lab/workspace/.r41-runner/rel048/tool/qwen3-30b-a3b-q4_k_m/raw.jsonl\nruntime=runner requests=8 passed=2 failed=6\n"
+        },
+        "greedy_reference": {
+          "status": "not_executed",
+          "reason": "reference_binary_not_provided"
+        },
+        "long_context": {
+          "status": "not_executed",
+          "reason": "check_class_not_executable"
+        }
+      },
+      "resolved_file": "models/Qwen3-30B-A3B-Q4_K_M.gguf",
+      "actual_sha256": "0d003f6662faee786ed5da3e31b29c978de5ae5d275c8794c606a7f3c01aa8f5",
+      "file_status": "pass",
+      "complete": false
+    }
+  ],
+  "complete": false,
+  "summary": {
+    "models": 1,
+    "files": {
+      "pass": 1
+    },
+    "checks": {
+      "load": {
+        "pass": 1
+      },
+      "cpu_cuda": {
+        "not_executed": 1
+      },
+      "chat": {
+        "pass": 1
+      },
+      "tool": {
+        "fail": 1
+      },
+      "greedy_reference": {
+        "not_executed": 1
+      },
+      "long_context": {
+        "not_executed": 1
+      }
+    }
+  }
+}

--- a/docs/compat-reports/0.4.8-2026-09-05-blackwell.json
+++ b/docs/compat-reports/0.4.8-2026-09-05-blackwell.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "xyntetik.runner.model-compat-report.v1",
+  "generated_utc": "2026-09-05T07:37:33Z",
+  "host": {
+    "os": "Linux",
+    "machine": "x86_64"
+  },
+  "runner": {
+    "path": "runner",
+    "version": "runner 0.4.8"
+  },
+  "reference": {
+    "path": null,
+    "version": null
+  },
+  "models": [
+    {
+      "id": "granite-4.1-8b-q4_0",
+      "architecture": "granite",
+      "file": "models/granite-4.1-8b-Q4_0.gguf",
+      "expected_sha256": "5adf9b6b78921093bd4a805e1060f85d7f744c3eafc14d1ca449364d1e721a1a",
+      "checks": {
+        "load": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 148.4,
+          "stderr_tail": "loaded /home/lab/workspace/models/granite-4.1-8b-Q4_0/granite-4.1-8b-Q4_0.gguf | granite | 40 layers | ctx 4096 | 32 threads | 0.01s\nsampling: generic (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\n\nprompt: 3 tok, 39.50 tok/s | gen: 1 tok, 19.11 tok/s\n"
+        },
+        "tokenizer": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 2837.3,
+          "stdout_tail": "\n0/721 strings differ (0 of them begin with whitespace)\nOK\n",
+          "stderr_tail": "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+        },
+        "cpu_cuda": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 176360.86,
+          "pins": {
+            "RUNNER_CUDA_TC": "0"
+          },
+          "min_prompt_tokens": 85,
+          "cpu_cuda_identity": {
+            "result": "pass",
+            "exact": "9/9",
+            "near_tie_tolerated": 0
+          },
+          "identical": "9/9",
+          "failed_prompts": [],
+          "report": "/home/lab/workspace/.r41-runner/rel048/cpu_cuda/granite-4.1-8b-q4_0.json",
+          "output_tail": "'\nok  : 'Q: What is 17 * 23?\\nA:'\nok  : 'The lighthouse keeper recorded the weather every morning: wind direction, cloud cover, and the hour the fog lifted.'\nok  : 'In 1929 the observatory published a revised catalogue listing 4218 objects, of which roughly one in nine turned out on later inspection to be a duplicate entry under a second designation. The correction'\nok  : \"def parse_header(buf, size):\\n    if size < 8:\\n        raise ValueError('short header')\\n    magic, version = struct.unpack('<II', buf[:8])\\n    if magic != GGUF_MAGIC:\\n        raise ValueError('not a gguf file')\\n    return magic, version\\n\\n# The loader above rejects a truncated header before unpacking it, which\"\nok  : 'The city of Lisbon sits on seven hills above the Tagus estuary, and its oldest quarter survived the 1755 earthquake largely intact because the bedrock there is firmer than the reclaimed ground downriver. Rebuilding the lower town took decades, and the grid of streets laid out afterwards was among the first in Europe designed with seismic loads in mind, which is why the district still reads as unusually regular to a visitor who'\n\ncpu_cuda: pass \u2014 9/9 exact, 0 near-tie tolerated (eager routing)\n"
+        },
+        "chat": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 958.4,
+          "prompt": "What is 2+2?",
+          "gpu": "off",
+          "failure_reasons": [],
+          "output_tail": "The answer to the mathematical expression 2 + 2 is 4.\n"
+        },
+        "greedy_reference": {
+          "status": "not_executed",
+          "reason": "reference_binary_not_provided"
+        }
+      },
+      "resolved_file": "models/granite-4.1-8b-Q4_0.gguf",
+      "actual_sha256": "5adf9b6b78921093bd4a805e1060f85d7f744c3eafc14d1ca449364d1e721a1a",
+      "file_status": "pass",
+      "complete": false
+    }
+  ],
+  "complete": false,
+  "summary": {
+    "models": 1,
+    "files": {
+      "pass": 1
+    },
+    "checks": {
+      "load": {
+        "pass": 1
+      },
+      "tokenizer": {
+        "pass": 1
+      },
+      "cpu_cuda": {
+        "pass": 1
+      },
+      "chat": {
+        "pass": 1
+      },
+      "greedy_reference": {
+        "not_executed": 1
+      }
+    }
+  }
+}

--- a/docs/compat-reports/cuda-smoke-0.4.8-2026-09-05-rtx3070.json
+++ b/docs/compat-reports/cuda-smoke-0.4.8-2026-09-05-rtx3070.json
@@ -1,0 +1,103 @@
+{
+  "checks": [
+    {
+      "check": "cuda_backend_present",
+      "detail": "caps.gpu.backend = 'cuda' (expected 'cuda'; absent means the CUDA driver never initialised)",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "version_matches",
+      "detail": "caps.version = '0.4.8', expected '0.4.8'",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_memory_is_boolean",
+      "detail": "caps.gpu.unified_memory = False",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_memory_agrees_with_pool_sizes",
+      "detail": "unified_memory=False with vram_bytes=8589279232 and ram_bytes=17109143552 (vram/ram = 0.502, one pool expected >= 0.85)",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_flag_not_suspiciously_false",
+      "detail": "unified_memory=False with vram/ram = 0.502",
+      "ok": true,
+      "severity": "warn"
+    },
+    {
+      "check": "vram_reported",
+      "detail": "vram_bytes = 8589279232",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "gpu_quants_present",
+      "detail": "gpu_quants has 16 entries",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "gpu_quants_subset_of_quants",
+      "detail": "every gpu_quant is loadable",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "generation_exit_zero",
+      "detail": "runner exited 0",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "gpu_engaged_for_generation",
+      "detail": "load output carries the CUDA backend line",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "tokens_generated",
+      "detail": "generated 24 tokens",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "layers_offloaded",
+      "detail": "gpu-split G=28/28",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_notice_matches_caps",
+      "detail": "load output omits the unified-memory notice while caps said False",
+      "ok": true,
+      "severity": "fail"
+    }
+  ],
+  "generation_output": "gpu-split: budget=7.46GB fixed=0.72GB G=28/28 full=1 used=1.66GB\r\ngpu: CUDA backend on NVIDIA GeForce RTX 3070 (0.6 GB weights in VRAM)\r\ngpu: VRAM 6.32 GB free of 8.59 GB after init (kv 0.47 GB + scratch 0.02 GB this instance)\r\nloaded C:/Users/zen/qwen3-0.6b-q8_0.gguf | qwen3 | 28 layers | ctx 4096 | 4 threads | 1.19s\r\nsampling: qwen3 (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\r\nThe capital of France is Paris. The capital of France is also the capital of the Republic of France. The capital of France is also the capital\r\nprompt: 5 tok, 188.00 tok/s | gen: 24 tok, 262.01 tok/s\r\n\r\n",
+  "gpu": {
+    "backend": "cuda",
+    "eseries": true,
+    "kv_q8": true,
+    "min_compute_capability": "7.5",
+    "min_gpu": "NVIDIA Turing / compute capability 7.5 or newer",
+    "moe": true,
+    "name": "NVIDIA GeForce RTX 3070",
+    "ptx_target": "sm_75",
+    "unified_memory": false,
+    "vram_bytes": 8589279232,
+    "vram_free_bytes": 7459569664
+  },
+  "host": {
+    "arch": "x86_64",
+    "os": "windows",
+    "ram_bytes": 17109143552
+  },
+  "passed": true,
+  "runner_version": "0.4.8"
+}

--- a/docs/moe-support.md
+++ b/docs/moe-support.md
@@ -1,7 +1,7 @@
 # Sparse-MoE support — implementation and test report
 
 Date: 2026-07-24
-Runner: v0.4.7 (core support plus the follow-ups at the end of this doc)
+Runner: v0.4.8 (core support plus the follow-ups at the end of this doc)
 Hardware: NVIDIA RTX PRO 6000 Blackwell, **24 GB MIG slice** (`MIG 1g.24gb`),
 CPU fallback on the same host (64 threads).
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xyntetik-runner-client"
-version = "0.4.7"
+version = "0.4.8"
 description = "Python client and process boundary for Xyntetik Runner"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/runner.h
+++ b/src/runner.h
@@ -2,7 +2,7 @@
 #ifndef RUNNER_H
 #define RUNNER_H
 
-#define RUNNER_VERSION "0.4.7"
+#define RUNNER_VERSION "0.4.8"
 #define RUNNER_CUDA_NVCC_ARCH "compute_75"
 #define RUNNER_CUDA_PTX_TARGET "sm_75"
 #define RUNNER_CUDA_MIN_CC "7.5"


### PR DESCRIPTION
Release candidate for v0.4.8. **This PR stops before the tag**: no tag, no
GitHub Release, no GHCR push. The reviewer owns both.

## The release

**v0.4.8 - 2026-09-05, the E-series and contraction release.** Gemma 4's
current shared-KV exports load, the CPU prefill dot gives one answer whatever
the batch shape, and the serving surface gains `cached_tokens`,
`GET /metrics` and a fourth draft source that needs no weights.

Every existing `Unreleased` entry is kept verbatim and nothing unmeasured was
added. The section keeps this file's own heading convention,
`## v0.4.8 - 2026-09-05`, rather than a new spelling.

## Version pins (six)

`src/runner.h`, `python/pyproject.toml`, `SECURITY.md`,
`docs/moe-support.md`, and the README's three current mentions (the
`--version` example, the pre-1.0 banner, the container tag). Nothing embedded
derives from the version: `scripts/check-generated.py` is clean and
`scripts/embed-metal.py` reproduces `src/kernels_metal.h` byte for byte.

One deviation from the brief, forced by a gate. The historical sentence about
the sublayer-removal artifact was to be left alone, but it read "loads only
in this runner from v0.4.7 on", and `check-release.py` treats a `v`-prefixed
triple as a current release string, so at 0.4.8 it became a hard
stale-string failure. It now says "from the 0.4.7 release on": the same fact,
in the bare-triple spelling the gate deliberately does not read as a version
pin.

## Release-flag rule

Checked, nothing new depends on it. The only flag the code's behaviour rests
on is `GPU_BACKEND_DEF`, already applied with `override` so a tagged build's
command-line `CFLAGS` cannot suppress it; `QUANTS_CFLAGS` derives
`-fno-fast-math` from whatever `CFLAGS` is rather than appending to it. Both
are pinned by `test-makefile-sane`, which builds with `CFLAGS=-O0` on the
command line and fails if either identity is lost. This release's
blocking-independence work is an explicit `fmaf` in the source, correct by
construction rather than by a flag.

## Gates

**Windows CUDA smoke, RTX 3070, display-attached: PASS**, 13 checks, 0
warnings. The tree was archived at the pins commit, rebuilt on the box with
the msys toolchain (`make OS=Windows_NT -j4 runner`, rc 0), and the binary
answered the gate's own version assertion with 0.4.8. `unified_memory` False
against vram 8,589,279,232 and ram 17,109,143,552 (ratio 0.502), 28 of 28
layers offloaded, 24 tokens generated. Report:
`docs/compat-reports/cuda-smoke-0.4.8-2026-09-05-rtx3070.json`. No process
left on the box.

**Blackwell compat matrix**, three model sets, the same invocations and the
same `--gpu off` as the 0.4.7 reports. 10 checks executed, 0 failures against
0.4.7's roster:

| model | executed | not executed, with reason |
|---|---|---|
| `granite-4.1-8b-q4_0` | load, tokenizer, cpu_cuda, chat: pass | greedy_reference: `reference_binary_not_provided` |
| `gemma-4-e4b-it-q4_k_m` | load, cpu_cuda, chat: pass (report complete) | none |
| `qwen3-30b-a3b-q4_k_m` | load, chat: pass; tool: fail 6 of 8 | cpu_cuda: `insufficient_vram` (19.3 GB requested, 9.6 GB free); greedy_reference: `reference_binary_not_provided`; long_context: `check_class_not_executable` |

The `tool` row is unchanged from 0.4.7, request for request (8 requests, 2
passed, 6 failed), so it is a standing row rather than a regression in this
release. Another study holds the MIG slice; the rows that could not execute
say so with their reason and are counted as neither passes nor failures.
Reports: `docs/compat-reports/0.4.8-2026-09-05-blackwell.json`,
`-blackwell-moe.json`, `-blackwell-gemma4.json`.

**Local, macOS M1 (Metal)**

- `make test`: exit 0. Main pytest leg 502 passed / 15 skipped; `test-moe` 26
  passed / 2 skipped; `test-prune-experts` 20 passed; every C and Metal leg
  green.
- `scripts/conformance.sh`: 433 passed, 17 skipped.
- `scripts/help-parity.py`: ok, 75 options in parity.
- `make release-check`: exit 0 (it prints nothing on success). It refuses a
  report in which nothing ran; the three committed reports carry 10 executed
  checks between them.

## Not executed, and why

- `greedy_reference` everywhere: no reference binary was provided to the
  matrix run, as at 0.4.7.
- `cpu_cuda` on the 30B MoE and `long_context`: the shared GPU slice had
  9.6 GB free against 19.3 GB requested. Not faked, not retried, not counted.
- No macOS compat matrix this cycle: the pinned model set lives on the
  measurement box, and the M1 has none of the pinned files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
