### PR TITLE
Site: Cloudflare Web Analytics beacon

### DIFF
--- a/site/build.py
+++ b/site/build.py
@@ -375,6 +375,8 @@ def shell(meta: dict, body: str, sha: str) -> str:
   </div>
 </footer>
 <script src="/assets/site.js?v={sha[:8]}" defer></script>
+<!-- Cloudflare Web Analytics: page views without cookies or identifiers; the token is a public site id -->
+<script type="module" src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{{"token": "509dac0492754411ade436a38283a388"}}'></script>
 </body>
 </html>
 """

--- a/site/pages/support.html
+++ b/site/pages/support.html
@@ -55,7 +55,7 @@ nav: support
       <div><span>Consulting and enterprise work</span><p>Zenova AB takes engagements around local inference: private fine-tuning for data that cannot leave the building, with the receipts as the deliverable. This funds the hardware. The engine is never the thing being sold.</p></div>
       <div><span>Contributions</span><p>One-off, through the Stripe link above. They go to measurement time, hosting and hardware, as described on this page.</p></div>
       <div><span>Work in kind</span><p>A benchmark on hardware the project does not own, an unusual GGUF that fails to load, a coding agent that does not complete its loop, an independent run of the determinism claims. <a href="{{repo}}/issues">Open an issue</a> with <code>runner --version</code>, <code>runner --caps</code>, the exact filename and the load log. Reproductions are credited.</p></div>
-      <div><span>What it will not fund</span><p>Analytics on this site, a cookie banner, a paid tier of the engine, or a claim the repository does not make on the day the site is built.</p></div>
+      <div><span>What it will not fund</span><p>A cookie banner, a paid tier of the engine, or a claim the repository does not make on the day the site is built. The site counts page views with Cloudflare Web Analytics: no cookies, no identifiers, no cross-site tracking, one script tag that sits in the repository like the rest of the page. It costs nothing, and it is stated here so this line stays true.</p></div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
One script tag in the page shell (cookieless Cloudflare Web Analytics, public site token) and the support page reworded to state what is counted. Site-only change.

Co-Authored-By: Claude Code (Fable 5.1) & Joakimpalm-Zen