### PR TITLE
Reject malformed API history fields and fix RISC-V provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ names that were true when they were written.
 
 ## Unreleased
 
+- Chat, Responses and Messages now reject malformed nested history fields
+  instead of accepting and dropping or echoing them: assistant `content`,
+  `reasoning_content`, tool-result `name`/`tool_call_id`, Responses reasoning
+  hints, and Messages thinking blocks are type-checked at the HTTP boundary.
+  RISC-V builds now identify themselves as `riscv64` in `--caps`, inference
+  receipts and training provenance instead of falling through to `other` or
+  `x86_64`.
 - Receipts can be signed with a post-quantum key: `--keygen-algo ml-dsa-44`
   writes an ML-DSA-44 (FIPS 204) key in the same `signkey.v1` file, the
   record's signature object names its algorithm, and `--verify` accepts

--- a/src/api_anthropic.c
+++ b/src/api_anthropic.c
@@ -355,6 +355,30 @@ static bool anth_blocks(jv *messages, int message_index, jv *msg,
             // the request declared no tools -- and replaying reasoning has
             // nothing to do with tools. chat keys the same replay off
             // s->tmpl for that reason.
+            if (!strcmp(bt, "thinking")) {
+                jv *thinking = jv_get(b, "thinking");
+                if (!thinking || thinking->type != J_STR) {
+                    snprintf(err, errcap,
+                             "a thinking block must carry a thinking string");
+                    free(body.s); free(calls_json.s);
+                    return false;
+                }
+                jv *signature = jv_get(b, "signature");
+                if (!signature || signature->type != J_STR) {
+                    snprintf(err, errcap,
+                             "a thinking block must carry a signature string");
+                    free(body.s); free(calls_json.s);
+                    return false;
+                }
+            } else {
+                jv *data = jv_get(b, "data");
+                if (!data || data->type != J_STR) {
+                    snprintf(err, errcap,
+                             "a redacted_thinking block must carry a data string");
+                    free(body.s); free(calls_json.s);
+                    return false;
+                }
+            }
             const char *think_txt = tmpl == TMPL_HARMONY && !strcmp(bt, "thinking")
                 ? jv_str(jv_get(b, "thinking"), NULL) : NULL;
             if (think_txt && think_txt[0])

--- a/src/api_responses.c
+++ b/src/api_responses.c
@@ -559,6 +559,19 @@ void handle_responses(slot_t *s, sock_t fd, jv *req) {
         send_error(fd, 400, "reasoning must be an object");
         return;
     }
+    if (reasoning && reasoning->type == J_OBJ) {
+        static const char *fields[] = { "effort", "summary" };
+        for (size_t i = 0; i < sizeof(fields) / sizeof(fields[0]); i++) {
+            jv *v = jv_get(reasoning, fields[i]);
+            if (v && v->type != J_NULL && v->type != J_STR) {
+                char err[96];
+                snprintf(err, sizeof(err), "reasoning.%s must be a string",
+                         fields[i]);
+                send_error(fd, 400, err);
+                return;
+            }
+        }
+    }
 
     char terr[224];
     // Set where the refusal is the SERVER running out of memory rather than

--- a/src/build_arch.h
+++ b/src/build_arch.h
@@ -1,0 +1,16 @@
+#ifndef RUNNER_BUILD_ARCH_H
+#define RUNNER_BUILD_ARCH_H
+
+// One spelling for every public build/provenance surface. Keep this header
+// free of system includes so cross-target preprocess gates can exercise it.
+#if defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64)
+#define RUNNER_BUILD_ARCH "arm64"
+#elif defined(__x86_64__) || defined(_M_X64)
+#define RUNNER_BUILD_ARCH "x86_64"
+#elif defined(__riscv) && defined(__riscv_xlen) && __riscv_xlen == 64
+#define RUNNER_BUILD_ARCH "riscv64"
+#else
+#define RUNNER_BUILD_ARCH "other"
+#endif
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 #include "envelope.h"
 #include "oms.h"
 #include "server.h"
+#include "build_arch.h"
 // for render_prompt_alloc: chat mode renders the same prompts the chat route
 // does, so it uses the same measured-size renderer rather than a second one
 #include "api.h"
@@ -1187,13 +1188,7 @@ int main(int argc, char **argv) {
 #else
                "linux",
 #endif
-#if defined(__aarch64__) || defined(__arm64__)
-               "arm64",
-#elif defined(__x86_64__) || defined(_M_X64)
-               "x86_64",
-#else
-               "other",
-#endif
+               RUNNER_BUILD_ARCH,
                plat_cpu_count(), (unsigned long long)plat_ram_bytes(),
                // Not total RAM: "model file size <= RAM" is the test that
                // passes right before a machine starts thrashing. A launcher
@@ -2099,12 +2094,7 @@ int main(int argc, char **argv) {
 #endif
             sb_lit(&rec, build_os);
             sb_lit(&rec, "\",\"arch\":\"");
-            const char *build_arch =
-#if defined(__aarch64__) || defined(_M_ARM64)
-                    "arm64";
-#else
-                    "x86_64";
-#endif
+            const char *build_arch = RUNNER_BUILD_ARCH;
             sb_lit(&rec, build_arch);
             sb_lit(&rec, "\"},\"base\":{\"path\":\"");
             sb_esc(&rec, load_path, strlen(load_path));
@@ -2576,11 +2566,7 @@ int main(int argc, char **argv) {
 #else
                 .os = "linux",
 #endif
-#if defined(__aarch64__) || defined(_M_ARM64)
-                .arch = "arm64",
-#else
-                .arch = "x86_64",
-#endif
+                .arch = RUNNER_BUILD_ARCH,
                 .device = m.gpu ? gname : "cpu",
                 .gpu = m.gpu != NULL,
                 .gpu_layers = m.gpu_layers,

--- a/src/server.c
+++ b/src/server.c
@@ -163,6 +163,18 @@ static bool validate_chat_messages(const jv *msgs, char *err, size_t err_cap) {
                      "assistant or tool", i);
             return false;
         }
+        jv *name_v = jv_get(msg, "name");
+        if (name_v && name_v->type != J_NULL && name_v->type != J_STR) {
+            snprintf(err, err_cap, "messages[%d].name must be a string", i);
+            return false;
+        }
+        jv *call_id_v = jv_get(msg, "tool_call_id");
+        if (call_id_v && call_id_v->type != J_NULL &&
+            call_id_v->type != J_STR) {
+            snprintf(err, err_cap,
+                     "messages[%d].tool_call_id must be a string", i);
+            return false;
+        }
         jv *calls = jv_get(msg, "tool_calls");
         if (calls && calls->type != J_NULL) {
             if (calls->type != J_ARR) {
@@ -225,14 +237,22 @@ static bool validate_chat_messages(const jv *msgs, char *err, size_t err_cap) {
                 }
             }
         }
-        const char *reason = jv_str(jv_get(msg, "reasoning_content"), NULL);
+        jv *reasoning = jv_get(msg, "reasoning_content");
+        if (reasoning && reasoning->type != J_NULL && reasoning->type != J_STR) {
+            snprintf(err, err_cap,
+                     "messages[%d].reasoning_content must be a string", i);
+            return false;
+        }
+        const char *reason = jv_str(reasoning, NULL);
         bool assistant_payload = !strcmp(role, "assistant") &&
             ((calls && calls->type == J_ARR && calls->n > 0) ||
              (reason && reason[0]));
         jv *content = jv_get(msg, "content");
         bool content_shape = content &&
                              (content->type == J_STR || content->type == J_ARR);
-        if (!content_shape && !assistant_payload) {
+        bool content_absent = !content || content->type == J_NULL;
+        if ((!content_shape && !content_absent) ||
+            (content_absent && !assistant_payload)) {
             snprintf(err, err_cap,
                      "messages[%d].content must be a string or an array", i);
             return false;

--- a/tests/conformance/test_messages.py
+++ b/tests/conformance/test_messages.py
@@ -851,6 +851,24 @@ def test_replayed_reasoning_is_accepted(client, block, label):
     r.expect_status(200)
 
 
+@pytest.mark.parametrize("block,field", [
+    ({"type": "thinking", "thinking": 7, "signature": "sig"}, "thinking"),
+    ({"type": "thinking", "thinking": "scratch", "signature": False},
+     "signature"),
+    ({"type": "redacted_thinking", "data": 7}, "data"),
+])
+def test_replayed_reasoning_members_must_be_strings(client, block, field):
+    client.expect_400(
+        {"model": "local", "max_tokens": 8,
+         "messages": [
+             {"role": "user", "content": "hi"},
+             {"role": "assistant", "content": [block]},
+             {"role": "user", "content": "go on"},
+         ]},
+        name=f"messages-bad-replayed-{field}", contains=field,
+        path="/v1/messages")
+
+
 def test_replayed_reasoning_costs_nothing(client):
     """Accepting the block is the weak half; on THIS family (not Harmony) not
     putting it in the prompt is the half that matters, and a test that only

--- a/tests/conformance/test_request_validation.py
+++ b/tests/conformance/test_request_validation.py
@@ -223,6 +223,47 @@ def test_malformed_chat_messages_are_rejected(client, message, label, contains):
         name=f"bad-message-{label}", contains=contains)
 
 
+def test_assistant_payload_does_not_bypass_content_shape_validation(client):
+    client.expect_400(
+        {"messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": 7,
+             "reasoning_content": "thought"},
+            {"role": "user", "content": "retained"},
+        ], "max_tokens": 4, "temperature": 0},
+        name="bad-assistant-content-with-reasoning", contains="content")
+
+
+def test_reasoning_content_must_be_a_string(client):
+    client.expect_400(
+        {"messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "ok", "reasoning_content": 7},
+            {"role": "user", "content": "retained"},
+        ], "max_tokens": 4, "temperature": 0},
+        name="bad-reasoning-content-type", contains="reasoning_content")
+
+
+@pytest.mark.parametrize("result,field", [
+    ({"role": "tool", "content": "ok", "name": "f", "tool_call_id": 7},
+     "tool_call_id"),
+    ({"role": "tool", "content": "ok", "name": 7, "tool_call_id": "c1"},
+     "name"),
+])
+def test_tool_result_attribution_fields_must_be_strings(client, result, field):
+    client.expect_400(
+        {"messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": None, "tool_calls": [{
+                "id": "c1", "type": "function",
+                "function": {"name": "f", "arguments": "{}"},
+            }]},
+            result,
+            {"role": "user", "content": "retained"},
+        ], "max_tokens": 4, "temperature": 0},
+        name=f"bad-tool-result-{field}", contains=field)
+
+
 def test_chat_rejects_image_parts_instead_of_answering_text_only(client):
     client.expect_400({
         "messages": [{"role": "user", "content": [

--- a/tests/conformance/test_responses.py
+++ b/tests/conformance/test_responses.py
@@ -297,6 +297,18 @@ def test_reasoning_is_accepted_and_echoed(client):
                             got=d.get("reasoning"))
 
 
+@pytest.mark.parametrize("reasoning,field", [
+    ({"effort": 7}, "reasoning.effort"),
+    ({"summary": ["bad"]}, "reasoning.summary"),
+])
+def test_reasoning_members_must_be_strings(client, reasoning, field):
+    client.expect_400(
+        {"input": "hello", "max_output_tokens": 4,
+         "reasoning": reasoning},
+        name=f"responses-bad-{field}", contains=field,
+        path="/v1/responses")
+
+
 # ------------------------------------------------------------ text.format
 def test_text_format_json_schema_constrains_output(client, report):
     schema = {"type": "object",

--- a/tests/test_caps.py
+++ b/tests/test_caps.py
@@ -1,10 +1,27 @@
 import json
+import os
 import pathlib
+import shlex
 import subprocess
 import sys
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def test_build_arch_names_riscv64():
+    """The cross target's compiler macros must produce its real receipt ISA."""
+    cc = shlex.split(os.environ.get("CC", "cc"))
+    p = subprocess.run(
+        cc + ["-E", "-P", "-x", "c", "-", "-I", str(ROOT / "src"),
+              "-U__aarch64__", "-U__arm64__", "-U_M_ARM64",
+              "-U__x86_64__", "-U_M_X64",
+              "-D__riscv=1", "-D__riscv_xlen=64"],
+        input=b'#include "build_arch.h"\nRUNNER_BUILD_ARCH\n',
+        cwd=ROOT, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    assert p.returncode == 0, p.stderr.decode(errors="replace")
+    assert p.stdout.decode().strip() == '"riscv64"'
 
 
 # What each backend is expected to have kernels for, stated here on purpose.


### PR DESCRIPTION
Malformed nested fields in Chat Completions, Responses, and Messages could receive HTTP 200 while being dropped from the rendered prompt or echoed into an invalid response. These requests now receive HTTP 400 with the offending field named, while valid nullable assistant payloads and supported reasoning hints retain their existing behavior.

RISC-V binaries also used the x86-64 fallback in inference receipts and training provenance. A shared compile-time architecture label now reports `riscv64` consistently in `--caps`, receipts, and provenance.

Validation:
- `make test PYTHON=.venv/bin/python`
- `PYTHON=.venv/bin/python ./scripts/conformance.sh` (451 passed, 17 skipped)
- focused API/capability suite (235 passed, 5 skipped)
- `make cross-riscv64` (static 64-bit RISC-V executable produced)
- commit hygiene hook

README impact was checked: its malformed-request and RISC-V descriptions already state the corrected behavior. The Unreleased changelog records the fixes.
