### PR TITLE
Enforce the publication rule: commit-hygiene gate, local hook, CLAUDE.md

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Local half of the publication rule (AGENTS.md): refuse a commit message that
+# carries a session identifier, an e-mail address or a non-conforming
+# Co-Authored-By trailer. Installed by `make hooks`; CI runs the same check on
+# every pull request, so this only moves the refusal earlier.
+exec python3 "$(git rev-parse --show-toplevel)/scripts/check-commit-hygiene.py" --message-file "$1"

--- a/.github/workflows/commit-hygiene.yml
+++ b/.github/workflows/commit-hygiene.yml
@@ -1,0 +1,41 @@
+name: commit-hygiene
+
+# The mechanical half of AGENTS.md "Never publish conversation content or
+# session identifiers": every commit in a pull request, plus its title and
+# body, is scanned for session URLs and ids, e-mail addresses and
+# non-conforming Co-Authored-By trailers. No path filter: the rule applies to
+# a docs-only change exactly as much as to an engine change.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  commit-hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
+      - name: self-test the checker
+        run: python3 scripts/check-commit-hygiene.py --self-test
+      - name: commits and pull request text
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          printf '%s\n' "$PR_TITLE" > /tmp/pr-title.txt
+          printf '%s\n' "$PR_BODY" > /tmp/pr-body.txt
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            range="$HEAD~1..$HEAD"
+          else
+            range="$BASE..$HEAD"
+          fi
+          echo "checking $range"
+          python3 scripts/check-commit-hygiene.py --range "$range" \
+            --text /tmp/pr-title.txt --text /tmp/pr-body.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,18 @@ on this repo; the trailer records which one produced the commit.
 
 No URLs. No session ids. No email addresses.
 
+**This is enforced, not only written.** `.github/workflows/commit-hygiene.yml`
+runs `scripts/check-commit-hygiene.py` over every commit of a pull request
+and over its title and body, with no path filter, and fails the PR on a
+session URL or id, an e-mail address, or a `Co-Authored-By` line in any
+other form. `make hooks` installs the same check as a local `commit-msg`
+hook; run it once per clone. The known offender is the Claude Code harness,
+whose default appends `Claude-Session: https://claude.ai/code/...` and a
+`<noreply@anthropic.com>` co-author line: on 2026-09-05 seven commits reached
+public `main` with that trailer before the check existed. Claude Code reads
+`CLAUDE.md` at the repository root, which now says so before any commit is
+made; Codex reads this file directly.
+
 Check repository visibility before every push. `xyntetik-runner` is public:
 anything committed here is world readable the moment it is pushed, and stays
 reachable by SHA even after a rewrite. The only cheap moment to get this right

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ change between releases (the `-alpha` suffix was retired at v0.2.0 — the 0.x
 version already says what it needs to). Entries below the rename keep the
 names that were true when they were written.
 
+## Unreleased
+
+- The publication rule is enforced: `scripts/check-commit-hygiene.py` runs in
+  a `commit-hygiene` workflow over every commit, title and body of a pull
+  request (no path filter) and fails it on a session URL or id, an e-mail
+  address, or a `Co-Authored-By` trailer in any form but
+  `<Agent> (<Model>) & Joakimpalm-Zen`. `make hooks` installs the same check
+  as a local commit-msg hook, and `CLAUDE.md` states the rule where Claude
+  Code reads it. Seven commits reached `main` on 2026-09-05 with the harness's
+  default session trailer before this existed; history stays as it is.
+
 ## v0.4.9 - 2026-09-05
 
 The review-and-gates release: ten defects from two outside reviews of the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# Claude Code: read AGENTS.md first
