### PR TITLE
Fix six defects from the second outside review: NoPE LoRA gradients, schema sibling constraints, Anthropic thinking/mcp validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ names that were true when they were written.
 
 ## Unreleased
 
+- Six defects from a second outside review (2026-09-05), each with a gate:
+  - LoRA training on NoPE layers: the backward's recompute applied rope and
+    the adjoint reversed it on every layer, while the serving forward skips
+    the rotation and scales Q by the attention temperature on NoPE layers.
+    Both now follow `model_layer_ropes`; a NoPE fixture with the temperature
+    live joins the finite-difference gate (worst relative error 1.7 before,
+    at the float floor after).
+  - The schema compiler no longer weakens what it is given: boolean `false`
+    is refused instead of compiling to "anything"; an enum value outside the
+    declared type is dropped and a const beside an enum must be a member; a
+    `type` beside oneOf/anyOf is refused rather than ignored; and
+    `["integer","null"]` stays integer instead of widening to number
+    (`tests/test_json_schema.c`).
+  - Anthropic Messages: `thinking.type:"enabled"` without `budget_tokens` is
+    400 as the API requires, and any `mcp_servers` value other than absent,
+    null or an empty list is refused, not only a non-empty array
+    (`tests/conformance/test_request_validation.py`).
 - The tray icon is the Xyntetik ensö in three states: the bare ensö when
   nothing is loaded, the ensö with the spark on its end when a model is
   resident, and the full Runner mark (ensö, spark, three streaks) while

--- a/Makefile
+++ b/Makefile
@@ -610,7 +610,7 @@ $(TEST_TC_TOL): $(TEST_TC_TOL_SRC) $(HDR)
 TEST_LORA_GRAD_SRC = tests/test_lora_grad.c src/gguf.c src/compat.c \
                   $(QUANTS_OBJ) src/tokenizer.c src/model.c src/vramreg.c \
                   $(GPU_SRC)
-$(TEST_LORA_GRAD): $(TEST_LORA_GRAD_SRC) $(HDR) test.gguf test-lora.full.gguf test-q8.gguf test-lora-q8.full.gguf test-qk.gguf test-lora-qk.full.gguf
+$(TEST_LORA_GRAD): $(TEST_LORA_GRAD_SRC) $(HDR) test.gguf test-lora.full.gguf test-q8.gguf test-lora-q8.full.gguf test-qk.gguf test-lora-qk.full.gguf test-nope.gguf test-lora-nope.full.gguf
 	$(CC) $(CFLAGS) -I src $(TEST_LORA_GRAD_SRC) -o $@ $(LDFLAGS)
 
 test-lora.full.gguf: test.gguf scripts/make-test-lora.py
@@ -628,6 +628,14 @@ $(TEST_MVT): $(TEST_MVT_SRC) $(HDR) test.gguf test-q8.gguf test-bf16.gguf
 
 test-qk.gguf: scripts/make-test-model.py
 	$(PYTHON) scripts/make-test-model.py --qk-norm test-qk.gguf
+
+# NoPE every layer with a live attention temperature (floor 1): the LoRA
+# backward must skip the rotation and apply the temperature's adjoint
+test-nope.gguf: scripts/make-test-model.py
+	$(PYTHON) scripts/make-test-model.py test-nope.gguf --attn-knobs 1,0.5,1
+
+test-lora-nope.full.gguf: test-nope.gguf scripts/make-test-lora.py
+	$(PYTHON) scripts/make-test-lora.py test-nope.gguf test-lora-nope
 
 test-qkw.gguf: scripts/make-test-model.py
 	$(PYTHON) scripts/make-test-model.py --qk-norm --wide test-qkw.gguf
