### PR TITLE
Fix schema and Messages constraint gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1438,13 +1438,14 @@ For example, the usual OpenAI request needs no Runner-specific switch:
 }
 ```
 
-Muse's native atem format carries scalar parameter values as raw text rather
-than JSON strings. Consequently a scalar value cannot contain the literal
+Muse's native atem format carries string parameter values as raw text rather
+than JSON strings. Consequently a string value cannot contain the literal
 `</atem:parameter>` sequence: atem itself uses that sentinel as the value
 boundary and its reference template describes the output as regex-parsed,
-not XML-escaped. Declared parameters retain their schema optionality: members
-listed in `required` are forced, while other members may be omitted in their
-declared order.
+not XML-escaped. Numbers, booleans, null, arrays and objects retain their JSON
+spelling and are compiled against their declared types and bounds. Declared
+parameters retain their schema optionality: members listed in `required` are
+forced, while other members may be omitted in their declared order.
 
 For Muse, the recipient header is part of the constrained turn: `to=user`
 selects a plain answer and a declared tool recipient pins the matching
@@ -1453,11 +1454,14 @@ calls separated by `<|eom|>` into ordered OpenAI `tool_calls`; the separator
 is not treated as a global stop token.
 
 Native atem calling is selected automatically when a loaded Muse Glimmer
-model receives `tools`. Set `atem_tool_calling:false` on a Chat Completions
-request to use Runner's generic JSON-schema tool envelope instead; its payload
-is still constrained behind Muse's `to=user` recipient header, so the override
-does not leak prompt syntax into `content`. `tool_choice` (`auto`, `required`,
-named, and `none`) still controls the allowed recipients.
+model receives `tools` and every parameter constraint is representable in that
+syntax. Raw strings support the unconstrained and string-enum/const forms; a
+length, pattern, or otherwise unrepresentable string schema switches that
+request to Runner's generic JSON-schema envelope. Set `atem_tool_calling:false`
+on a Chat Completions request to select the same generic path explicitly. Its
+payload remains constrained behind Muse's `to=user` recipient header, so the
+override does not leak prompt syntax into `content`. `tool_choice` (`auto`,
+`required`, named, and `none`) still controls the allowed recipients.
 `parallel_tool_calls:true` with a required/named native choice constrains a
 bounded two-call turn. With native `tool_choice:"auto"`, the same flag retains
 the auto turn and therefore permits at most one call. Families without a native
@@ -1522,12 +1526,13 @@ prepended one - and calls them as `<|tool_call>call:NAME{city:<|"|>Oslo<|"|>}
 are compared against the reference template case by case in
 `scripts/template-conformance.py`.
 
-The native syntax does not cost the strict envelope. The generated turn is
-still constrained: the tool name comes from an enumeration of the declared
-functions, each argument key and type from that function's schema, and
-`tool_choice` (`auto`, `required`, named, `none`) selects which branches
-exist at all - `required` removes the prose branch, which is what enforcement
-means here. A call cut off by the token limit is closed to the smallest legal
+When the schema is representable in the native syntax, the generated turn
+remains constrained: the tool name comes from an enumeration of the declared
+functions, each argument key, type, literal and numeric/array bound comes from
+that function's schema, and `tool_choice` (`auto`, `required`, named, `none`)
+selects which branches exist at all - `required` removes the prose branch,
+which is what enforcement means here. A call cut off by the token limit is
+closed to the smallest legal
 ending and still reports `finish_reason:"length"`. What the client receives is
 ordinary JSON: `arguments` is translated out of gemma4's `<|"|>` spelling on
 both the buffered and the streamed path, so no native framing reaches an
@@ -1535,12 +1540,11 @@ OpenAI client.
 
 Declared parameters retain their schema optionality: members listed in
 `required` are forced, while other members may be omitted without changing
-gemma4's dict-sorted native order. One limit is worth knowing before you write
-a schema for this family: a parameter with no declared `type` is rejected with
-a 400 that names it. Gemma4's native call syntax has no spelling for a
-free-form value, and refusing is better than an unconstrained call the mapper
-may not be able to read back. This differs from the generic JSON envelope,
-which can represent a free JSON value.
+gemma4's dict-sorted native order. Gemma4's delimiter-based raw strings cannot
+enforce length or pattern constraints, and its native call syntax has no
+spelling for a free-form value. A request containing either uses the generic
+JSON envelope instead, switching the prompt declaration and output grammar
+together so the schema remains enforced.
 
 ### Apertus tool rendering
 
@@ -1640,6 +1644,11 @@ supports string or block-list system/content values, `tool_use`/`tool_result`,
 all tool-choice forms compatible with one call per turn, stop sequences,
 sampling controls, metadata, thinking-channel blocks, and Anthropic SSE event
 ordering. `max_tokens` is required.
+
+`thinking.type:"enabled"` requires `budget_tokens`; that field is rejected for
+`adaptive` and `disabled`. `thinking.display` accepts `summarized` or `omitted`
+with enabled/adaptive thinking. The omitted form keeps an empty thinking block
+while withholding reasoning text in buffered and SSE responses.
 
 Runner refuses hosted tools, MCP/container execution, image/document blocks,
 parallel tool use, `stop_sequences` sent alongside `tools` (see Chat

--- a/src/api_anthropic.c
+++ b/src/api_anthropic.c
@@ -631,6 +631,28 @@ static bool anth_reject_unsupported(slot_t *s, sock_t fd, jv *req) {
                        "is \"enabled\"");
             return true;
         }