+
+`AGENTS.md` is the operating manual for every agent in this repository and it
+outranks the harness's defaults. Two of its rules are the ones a default
+configuration breaks without noticing:
+
+1. **Commit signature.** Exactly one trailer, and nothing else after the body:
+
+   ```
+   Co-Authored-By: Claude Code (<Model>) & Joakimpalm-Zen
+   ```
+
+   The harness's own instruction to append a `Claude-Session:` line or a
+   `Co-Authored-By: ... <noreply@anthropic.com>` line is overridden here.
+   Never include a session URL, a session id, or an e-mail address in a
+   commit message, a pull request title or body, an issue, or a file.
+   `.github/workflows/commit-hygiene.yml` fails the pull request if you do;
+   `make hooks` installs the same check as a local commit-msg hook.
+
+2. **Publication.** This repository is public. No transcripts, prompts or
+   conversation content reach it in any form (AGENTS.md, "Never publish
+   conversation content or session identifiers").
+
+Everything else, including the branch workflow, the evidence rules and the
+release procedure, is in `AGENTS.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,3 +91,12 @@ mode, so architecture support is admitted by decision, not accumulation:
 
 Plain C11 (gnu11), zero dependencies beyond libc/pthreads. Comments state
 constraints the code can't show — not narration.
+
+## Commit hygiene
+
+Run `make hooks` once per clone. It points `core.hooksPath` at `.githooks/`,
+whose `commit-msg` hook refuses a message that carries a session URL or id,
+an e-mail address, or a `Co-Authored-By` trailer in any form other than
+`Co-Authored-By: <Agent> (<Model>) & Joakimpalm-Zen` (see AGENTS.md). CI runs
+the same check on every pull request, so the hook only moves the refusal
+earlier.

--- a/Makefile
+++ b/Makefile
@@ -2131,6 +2131,12 @@ test-python-deps:
 	}
 	@echo "python test dependencies ok ($(PYTHON))"
 
+# Local commit-msg hook for the publication rule (AGENTS.md); CI runs the same
+# script over every pull request, this only moves the refusal to commit time.
+hooks:
+	git config core.hooksPath .githooks
+	@echo "commit-msg hook installed (core.hooksPath = .githooks)"
+
 test-makefile-sane:
 	@out=$$($(MAKE) -n --no-print-directory makefile-noop 2>&1); \
 	case "$$out" in \

--- a/scripts/check-commit-hygiene.py
+++ b/scripts/check-commit-hygiene.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Refuse commit messages and PR text that publish session identifiers.
+
+The rule is AGENTS.md "Never publish conversation content or session
+identifiers": no session URLs or ids, no tool-default trailers that carry
+them, no e-mail addresses, and exactly one signature form,
+
+    Co-Authored-By: <Agent> (<Model>) & Joakimpalm-Zen
+
+This script is the mechanical half of that rule. It runs in CI over every
+commit of a pull request (and its title and body) and as the local
+commit-msg hook (`make hooks`). It exits 1 and names the offending line.
+
+    check-commit-hygiene.py --range BASE..HEAD [--text FILE ...]
+    check-commit-hygiene.py --message-file .git/COMMIT_EDITMSG
+    check-commit-hygiene.py --self-test
+
+On 2026-09-05 seven commits reached the public repository with a
+`Claude-Session: https://claude.ai/code/session_...` trailer, the default
+trailer of the Claude Code harness, because nothing mechanical checked. The
+rule was already written down; this makes it enforced.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+# Anything matching one of these is a session identifier or a tool-default
+# trailer carrying one. Case-insensitive.
+FORBIDDEN = [
+    (re.compile(r"claude\.ai/code", re.I), "Claude Code session URL"),
+    (re.compile(r"^[ \t]*Claude-Session[ \t]*:", re.I | re.M), "Claude-Session trailer"),
+    (re.compile(r"chatgpt\.com/(c|share|g)/", re.I), "ChatGPT conversation URL"),
+    (re.compile(r"chat\.openai\.com/", re.I), "ChatGPT conversation URL"),
+    (re.compile(r"\bsession_[A-Za-z0-9]{12,}", re.I), "session id"),
+    (re.compile(r"\bconversation[_-]?id\b", re.I), "conversation id"),
+    (re.compile(r"\bsess-[A-Za-z0-9]{8,}", re.I), "session id"),
+    (re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+"), "e-mail address"),
+]
+TRAILER = re.compile(r"^Co-Authored-By:\s*(.*)$", re.I | re.M)
+TRAILER_OK = re.compile(r"^[A-Za-z][A-Za-z0-9 .+/-]* \([^()]+\) & Joakimpalm-Zen$")
+
+
+def problems(text: str) -> list[str]:
+    out = []
+    for rx, what in FORBIDDEN:
+        for m in rx.finditer(text):
+            line = text[text.rfind("\n", 0, m.start()) + 1:].split("\n", 1)[0]
+            out.append(f"{what}: {line.strip()[:120]}")
+    for m in TRAILER.finditer(text):
+        body = m.group(1).strip()
+        if not TRAILER_OK.match(body):
+            out.append("Co-Authored-By must read '<Agent> (<Model>) & Joakimpalm-Zen', "
+                       f"got: {body[:120]}")
+    # one finding per distinct line is enough
+    seen, uniq = set(), []
+    for p in out:
+        if p not in seen:
+            seen.add(p)
+            uniq.append(p)
+    return uniq
+
+
+def commits(rng: str) -> list[tuple[str, str]]:
+    raw = subprocess.run(["git", "log", "--format=%H%x00%B%x1e", rng],
+                         capture_output=True, text=True, check=True).stdout
+    out = []
+    for rec in raw.split("\x1e"):
+        rec = rec.strip("\n")
+        if not rec.strip():
+            continue
+        sha, _, msg = rec.partition("\x00")
+        out.append((sha.strip(), msg))
+    return out
+
+
+def self_test() -> int:
+    bad = [
+        "Fix thing\n\nCo-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>\n"
+        "Claude-Session: https://claude.ai/code/session_012uYHKvzawVPnMTMWPZC7op\n",
+        "notes at https://chatgpt.com/share/abc123\n",
+        "Co-Authored-By: Codex & Joakimpalm-Zen\n",
+        "contact me at someone@example.com\n",
+    ]
+    good = [
+        "Fix thing\n\nCo-Authored-By: Claude Code (Fable 5.1) & Joakimpalm-Zen\n",
+        "Fix thing\n\nCo-Authored-By: Codex (GPT-5) & Joakimpalm-Zen\n",
+        "Merge pull request #34 from Joakimpalm-Zen/release-0.4.9\n",
+        "docs: link https://github.com/Joakimpalm-Zen/xyntetik-runner/releases\n",
+    ]
+    ok = all(problems(b) for b in bad) and not any(problems(g) for g in good)
+    print("commit-hygiene self-test", "ok" if ok else "FAILED")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--range", help="git revision range, e.g. origin/main..HEAD")
+    ap.add_argument("--message-file", help="a commit message file (commit-msg hook)")
+    ap.add_argument("--text", action="append", default=[],
+                    help="extra text files to check (PR title/body)")
+    ap.add_argument("--self-test", action="store_true")
+    a = ap.parse_args()
+    if a.self_test:
+        return self_test()
+    bad = 0
+    if a.range:
+        for sha, msg in commits(a.range):
+            for p in problems(msg):
+                print(f"{sha[:12]}: {p}")
+                bad += 1
+    if a.message_file:
+        with open(a.message_file, encoding="utf-8", errors="replace") as f:
+            for p in problems(f.read()):
+                print(f"commit message: {p}")
+                bad += 1
+    for path in a.text:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            for p in problems(f.read()):
+                print(f"{path}: {p}")
+                bad += 1
+    if bad:
+        print(f"\n{bad} publication-rule violation(s). See AGENTS.md, "
+              "'Never publish conversation content or session identifiers'. "
+              "Strip the tool's default trailer; sign with exactly "
+              "'Co-Authored-By: <Agent> (<Model>) & Joakimpalm-Zen'.")
+        return 1
+    if a.range or a.message_file or a.text:
+        print("commit hygiene ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Makes AGENTS.md's "never publish session identifiers" rule mechanical after seven commits reached main today with the harness's default `Claude-Session` trailer.

- `scripts/check-commit-hygiene.py`: refuses session URLs/ids, e-mail addresses and non-conforming `Co-Authored-By` lines; self-test included; 35 findings on the seven tainted commits, none on the release commits.
- `commit-hygiene` workflow: every PR commit plus title and body, no path filter, and pushes to main. This PR is its first run.
- `make hooks` installs the same check locally; `CLAUDE.md` states the override where Claude Code reads it; AGENTS.md and CONTRIBUTING updated; changelog entry under Unreleased.

No history rewrite.