@@ -1679,6 +1687,9 @@ test: test-python-deps $(TEST_JSON_SCHEMA) $(TEST_SVAL_WALK) $(TEST_JSON_OOM) $(
 	@# W^T dy through frozen Q8_0 rows) is the one genuinely new kernel
 	@# family here, so it gets its own gradient gate
 	./$(TEST_LORA_GRAD) test-q8.gguf test-lora-q8.full.gguf
+	@# and on NoPE layers with the attention temperature live: the recompute
+	@# and the backward must match the serving forward (no rope, Q scaled)
+	./$(TEST_LORA_GRAD) test-nope.gguf test-lora-nope.full.gguf
 	@# and with qwen3-style per-head QK norms in the layer: the norm adjoint
 	@# sits between the rope adjoint and the projection backward
 	./$(TEST_LORA_GRAD) test-qk.gguf test-lora-qk.full.gguf

--- a/src/api_anthropic.c
+++ b/src/api_anthropic.c
@@ -579,7 +579,10 @@ static jv *anth_tool_choice(jv *tc, char *err, int errcap, bool *oom) {
 // invariant: a client told 200 believes the thing it asked for happened.
 static bool anth_reject_unsupported(slot_t *s, sock_t fd, jv *req) {
     jv *v = jv_get(req, "mcp_servers");
-    if (v && v->type == J_ARR && v->n > 0) {
+    // anything but absent, null or an empty list is a request for MCP
+    // servers; a malformed value (an object, a string) used to slip past a
+    // check that only looked at non-empty arrays and was answered 200
+    if (v && v->type != J_NULL && !(v->type == J_ARR && v->n == 0)) {
         send_error(fd, 400,
                    "mcp_servers is not supported: this runtime cannot reach "
                    "remote MCP servers on your behalf. Run the tools locally "
@@ -614,6 +617,18 @@ static bool anth_reject_unsupported(slot_t *s, sock_t fd, jv *req) {
             send_error(fd, 400,
                        "thinking.type must be \"enabled\", \"disabled\" or "
                        "\"adaptive\"");
+            return true;
+        }
+        // the API defines budget_tokens as required with type "enabled"; the
+        // comment below said so while the code checked it only when present,
+        // so {"type":"enabled"} alone was answered 200. Shape first, then
+        // the per-model answer.
+        jv *budget_present = jv_get(v, "budget_tokens");
+        if (!strcmp(type, "enabled") &&
+            (!budget_present || budget_present->type == J_NULL)) {
+            send_error(fd, 400,
+                       "thinking.budget_tokens is required when thinking.type "
+                       "is \"enabled\"");
             return true;
         }
         if (!strcmp(type, "enabled") && !s->m->think_open) {

--- a/src/model.c
+++ b/src/model.c
@@ -6381,7 +6381,17 @@ static bool lora_layer_bw(model_t *m, int l, const int32_t *toks, int T,
                    sizeof(float) * (size_t)q_dim);
             qk_norm(qt, ly->qnorm_w, n_head, hd_l, m->rms_eps);
         }
-        rope_apply(m, qt, n_head, t, l);
+        if (model_layer_ropes(m, l)) {
+            rope_apply(m, qt, n_head, t, l);
+        } else {
+            // NoPE layer: the serving forward skips the rotation and scales
+            // Q by the attention temperature instead; recomputing with rope
+            // here handed the adjoint a Q the model never used (NoPE
+            // fixture: FD worst relative error 1.7 before this branch)
+            float ts = model_attn_temp(m, t);
+            if (ts != 1.0f)
+                for (int i = 0; i < q_dim; i++) qt[i] *= ts;
+        }
         if (ly->knorm_w) {
             float *kt = kpre + (size_t)t * kv_dim;
             matvec_b(m->tp, kt, kv_dim, ly->wk, x1, E, E, kv_dim, ly->bk, 1);
@@ -6464,8 +6474,18 @@ static bool lora_layer_bw(model_t *m, int l, const int32_t *toks, int T,
     if (lprof) { double n2 = plat_now(); lbw_prof[2] += n2 - lt; lt = n2; }
     // ---- phase B2: projection backwards now that dK/dV are complete
     for (int t = 0; ok && t < T; t++) {
-        rope_unapply(m, dq + (size_t)t * q_dim, n_head, t, l);
-        rope_unapply(m, dk + (size_t)t * kv_dim, n_kv, t, l);
+        if (model_layer_ropes(m, l)) {
+            rope_unapply(m, dq + (size_t)t * q_dim, n_head, t, l);
+            rope_unapply(m, dk + (size_t)t * kv_dim, n_kv, t, l);
+        } else {
+            // a NoPE layer's only Q transform is the scalar temperature, whose
+            // adjoint is the same scalar; K is stored as projected (no rope)
+            float ts = model_attn_temp(m, t);
+            if (ts != 1.0f) {
+                float *dqt = dq + (size_t)t * q_dim;
+                for (int i = 0; i < q_dim; i++) dqt[i] *= ts;
+            }
+        }
         // per-head QK-norm adjoints (qwen3-style): the cached/roped values
         // are POST-norm, so the projection backward needs the pre-norm
         // gradient computed against the recomputed pre-norm activations

--- a/src/schema.c
+++ b/src/schema.c
@@ -959,8 +959,44 @@ static snode *compile_oneof(jv *alts, char *err, int errcap, int depth) {
     return n;
 }
 
+// does scalar literal `v` satisfy the `type` keyword (a string or a list)?
+static bool literal_has_type_name(const jv *v, const char *t) {
+    if (!strcmp(t, "string"))  return v->type == J_STR;
+    if (!strcmp(t, "boolean")) return v->type == J_BOOL;
+    if (!strcmp(t, "null"))    return v->type == J_NULL;
+    if (!strcmp(t, "number"))  return v->type == J_NUM;
+    if (!strcmp(t, "integer")) return v->type == J_NUM && v->num == floor(v->num);
+    return false; // object / array literals are refused as non-scalars anyway
+}
+static bool literal_has_type(const jv *v, jv *ty) {
+    if (ty->type == J_STR) return literal_has_type_name(v, ty->str);
+    if (ty->type == J_ARR) {
+        for (int i = 0; i < ty->n; i++)
+            if (literal_has_type_name(v, jv_str(ty->items[i], "?"))) return true;
+        return false;
+    }
+    return true; // a malformed type keyword is reported by compile_typed
+}
+static bool literal_equal(const jv *a, const jv *b) {
+    if (a->type != b->type) return false;
+    switch (a->type) {
+        case J_NUM:  return a->num == b->num;
+        case J_STR:  return !strcmp(a->str, b->str);
+        case J_BOOL: return a->b == b->b;
+        case J_NULL: return true;
+        default:     return false;
+    }
+}
+
 static snode *compile_node(jv *s, char *err, int errcap, int depth) {
     if (depth > 24) { snprintf(err, errcap, "schema too deep"); return NULL; }
+    if (s && s->type == J_BOOL && !s->b) {
+        // `false` admits no value at all. It used to compile to ANY, the
+        // exact opposite, so {"properties":{"x":false},"required":["x"]}
+        // accepted {"x":42}. Refused rather than weakened.
+        snprintf(err, errcap, "boolean schema false admits no value");
+        return NULL;
+    }
     if (!s || s->type == J_NULL || (s->type == J_OBJ && s->n == 0) ||
         s->type == J_BOOL) // `true` / `{}` = anything
         return sn_new(SN_ANY);
@@ -969,6 +1005,13 @@ static snode *compile_node(jv *s, char *err, int errcap, int depth) {
 
     jv *one = jv_get(s, "oneOf");
     jv *any = jv_get(s, "anyOf");
+    if ((one || any) && jv_get(s, "type")) {
+        // a sibling `type` must hold for every alternative; it was dropped,
+        // so {"type":"string","anyOf":[...,{"type":"integer"}]} accepted 1
+        snprintf(err, errcap, "'type' beside oneOf/anyOf is not supported: "
+                 "declare the type on each alternative");
+        return NULL;
+    }
     if (one || any) return compile_oneof(one ? one : any, err, errcap, depth);
 
     // enum / const dominate the type
@@ -982,25 +1025,45 @@ static snode *compile_node(jv *s, char *err, int errcap, int depth) {
             snprintf(err, errcap, "enum must be an array");
             return NULL;
         }
-        snode *n = sn_new(SN_ENUM);
-        if (!n) return NULL;
         int cnt = en ? en->n : 1;
         if (cnt <= 0 || cnt > 60) {
             snprintf(err, errcap, "enum size must be 1..60");
-            schema_free(n);
             return NULL;
         }
-        n->lits = calloc(cnt, sizeof(char *));
-        if (!n->lits) { schema_free(n); return NULL; }
         for (int i = 0; i < cnt; i++) {
             jv *v = en ? en->items[i] : cn;
             if (v->type != J_STR && v->type != J_NUM &&
                 v->type != J_BOOL && v->type != J_NULL) {
                 snprintf(err, errcap, "enum values must be scalars");
-                schema_free(n);
                 return NULL;
             }
-            char *lit = sn_literal(v);
+        }
+        // Siblings intersect, they do not lose: an enum value outside the
+        // declared type is dropped (it could never validate), and a const
+        // beside an enum must be one of its members. Before this,
+        // {"type":"integer","enum":["bad",1]} accepted "bad" and
+        // {"const":1,"enum":[2]} accepted 2.
+        jv *ty = jv_get(s, "type");
+        jv *keep[60];
+        int n_keep = 0;
+        for (int i = 0; i < cnt; i++) {
+            jv *v = en ? en->items[i] : cn;
+            if (ty && !literal_has_type(v, ty)) continue;
+            if (en && cn && !literal_equal(v, cn)) continue;
+            keep[n_keep++] = v;
+        }
+        if (n_keep == 0) {
+            snprintf(err, errcap, en && cn
+                     ? "const is not one of the enum values"
+                     : "no enum value matches the declared type");
+            return NULL;
+        }
+        snode *n = sn_new(SN_ENUM);
+        if (!n) return NULL;
+        n->lits = calloc(n_keep, sizeof(char *));
+        if (!n->lits) { schema_free(n); return NULL; }
+        for (int i = 0; i < n_keep; i++) {
+            char *lit = sn_literal(keep[i]);
             if (!lit) { schema_free(n); return NULL; }
             n->lits[i] = lit;
             n->n_lits++;
@@ -1028,13 +1091,20 @@ static snode *compile_node(jv *s, char *err, int errcap, int depth) {
         if (!n) return NULL;
         n->alts = calloc(ty->n, sizeof(snode *));
         if (!n->alts) { schema_free(n); return NULL; }
+        // number|integer merge into one numeric alternative; it is "number"
+        // only when "number" is actually listed. ["integer","null"] used to
+        // widen to number because the list had more than one member, so
+        // 1.5 validated as an integer.
+        bool any_number = false;
+        for (int i = 0; i < ty->n; i++)
+            if (!strcmp(jv_str(ty->items[i], "?"), "number")) any_number = true;
         bool has_num = false;
         for (int i = 0; i < ty->n; i++) {
             const char *t = jv_str(ty->items[i], "?");
             if ((!strcmp(t, "number") || !strcmp(t, "integer"))) {
                 if (has_num) continue; // merge number|integer
                 has_num = true;
-                t = strcmp(t, "integer") == 0 && ty->n == 1 ? "integer" : "number";
+                t = any_number ? "number" : "integer";
             }
             snode *alt = compile_typed(s, t, err, errcap, depth + 1);
             if (!alt) { schema_free(n); return NULL; }

--- a/tests/conformance/test_request_validation.py
+++ b/tests/conformance/test_request_validation.py
@@ -489,6 +489,29 @@ def test_thinking_budget_tokens_is_validated(client, budget):
         path="/v1/messages")
 
 
+def test_thinking_enabled_requires_budget_tokens(client):
+    """The API defines budget_tokens as required with type "enabled". The
+    code said so in a comment while checking it only when present, so
+    {"type":"enabled"} alone was answered 200 (outside review, 2026-09-05)."""
+    client.expect_400(
+        {"max_tokens": 4, "messages": [{"role": "user", "content": "hi"}],
+         "thinking": {"type": "enabled"}},
+        name="thinking-enabled-no-budget", contains="budget_tokens",
+        path="/v1/messages")
+
+
+@pytest.mark.parametrize("value", [{"type": "url", "url": "https://x"}, "x", 1])
+def test_malformed_mcp_servers_is_refused_too(client, value):
+    """The MCP refusal looked only at non-empty arrays; an object-shaped or
+    scalar mcp_servers was silently ignored and answered 200 although the
+    runtime cannot reach an MCP server in any shape."""
+    client.expect_400(
+        {"max_tokens": 4, "messages": [{"role": "user", "content": "hi"}],
+         "mcp_servers": value},
+        name=f"mcp-servers-malformed-{type(value).__name__}", contains="mcp",
+        path="/v1/messages")
+
+
 # ------------------------------------------------------- sampling parameters
 #
 # RI-5: a caller sending several sampling settings at once cannot act on

--- a/tests/test_json_schema.c
+++ b/tests/test_json_schema.c
@@ -2718,7 +2718,63 @@ static void test_tojson_dump_matches_jinja(void) {
     puts("ok: jv_dump_tojson reproduces jinja's tojson; jv_dump stays compact");
 }
 
+// Sibling constraints intersect; they are never dropped (outside review,
+// 2026-09-05: four ways a schema was silently weakened at compile time).
+static snode *compile_src(const char *schema_src) {
+    jv *j = json_parse(schema_src, strlen(schema_src));
+    assert(j != NULL);
+    char err[256] = "";
+    snode *n = schema_compile(j, err, sizeof(err));
+    jv_free(j);
+    return n;
+}
+static bool compiles(const char *schema_src) {
+    snode *n = compile_src(schema_src);
+    if (n) schema_free(n);
+    return n != NULL;
+}
+static bool accepts(const char *schema_src, const char *doc) {
+    snode *n = compile_src(schema_src);
+    assert(n && "schema must compile for an acceptance check");
+    sval v; sval_init(&v, n);
+    bool ok = sval_feed(&v, doc, (int)strlen(doc)) && v.done;
+    schema_free(n);
+    return ok;
+}
+static void test_schema_sibling_constraints_are_not_dropped(void) {
+    // boolean false admits nothing: refused, never compiled to ANY
+    assert(!compiles("false"));
+    assert(!compiles("{\"type\":\"object\",\"properties\":{\"x\":false},"
+                     "\"required\":[\"x\"]}"));
+    assert(compiles("true"));
+    // enum intersects type: the off-type value is dropped, not admitted
+    // (numeric cases sit inside an object so the closing brace completes them)
+    #define WRAP(inner) "{\"type\":\"object\",\"properties\":{\"v\":" inner "},\"required\":[\"v\"]}"
+    const char *ie = WRAP("{\"type\":\"integer\",\"enum\":[\"bad\",1]}");
+    assert(accepts(ie, "{\"v\":1}"));
+    assert(!accepts(ie, "{\"v\":\"bad\"}"));
+    assert(!compiles("{\"type\":\"integer\",\"enum\":[\"bad\"]}"));
+    // const beside enum: must be a member, and then it is the only value
+    assert(!compiles("{\"const\":1,\"enum\":[2]}"));
+    const char *ce = WRAP("{\"const\":2,\"enum\":[1,2]}");
+    assert(accepts(ce, "{\"v\":2}"));
+    assert(!accepts(ce, "{\"v\":1}"));
+    // type beside oneOf/anyOf is refused rather than ignored
+    assert(!compiles("{\"type\":\"string\",\"anyOf\":[{\"type\":\"string\"},"
+                     "{\"type\":\"integer\"}]}"));
+    assert(compiles("{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]}"));
+    // integer|null stays integer
+    const char *in = WRAP("{\"type\":[\"integer\",\"null\"]}");
+    assert(accepts(in, "{\"v\":1}"));
+    assert(accepts(in, "{\"v\":null}"));
+    assert(!accepts(in, "{\"v\":1.5}"));
+    // number|integer|null is still a number
+    assert(accepts(WRAP("{\"type\":[\"number\",\"integer\",\"null\"]}"), "{\"v\":1.5}"));
+    #undef WRAP
+}
+
 int main(void) {
+    test_schema_sibling_constraints_are_not_dropped();
     test_strict_bounded_numbers();
     test_json_rejects_unpaired_utf16_surrogates();
     test_json_rejects_ill_formed_raw_utf8();


### PR DESCRIPTION
Confirmed by reading and reproduced before fixing:

1. **NoPE LoRA gradients (P1)** `model.c`: recompute and backward now follow `model_layer_ropes`, with the attention-temperature adjoint on NoPE layers. New NoPE fixture in the FD gate: worst rel err 1.728 → 0.
2. **Schema `false` → ANY (P1)** `schema.c`: refused at compile time.
3. **enum/const/composition drop siblings (P1)**: enum ∩ type, const ∈ enum, and `type` beside oneOf/anyOf refused rather than ignored.
4. **`["integer","null"]` accepts 1.5 (P1)**: merged numeric alternative is number only when number is listed.
5. **thinking:enabled without budget_tokens (P2)** `api_anthropic.c`: 400.
6. **Malformed mcp_servers (P2)**: any non-null, non-empty-list value is refused.

Gates: `tests/test_json_schema.c`, NoPE row in `make test`'s lora-grad run, two conformance tests. Locally: template, sval-walk, tools, schema-oom, all four lora-grad fixtures, and the full conformance suite (437 passed).