+        if (strcmp(type, "enabled") && budget_present &&
+            budget_present->type != J_NULL) {
+            send_error(fd, 400,
+                       "thinking.budget_tokens is only valid when thinking.type "
+                       "is \"enabled\"");
+            return true;
+        }
+        jv *display = jv_get(v, "display");
+        if (!strcmp(type, "disabled") && display && display->type != J_NULL) {
+            send_error(fd, 400,
+                       "thinking.display is not valid when thinking.type is "
+                       "\"disabled\"");
+            return true;
+        }
+        if (display && display->type != J_NULL &&
+            (display->type != J_STR ||
+             (strcmp(display->str, "summarized") &&
+              strcmp(display->str, "omitted")))) {
+            send_error(fd, 400,
+                       "thinking.display must be \"summarized\" or \"omitted\"");
+            return true;
+        }
         if (!strcmp(type, "enabled") && !s->m->think_open) {
             send_error(fd, 400,
                        "thinking:enabled is not supported by the resident "

--- a/src/completion.c
+++ b/src/completion.c
@@ -26,6 +26,7 @@ typedef struct {
     bool  dead;         // client went away
     char  id[48];
     int   api;          // API_* — the dialect this response is framed in
+    bool  omit_reasoning; // Anthropic thinking.display == "omitted"
     think_split ts;     // thinking-tag splitter (pass-through when untagged)
     // OpenAI "stop" sequences: matched against the content channel only
     // (reasoning text must not trigger a client's stop strings)
@@ -249,6 +250,7 @@ static void completion_cleanup(engine *e, snode *schema, gen_ctx *g) {
 static int responses_text_delta(gen_ctx *g, int reasoning, const char *bytes,
                                 int n);
 static int anth_delta(gen_ctx *g, const char *kind, const char *bytes, int n);
+static int anth_open_block(gen_ctx *g, const char *kind);
 
 // How many trailing bytes of `s` begin a UTF-8 sequence that is not finished
 // yet — i.e. how much must be held back until the next token arrives. 0 when
@@ -333,6 +335,8 @@ static int send_text_delta_raw(gen_ctx *g, int reasoning, const char *bytes, int
     if (g->api == API_RESPONSES) return responses_text_delta(g, reasoning, bytes, n);
     // Anthropic separates reasoning into a `thinking` content block rather
     // than a field on the message, so the channel selects the block kind
+    if (g->api == API_MESSAGES && reasoning && g->omit_reasoning)
+        return anth_open_block(g, "thinking");
     if (g->api == API_MESSAGES)
         return anth_delta(g, reasoning ? "thinking" : "text", bytes, n);
     sbuf c = {0};
@@ -368,7 +372,6 @@ static int resp_open_item(gen_ctx *g, const char *kind);
 static int resp_delta(gen_ctx *g, const char *kind, const char *bytes, int n);
 static int resp_close_item(gen_ctx *g);
 
-static int anth_open_block(gen_ctx *g, const char *kind);
 static int anth_close_block(gen_ctx *g);
 
 static int sink_call_begin(void *ud, const char *name) {
@@ -1126,7 +1129,7 @@ static void anth_body(sbuf *r, gen_ctx *g, const resp_doc *d) {
             // reasoning is a block of its own here rather than a field on the
             // message, and it always precedes the answer
             sb_lit(r, "{\"type\":\"thinking\",\"thinking\":\"");
-            sb_esc(r, d->reason, d->reason_n);
+            if (!g->omit_reasoning) sb_esc(r, d->reason, d->reason_n);
             sb_lit(r, "\",\"signature\":\"\"}");
             idx++;
         }
@@ -2017,7 +2020,16 @@ void run_completion(slot_t *s, sock_t fd, const char *prompt, int api,
     // prompt still wants its own slot's cache, and one that wants fresh-prompt
     // telemetry wants neither. cache_prompt:false remains the full opt-out.
     prefix_reuse reuse = { 0, 0, 0.0 };
+    bool omit_reasoning = false;
+    if (api == API_MESSAGES) {
+        jv *thinking = jv_get(req, "thinking");
+        jv *display = thinking && thinking->type == J_OBJ
+                    ? jv_get(thinking, "display") : NULL;
+        omit_reasoning = display && display->type == J_STR &&
+                         !strcmp(display->str, "omitted");
+    }
     gen_ctx g = { .out = {0}, .fd = fd, .stream = stream, .api = api,
+                  .omit_reasoning = omit_reasoning,
                   .stop_strs = stops, .n_stop = n_stops, .eng = e,
                   .created = (long)time(NULL) };
     client_stop stop = { .fd = fd, .dead = &g.dead,

--- a/src/schema.c
+++ b/src/schema.c
@@ -878,24 +878,10 @@ static snode *compile_oneof(jv *alts, char *err, int errcap, int depth) {
             break;
         }
     }
-    if (all_scalar_const) {
-        if (alts->n <= 0 || alts->n > 60) {
-            snprintf(err, errcap, "enum size must be 1..60");
-            return NULL;
-        }
-        snode *n = sn_new(SN_ENUM);
-        if (!n) return NULL;
-        n->lits = calloc(alts->n, sizeof(char *));
-        if (!n->lits) { schema_free(n); return NULL; }
-        for (int i = 0; i < alts->n; i++) {
-            char *lit = sn_literal(jv_get(alts->items[i], "const"));
-            if (!lit) { schema_free(n); return NULL; }
-            n->lits[i] = lit;
-            n->n_lits++;
-        }
-        return n;
+    if (all_scalar_const && alts->n > 60) {
+        snprintf(err, errcap, "enum size must be 1..60");
+        return NULL;
     }
-
     bool matched = false;
     snode *disc = compile_discriminated_action(alts, err, errcap, depth, &matched);
     if (matched) return disc;
@@ -968,6 +954,14 @@ static bool literal_has_type_name(const jv *v, const char *t) {
     if (!strcmp(t, "integer")) return v->type == J_NUM && v->num == floor(v->num);
     return false; // object / array literals are refused as non-scalars anyway
 }
+
+static bool schema_type_name(const char *t) {
+    return !strcmp(t, "string") || !strcmp(t, "number") ||
+           !strcmp(t, "integer") || !strcmp(t, "boolean") ||
+           !strcmp(t, "null") || !strcmp(t, "array") ||
+           !strcmp(t, "object");
+}
+
 static bool literal_has_type(const jv *v, jv *ty) {
     if (ty->type == J_STR) return literal_has_type_name(v, ty->str);
     if (ty->type == J_ARR) {
@@ -997,15 +991,16 @@ static snode *compile_node(jv *s, char *err, int errcap, int depth) {
         snprintf(err, errcap, "boolean schema false admits no value");
         return NULL;
     }
-    if (!s || s->type == J_NULL || (s->type == J_OBJ && s->n == 0) ||
-        s->type == J_BOOL) // `true` / `{}` = anything
+    if (!s || (s->type == J_OBJ && s->n == 0) ||
+        s->type == J_BOOL) // absent / `true` / `{}` = anything
         return sn_new(SN_ANY);
     if (s->type != J_OBJ) { snprintf(err, errcap, "schema node must be an object"); return NULL; }
     if (!check_keywords(s, err, errcap)) return NULL;
 
     jv *one = jv_get(s, "oneOf");
     jv *any = jv_get(s, "anyOf");
-    if ((one || any) && jv_get(s, "type")) {
+    jv *ty = jv_get(s, "type");
+    if ((one || any) && ty) {
         // a sibling `type` must hold for every alternative; it was dropped,
         // so {"type":"string","anyOf":[...,{"type":"integer"}]} accepted 1
         snprintf(err, errcap, "'type' beside oneOf/anyOf is not supported: "
@@ -1013,6 +1008,34 @@ static snode *compile_node(jv *s, char *err, int errcap, int depth) {
         return NULL;
     }
     if (one || any) return compile_oneof(one ? one : any, err, errcap, depth);
+
+    // enum/const return before compile_typed, so validate the type keyword's
+    // shape here rather than relying on the typed path to catch it later.
+    if (ty && ty->type != J_STR && ty->type != J_ARR) {
+        snprintf(err, errcap, "bad 'type' value");
+        return NULL;
+    }
+    if (ty && ty->type == J_STR && !schema_type_name(ty->str)) {
+        snprintf(err, errcap, "unsupported type '%s'", ty->str);
+        return NULL;
+    }
+    if (ty && ty->type == J_ARR) {
+        if (ty->n <= 0) {
+            snprintf(err, errcap, "'type' array must list at least one type");
+            return NULL;
+        }
+        for (int i = 0; i < ty->n; i++) {
+            if (!ty->items[i] || ty->items[i]->type != J_STR) {
+                snprintf(err, errcap, "'type' array members must be strings");
+                return NULL;
+            }
+            if (!schema_type_name(ty->items[i]->str)) {
+                snprintf(err, errcap, "unsupported type '%s'",
+                         ty->items[i]->str);
+                return NULL;
+            }
+        }
+    }
 
     // enum / const dominate the type
     jv *en = jv_get(s, "enum");
@@ -1043,7 +1066,6 @@ static snode *compile_node(jv *s, char *err, int errcap, int depth) {
         // beside an enum must be one of its members. Before this,
         // {"type":"integer","enum":["bad",1]} accepted "bad" and
         // {"const":1,"enum":[2]} accepted 2.
-        jv *ty = jv_get(s, "type");
         jv *keep[60];
         int n_keep = 0;
         for (int i = 0; i < cnt; i++) {
@@ -1071,7 +1093,6 @@ static snode *compile_node(jv *s, char *err, int errcap, int depth) {
         return n;
     }
 
-    jv *ty = jv_get(s, "type");
     if (!ty) {
         if (jv_get(s, "properties")) return compile_typed(s, "object", err, errcap, depth);
         if (jv_get(s, "items"))      return compile_typed(s, "array", err, errcap, depth);
@@ -1079,14 +1100,6 @@ static snode *compile_node(jv *s, char *err, int errcap, int depth) {
     }
     if (ty->type == J_STR) return compile_typed(s, ty->str, err, errcap, depth);
     if (ty->type == J_ARR) { // union, e.g. ["string","null"]
-        // An empty list compiles to a union with no alternatives, which every
-        // consumer treats as "at least one exists": pick_alt matches nothing so
-        // sampling stalls, and the forced-completion path then reads alts[0]
-        // out of a zero-byte allocation. Reject it at compile time.
-        if (ty->n <= 0) {
-            snprintf(err, errcap, "'type' array must list at least one type");
-            return NULL;
-        }
         snode *n = sn_new(SN_UNION);
         if (!n) return NULL;
         n->alts = calloc(ty->n, sizeof(snode *));
@@ -1260,6 +1273,55 @@ static bool native_members_required(snode *n, jv *params, jv *props,
     return true;
 }
 
+// ATEM spells strings as raw bytes, without JSON quotes. A free string is
+// representable by SN_RAW and a string enum/const by an enum whose literals
+// are the decoded strings. Length/pattern constraints need a different raw
+// machine, so the native protocol declines them and its caller selects the
+// generic JSON envelope instead.
+static snode *atem_string_value(jv *schema, const char *name, bool *raw,
+                                char *err, int errcap) {
+    snode *json = compile_node(schema, err, errcap, 0);
+    if (!json) return NULL;
+    if (json->kind == SN_STR && json->min_items == 0 &&
+        json->max_items < 0 && json->n_pat == 0) {
+        schema_free(json);
+        *raw = true;
+        return atem_raw("</atem:parameter>");
+    }
+    if (json->kind != SN_ENUM) {
+        snprintf(err, errcap,
+                 "atem raw string parameter '%s' has constraints that native "
+                 "syntax cannot enforce", name);
+        schema_free(json);
+        return NULL;
+    }
+    snode *native = sn_new(SN_ENUM);
+    if (!native) { schema_free(json); return NULL; }
+    native->lits = calloc((size_t)json->n_lits, sizeof(*native->lits));
+    if (!native->lits) { schema_free(native); schema_free(json); return NULL; }
+    native->whitespace_significant = true;
+    for (int i = 0; i < json->n_lits; i++) {
+        jv *literal = json_parse(json->lits[i], strlen(json->lits[i]));
+        const char *text = jv_str(literal, NULL);
+        if (!text || !text[0] || strstr(text, "</atem:parameter>")) {
+            snprintf(err, errcap,
+                     "atem string enum parameter '%s' has an unrepresentable "
+                     "native value", name);
+            jv_free(literal); schema_free(native); schema_free(json);
+            return NULL;
+        }
+        native->lits[native->n_lits] = strdup(text);
+        jv_free(literal);
+        if (!native->lits[native->n_lits]) {
+            schema_free(native); schema_free(json); return NULL;
+        }
+        native->n_lits++;
+    }
+    schema_free(json);
+    *raw = false;
+    return native;
+}
+
 static snode *atem_tool_tail(jv *tool, char *err, int errcap) {
     jv *fn = jv_get(tool, "function");
     if (!fn) fn = tool;
@@ -1284,13 +1346,17 @@ static snode *atem_tool_tail(jv *tool, char *err, int errcap) {
         const char *type = jv_str(ty, "");
         sbuf open = {0};
         sb_fmt(&open, "<atem:parameter name=\"%s\">", props->keys[i]);
-        bool structured = !strcmp(type, "object") || !strcmp(type, "array");
-        snode *value = structured
+        bool json_spelled = !strcmp(type, "object") || !strcmp(type, "array") ||
+                            !strcmp(type, "integer") || !strcmp(type, "number") ||
+                            !strcmp(type, "boolean") || !strcmp(type, "null");
+        bool raw = false;
+        snode *value = json_spelled
                      ? compile_node(props->items[i], err, errcap, 0)
-                     : atem_raw("</atem:parameter>");
-        snode *tail = atem_seq(structured ? 3 : 2);
+                     : atem_string_value(props->items[i], props->keys[i], &raw,
+                                         err, errcap);
+        snode *tail = atem_seq(raw ? 2 : 3);
         if (open.failed || !value || !tail || !atem_seq_add(tail, value) ||
-            (structured &&
+            (!raw &&
              !atem_seq_add(tail, atem_lit("</atem:parameter>"))) ||
             !atem_seq_add(tail, atem_lit("\n")) ||
             !native_member_set(members, i, open.s, open.s, tail)) {
@@ -1359,6 +1425,13 @@ fail:
     if (!err[0]) snprintf(err, errcap, "out of memory compiling atem tools");
     schema_free(names); schema_free(choice); schema_free(root);
     return NULL;
+}
+
+bool schema_atem_constrainable(struct jv *tools, char *err, int errcap) {
+    snode *probe = schema_compile_atem_tools(tools, err, errcap);
+    if (!probe) return false;
+    schema_free(probe);
+    return true;
 }
 
 static snode *schema_compile_atem_turn_prefix(struct jv *tools, bool allow_user,
@@ -1987,11 +2060,20 @@ static snode *g4_array(jv *schema, const char *what, int depth, int *budget,
                  what);
         return NULL;
     }
-    double dmax = jv_num(jv_get(schema, "maxItems"), G4_MAX_ITEMS);
-    int max = dmax > 0 && dmax < G4_MAX_ITEMS ? (int)dmax : G4_MAX_ITEMS;
-    double dmin = jv_num(jv_get(schema, "minItems"), 0);
-    int min = dmin > 0 ? (int)dmin : 0;
-    if (min > max) min = max;
+    int declared_max, min;
+    if (!compile_bound(jv_get(schema, "maxItems"), G4_MAX_ITEMS,
+                       &declared_max) ||
+        !compile_bound(jv_get(schema, "minItems"), 0, &min)) {
+        snprintf(err, errcap,
+                 "gemma4 %s has invalid integer minItems/maxItems", what);
+        return NULL;
+    }
+    int max = declared_max < G4_MAX_ITEMS ? declared_max : G4_MAX_ITEMS;
+    if (min > max) {
+        snprintf(err, errcap,
+                 "gemma4 %s minItems exceeds its enforceable maxItems", what);
+        return NULL;
+    }
     snode *tail = atem_lit("]");
     if (!tail) return NULL;
     for (int i = max; i >= 1; i--) {
@@ -2120,10 +2202,11 @@ static snode *g4_value(jv *schema, const char *what, int depth, int *budget,
         // generic envelope admits it as free JSON, but format_argument has no
         // free-form spelling to constrain a native call to.
         jv *en = jv_get(schema, "enum");
+        jv *cn = jv_get(schema, "const");
         bool all_str = en && en->type == J_ARR && en->n > 0;
         for (int i = 0; all_str && i < en->n; i++)
             if (!en->items[i] || en->items[i]->type != J_STR) all_str = false;
-        if (all_str) type = "string";
+        if (all_str || (cn && cn->type == J_STR)) type = "string";
         else {
             snprintf(err, errcap,
                      "gemma4 %s has no declared `type`: this family's native "
@@ -2133,38 +2216,58 @@ static snode *g4_value(jv *schema, const char *what, int depth, int *budget,
         }
     }
     if (!strcmp(type, "string")) {
+        if (jv_get(schema, "minLength") || jv_get(schema, "maxLength") ||
+            jv_get(schema, "pattern")) {
+            snprintf(err, errcap,
+                     "gemma4 %s has string length/pattern constraints that its "
+                     "native delimiter syntax cannot enforce", what);
+            return NULL;
+        }
         jv *en = jv_get(schema, "enum");
-        if (en && en->type == J_ARR && en->n > 0 && en->n <= 60) {
+        jv *cn = jv_get(schema, "const");
+        if (en || cn) {
+            snode *json = compile_node(schema, err, errcap, 0);
+            if (!json) return NULL;
+            if (json->kind != SN_ENUM) {
+                snprintf(err, errcap,
+                         "gemma4 %s string literal schema did not compile to an enum",
+                         what);
+                schema_free(json);
+                return NULL;
+            }
             snode *n = sn_new(SN_ENUM);
-            if (!n) return NULL;
-            n->lits = calloc((size_t)en->n, sizeof(*n->lits));
-            if (!n->lits) { schema_free(n); return NULL; }
+            if (!n) { schema_free(json); return NULL; }
+            n->lits = calloc((size_t)json->n_lits, sizeof(*n->lits));
+            if (!n->lits) { schema_free(n); schema_free(json); return NULL; }
             n->whitespace_significant = true;
-            for (int i = 0; i < en->n; i++) {
-                const char *v = jv_str(en->items[i], NULL);
-                if (!v) {
+            for (int i = 0; i < json->n_lits; i++) {
+                jv *literal = json_parse(json->lits[i], strlen(json->lits[i]));
+                const char *v = jv_str(literal, NULL);
+                if (!v || strstr(v, "<|\"|>")) {
                     snprintf(err, errcap,
-                             "gemma4 %s has a non-string enum value", what);
-                    schema_free(n);
+                             "gemma4 %s has an unrepresentable native string "
+                             "literal", what);
+                    jv_free(literal); schema_free(n); schema_free(json);
                     return NULL;
                 }
                 sbuf lit = {0};
                 sb_fmt(&lit, "<|\"|>%s<|\"|>", v);
-                if (lit.failed) { free(lit.s); schema_free(n); return NULL; }
+                jv_free(literal);
+                if (lit.failed) {
+                    free(lit.s); schema_free(n); schema_free(json); return NULL;
+                }
                 n->lits[n->n_lits++] = lit.s;
             }
+            schema_free(json);
             return n;
         }
-        // The <|"|> delimiter is a reserved token, so the value between the
-        // two needs no escaping and is raw bytes up to the closer.
-        double dmax = jv_num(jv_get(schema, "maxLength"), -1);
+        // The <|"|> delimiter is a reserved token, so an unconstrained value
+        // between the two needs no escaping and is raw bytes up to the closer.
         snode *seq = atem_seq(2);
         // built only once there is a sequence to own it: the cleanup below
         // frees it through `seq`, so a body with no sequence is a leak (the
         // two other sites with this shape already guard it the same way)
-        snode *body = !seq ? NULL
-                    : dmax > 0 ? atem_raw_bounded("<|\"|>", (int)dmax)
-                               : atem_raw("<|\"|>");
+        snode *body = !seq ? NULL : atem_raw("<|\"|>");
         if (!seq || !body || !atem_seq_add(seq, atem_lit("<|\"|>")) ||
             !atem_seq_add(seq, body)) {
             if (seq && seq->n_props < 2) schema_free(body);
@@ -2176,17 +2279,15 @@ static snode *g4_value(jv *schema, const char *what, int depth, int *budget,
         return seq;
     }
     if (!strcmp(type, "boolean")) {
-        snode *n = sn_new(SN_ENUM);
-        if (!n) return NULL;
-        n->lits = calloc(2, sizeof(*n->lits));
-        if (!n->lits) { schema_free(n); return NULL; }
-        n->whitespace_significant = true;
-        n->lits[n->n_lits++] = strdup("true");
-        n->lits[n->n_lits++] = strdup("false");
-        if (!n->lits[0] || !n->lits[1]) { schema_free(n); return NULL; }
+        snode *n = compile_node(schema, err, errcap, 0);
+        if (n) n->whitespace_significant = true;
         return n;
     }
-    if (!strcmp(type, "null")) return atem_lit("null");
+    if (!strcmp(type, "null")) {
+        snode *n = compile_node(schema, err, errcap, 0);
+        if (n) n->whitespace_significant = true;
+        return n;
+    }
     if (!strcmp(type, "integer") || !strcmp(type, "number")) {
         // Numbers are spelled identically in JSON and in format_argument, so
         // the ordinary compiler's bounded node applies unchanged -- including

--- a/src/schema.h
+++ b/src/schema.h
@@ -49,9 +49,13 @@ struct snode {
 
 struct jv;
 snode *schema_compile(struct jv *schema, char *err, int errcap);
-// Compile OpenAI tools[] to Muse's native atem call block. Scalar parameter
-// values are added in S3; S2 admits structured JSON values.
+// Compile OpenAI tools[] to Muse's native atem call block. JSON-spelled values
+// use the ordinary schema compiler; free strings use ATEM's raw sentinel form.
 snode *schema_compile_atem_tools(struct jv *tools, char *err, int errcap);
+// True when Muse's native raw-string protocol can represent every declared
+// parameter constraint exactly. Callers fall back to the generic envelope
+// when it cannot, keeping the schema strict without changing the request.
+bool schema_atem_constrainable(struct jv *tools, char *err, int errcap);
 // Compile the recipient header together with the native call. The duplicated
 // invoke name is pinned by the header discriminator; `user` selects raw text
 // or final_schema when supplied.

--- a/src/template.c
+++ b/src/template.c
@@ -2705,8 +2705,18 @@ const jv *tool_decl_native(int tmpl, bool strict, bool atem_tool_calling,
         env->proto = TP_QWEN;
         env->tools = tools;
     } else if (strict && tmpl == TMPL_MUSE) {
-        env->proto = atem_tool_calling ? TP_ATEM : TP_MUSE_USER;
+        env->proto = TP_MUSE_USER;
         env->tools = tools;
+        if (atem_tool_calling) {
+            char why[192];
+            if (!tools || schema_atem_constrainable(tools, why, sizeof(why))) {
+                env->proto = TP_ATEM;
+            } else {
+                fprintf(stderr, "tools: muse native atem syntax unavailable for "
+                                "this request (%s); using the generic envelope\n",
+                        why);
+            }
+        }
     } else if (strict && tmpl == TMPL_HARMONY) {
         env->proto = TP_HARMONY;
         env->tools = tools;

--- a/tests/conformance/test_request_validation.py
+++ b/tests/conformance/test_request_validation.py
@@ -500,6 +500,28 @@ def test_thinking_enabled_requires_budget_tokens(client):
         path="/v1/messages")
 
 
+@pytest.mark.parametrize("thinking", [
+    {"type": "adaptive", "display": "garbage"},
+    {"type": "adaptive", "display": 7},
+    {"type": "disabled", "display": "omitted"},
+])
+def test_thinking_display_matches_the_selected_mode(client, thinking):
+    client.expect_400(
+        {"max_tokens": 4, "messages": [{"role": "user", "content": "hi"}],
+         "thinking": thinking},
+        name=f"thinking-display-{thinking['type']}-{thinking['display']!r}",
+        contains="display", path="/v1/messages")
+
+
+@pytest.mark.parametrize("mode", ["adaptive", "disabled"])
+def test_thinking_budget_is_only_valid_in_enabled_mode(client, mode):
+    client.expect_400(
+        {"max_tokens": 4, "messages": [{"role": "user", "content": "hi"}],
+         "thinking": {"type": mode, "budget_tokens": 1024}},
+        name=f"thinking-budget-{mode}", contains="budget_tokens",
+        path="/v1/messages")
+
+
 @pytest.mark.parametrize("value", [{"type": "url", "url": "https://x"}, "x", 1])
 def test_malformed_mcp_servers_is_refused_too(client, value):
     """The MCP refusal looked only at non-empty arrays; an object-shaped or

--- a/tests/test_json_schema.c
+++ b/tests/test_json_schema.c
@@ -708,6 +708,20 @@ static void test_schema_rejects_misspelled_keyword_types(void) {
         // VALUES, so this compiled to the literal `1`
         { "{\"enum\":{\"a\":1}}", "enum" },
         { "{\"enum\":\"a\"}", "enum" },
+        // enum/const return before the ordinary typed compiler, so malformed
+        // type keywords beside them must still be rejected here
+        { "{\"type\":7,\"enum\":[1]}", "type" },
+        { "{\"type\":true,\"const\":1}", "type" },
+        { "{\"type\":[\"integer\",7],\"enum\":[1]}", "type" },
+        { "{\"type\":[],\"enum\":[1]}", "type" },
+        { "{\"type\":[\"integer\",\"mystery\"],\"enum\":[1]}",
+          "unsupported type" },
+        // JSON Schema nodes are objects or booleans. Explicit null is data,
+        // not the absent-schema sentinel used internally for unconstrained
+        // array items.
+        { "null", "schema node" },
+        { "{\"type\":\"object\",\"properties\":{\"x\":null}}",
+          "schema node" },
         // and a non-object `properties` fell through to the open-object
         // machine, which accepts any object at all -- the one outcome this
         // compiler exists to prevent
@@ -2759,6 +2773,12 @@ static void test_schema_sibling_constraints_are_not_dropped(void) {
     const char *ce = WRAP("{\"const\":2,\"enum\":[1,2]}");
     assert(accepts(ce, "{\"v\":2}"));
     assert(!accepts(ce, "{\"v\":1}"));
+    // Every scalar-const union alternative still carries its sibling
+    // constraints. The literal-only merge must not bypass them.
+    assert(!compiles("{\"anyOf\":[{\"type\":\"string\",\"const\":1},"
+                     "{\"const\":\"x\"}]}"));
+    assert(!compiles("{\"anyOf\":[{\"const\":1,\"minimum\":2},"
+                     "{\"const\":\"x\"}]}"));
     // type beside oneOf/anyOf is refused rather than ignored
     assert(!compiles("{\"type\":\"string\",\"anyOf\":[{\"type\":\"string\"},"
                      "{\"type\":\"integer\"}]}"));

--- a/tests/test_responses_sm.c
+++ b/tests/test_responses_sm.c
@@ -719,9 +719,63 @@ static void test_every_tool_call_reaches_the_typed_surfaces(void) {
     free(tc.s);
 }
 
+static void test_anthropic_omitted_thinking_hides_buffered_text(void) {
+    SV.model_name = "test-thinking-display";
+    gen_ctx g;
+    memset(&g, 0, sizeof(g));
+    g.omit_reasoning = true;
+    snprintf(g.id, sizeof(g.id), "msg_omit");
+    static const char SECRET[] = "private reasoning";
+    resp_doc d = { .with_output = true,
+                   .reason = SECRET, .reason_n = sizeof(SECRET) - 1,
+                   .text = "answer", .text_n = 6,
+                   .stop_reason = "end_turn" };
+    sbuf body = {0};
+    anth_body(&body, &g, &d);
+    ck(body.s && !strstr(body.s, SECRET),
+       "thinking.display omitted hides buffered reasoning text");
+    ck(body.s && strstr(body.s,
+       "{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}"),
+       "omitted reasoning keeps an empty continuity block");
+    free(body.s);
+}
+
+static void test_anthropic_omitted_thinking_hides_streamed_deltas(void) {
+    int sv[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
+        ck(0, "socketpair for omitted thinking stream");
+        return;
+    }
+    gen_ctx g;
+    memset(&g, 0, sizeof(g));
+    g.fd = sv[0];
+    g.stream = true;
+    g.api = API_MESSAGES;
+    g.omit_reasoning = true;
+    static const char SECRET[] = "private reasoning";
+    ck(send_text_delta_raw(&g, 1, SECRET, sizeof(SECRET) - 1) == 0,
+       "omitted thinking stream opens without writing its text");
+    anth_close_block(&g);
+    shutdown(sv[0], SHUT_WR);
+    char wire[4096];
+    ssize_t n = recv(sv[1], wire, sizeof(wire) - 1, 0);
+    if (n < 0) n = 0;
+    wire[n] = 0;
+    ck(strstr(wire, "\"type\":\"thinking\"") != NULL,
+       "omitted thinking stream keeps the continuity block");
+    ck(strstr(wire, SECRET) == NULL &&
+       strstr(wire, "thinking_delta") == NULL,
+       "omitted thinking stream emits no reasoning delta");
+    close(sv[0]);
+    close(sv[1]);
+    free(g.item_text.s);
+}
+
 int main(int argc, char **argv) {
     if (argc > 1) g_model_path = argv[1];
     test_every_tool_call_reaches_the_typed_surfaces();
+    test_anthropic_omitted_thinking_hides_buffered_text();
+    test_anthropic_omitted_thinking_hides_streamed_deltas();
     test_utf8_tail_is_held_until_the_character_completes();
     test_a_failed_utf8_join_keeps_the_stream_in_order();
     test_message_item_order();

--- a/tests/test_tools.c
+++ b/tests/test_tools.c
@@ -113,6 +113,63 @@ static void test_atem_scalar_is_raw_until_parameter_close(void) {
     jv_free(tools);
 }
 
+static void test_atem_json_scalar_schemas_are_enforced(void) {
+    jv *tools = parse(
+        "[{\"type\":\"function\",\"function\":{\"name\":\"set\","
+        "\"parameters\":{\"type\":\"object\",\"properties\":{"
+        "\"level\":{\"type\":\"integer\",\"minimum\":5,\"maximum\":9},"
+        "\"enabled\":{\"type\":\"boolean\"}},"
+        "\"required\":[\"level\",\"enabled\"]}}}]"
+    );
+    char err[192];
+    snode *root = schema_compile_atem_tools(tools, err, sizeof(err));
+    if (!root) fprintf(stderr, "typed atem scalars did not compile: %s\n", err);
+    assert(root != NULL);
+    const char *head =
+        "<atem:function_calls>\n<atem:invoke name=\"set\">\n"
+        "<atem:parameter name=\"level\">";
+    const char *middle =
+        "</atem:parameter>\n<atem:parameter name=\"enabled\">";
+    const char *tail =
+        "</atem:parameter>\n</atem:invoke>\n</atem:function_calls>";
+    char doc[512];
+    snprintf(doc, sizeof(doc), "%s7%strue%s", head, middle, tail);
+    assert(accepts(root, doc));
+    snprintf(doc, sizeof(doc), "%s1.5%strue%s", head, middle, tail);
+    assert(!accepts(root, doc));
+    snprintf(doc, sizeof(doc), "%s100%strue%s", head, middle, tail);
+    assert(!accepts(root, doc));
+    snprintf(doc, sizeof(doc), "%s7%s1%s", head, middle, tail);
+    assert(!accepts(root, doc));
+    schema_free(root);
+    jv_free(tools);
+}
+
+static void test_atem_unrepresentable_string_schema_uses_generic_envelope(void) {
+    jv *tools = parse(
+        "[{\"type\":\"function\",\"function\":{\"name\":\"save\","
+        "\"parameters\":{\"type\":\"object\",\"properties\":{"
+        "\"text\":{\"type\":\"string\",\"minLength\":3}},"
+        "\"required\":[\"text\"]}}}]"
+    );
+    tool_envelope e = {0};
+    char err[192];
+    assert(tool_envelope_build(tools, NULL, NULL, &e, err, sizeof(err)) == 1);
+    bool skip_generic = true;
+    const jv *decl = tool_decl_native(TMPL_MUSE, true, true, tools, &e,
+                                      &skip_generic);
+    assert(decl == NULL);
+    assert(!skip_generic);
+    assert(e.proto == TP_MUSE_USER);
+    snode *root = compile(&e);
+    assert(root != NULL);
+    assert(accepts(root, "{\"tool\":\"save\",\"args\":{\"text\":\"abc\"}}"));
+    assert(!accepts(root, "{\"tool\":\"save\",\"args\":{\"text\":\"x\"}}"));
+    schema_free(root);
+    tool_envelope_free(&e);
+    jv_free(tools);
+}
+
 static void test_atem_truncation_closes_started_call(void) {
     jv *tools = parse(
         "[{\"type\":\"function\",\"function\":{\"name\":\"notes.save\","
@@ -2034,6 +2091,88 @@ static void test_gemma4_structured_arguments_round_trip(void) {
     jv_free(tools);
 }
 
+static void test_gemma4_zero_max_items_allows_only_empty_array(void) {
+    jv *tools = parse(
+        "[{\"type\":\"function\",\"function\":{\"name\":\"store\","
+        "\"parameters\":{\"type\":\"object\",\"properties\":{"
+        "\"values\":{\"type\":\"array\",\"maxItems\":0,"
+        "\"items\":{\"type\":\"integer\"}}},"
+        "\"required\":[\"values\"]}}}]"
+    );
+    char err[192];
+    snode *root = schema_compile_gemma4_turn(tools, false, NULL, NULL, false,
+                                             false, err, sizeof(err));
+    if (!root) fprintf(stderr, "zero-item gemma4 array: %s\n", err);
+    assert(root != NULL);
+    assert(accepts(root,
+        "<|tool_call>call:store{values:[]}<tool_call|>"));
+    assert(!accepts(root,
+        "<|tool_call>call:store{values:[1]}<tool_call|>"));
+    schema_free(root);
+    jv_free(tools);
+}
+
+static void test_gemma4_boolean_const_is_enforced(void) {
+    jv *tools = parse(
+        "[{\"type\":\"function\",\"function\":{\"name\":\"set\","
+        "\"parameters\":{\"type\":\"object\",\"properties\":{"
+        "\"enabled\":{\"type\":\"boolean\",\"const\":true}},"
+        "\"required\":[\"enabled\"]}}}]"
+    );
+    char err[192];
+    snode *root = schema_compile_gemma4_turn(tools, false, NULL, NULL, false,
+                                             false, err, sizeof(err));
+    assert(root != NULL);
+    assert(accepts(root, "<|tool_call>call:set{enabled:true}<tool_call|>"));
+    assert(!accepts(root, "<|tool_call>call:set{enabled:false}<tool_call|>"));
+    schema_free(root);
+    jv_free(tools);
+}
+
+static void test_gemma4_string_const_is_enforced(void) {
+    jv *tools = parse(
+        "[{\"type\":\"function\",\"function\":{\"name\":\"tag\","
+        "\"parameters\":{\"type\":\"object\",\"properties\":{"
+        "\"name\":{\"type\":\"string\",\"const\":\"fixed\"}},"
+        "\"required\":[\"name\"]}}}]"
+    );
+    char err[192];
+    snode *root = schema_compile_gemma4_turn(tools, false, NULL, NULL, false,
+                                             false, err, sizeof(err));
+    assert(root != NULL);
+    assert(accepts(root,
+        "<|tool_call>call:tag{name:<|\"|>fixed<|\"|>}<tool_call|>"));
+    assert(!accepts(root,
+        "<|tool_call>call:tag{name:<|\"|>other<|\"|>}<tool_call|>"));
+    schema_free(root);
+    jv_free(tools);
+}
+
+static void test_gemma4_unrepresentable_string_schema_uses_generic_envelope(void) {
+    jv *tools = parse(
+        "[{\"type\":\"function\",\"function\":{\"name\":\"save\","
+        "\"parameters\":{\"type\":\"object\",\"properties\":{"
+        "\"text\":{\"type\":\"string\",\"minLength\":3}},"
+        "\"required\":[\"text\"]}}}]"
+    );
+    tool_envelope e = {0};
+    char err[192];
+    assert(tool_envelope_build(tools, NULL, NULL, &e, err, sizeof(err)) == 1);
+    bool skip_generic = true;
+    const jv *decl = tool_decl_native(TMPL_GEMMA4, true, true, tools, &e,
+                                      &skip_generic);
+    assert(decl == NULL);
+    assert(!skip_generic);
+    assert(e.proto == TP_GENERIC);
+    snode *root = compile(&e);
+    assert(root != NULL);
+    assert(accepts(root, "{\"tool\":\"save\",\"args\":{\"text\":\"abc\"}}"));
+    assert(!accepts(root, "{\"tool\":\"save\",\"args\":{\"text\":\"x\"}}"));
+    schema_free(root);
+    tool_envelope_free(&e);
+    jv_free(tools);
+}
+
 static void test_gemma4_untyped_parameter_is_refused_not_guessed(void) {
     // The generic envelope admits an untyped parameter as free JSON. gemma4's
     // native syntax has no free-form spelling, so the choice is between an
@@ -2212,6 +2351,8 @@ int main(void) {
     test_buffered_mapper_rejects_invalid_arguments();
     test_atem_structured_tool_automaton();
     test_atem_scalar_is_raw_until_parameter_close();
+    test_atem_json_scalar_schemas_are_enforced();
+    test_atem_unrepresentable_string_schema_uses_generic_envelope();
     test_atem_truncation_closes_started_call();
     test_atem_truncation_inside_a_tool_name_picks_its_own_args();
     test_atem_buffered_maps_reasoning_and_multiple_calls();
@@ -2262,6 +2403,10 @@ int main(void) {
     test_gemma4_truncated_call_still_parses();
     test_gemma4_native_mapping_and_stream_boundaries();
     test_gemma4_structured_arguments_round_trip();
+    test_gemma4_zero_max_items_allows_only_empty_array();
+    test_gemma4_boolean_const_is_enforced();
+    test_gemma4_string_const_is_enforced();
+    test_gemma4_unrepresentable_string_schema_uses_generic_envelope();
     test_gemma4_untyped_parameter_is_refused_not_guessed();
     test_gemma4_nested_arrays_are_bounded_not_expanded();
     test_native_truncation_closes_to_a_legal_turn();


### PR DESCRIPTION
Six constraint paths could accept or expose behavior outside the request contract: malformed or null schema nodes escaped validation, scalar-const unions dropped sibling constraints, Muse and Gemma native tool grammars weakened selected scalar/array/string constraints, and Anthropic thinking fields were accepted without enforcing their mode or display semantics.

This change validates schema shape before literal shortcuts, compiles representable Muse and Gemma arguments against their declared schemas, selects the generic strict envelope when a native delimiter format cannot express a constraint, and validates Anthropic `budget_tokens`/`display` while suppressing omitted reasoning text in buffered and SSE responses. README behavior is updated; the site has only the existing high-level capability summary and the Hugging Face artifact set is unchanged.

Validation:
- `make test` (all C/Metal gates; 540 passed, 20 skipped in the broad Python matrix; 26 passed, 2 skipped MoE; 20 passed expert pruning)
- `./test-json-schema`
- `./test-tools`
- `./test-schema-oom`
- `./test-responses-sm /tmp/runner-sweep4-fix.gguf`
- `pytest -q tests/conformance/test_request_validation.py` (127 passed)
- `pytest -q tests/conformance/test_messages.py` (53 passed, 5 skipped)
- `make test-help-interface`
- `python3 scripts/check-commit-hygiene.py --range origin/main..HEAD`
