### PR TITLE
Bugfix round: gemma-4 MoE heap scratch (no VLAs on server threads), Ed25519 shift UB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ names that were true when they were written.
 
 ## Unreleased
 
+- A gemma-4 MoE forward no longer sizes stack arrays by the file's embedding
+  width: four per-token buffers (16 bytes per element, widths up to 2^20
+  admitted by the loader) were variable-length arrays on slot and scheduler
+  threads with 512 KB stacks, so a wide enough declared width crashed the
+  server mid-forward instead of failing at load. They are model-owned heap
+  scratch now, byte-identical output on the Gemma MoE fixtures, and
+  `test-makefile-sane` compiles every engine source with `-Werror=vla`.
+- Two left shifts of a negative value in the Ed25519 carry routines
+  (undefined behaviour, reported by UBSan on the envelope test) are
+  multiplications; the RFC 8032 known answers pin the bits.
 - Chat, Responses and Messages now reject malformed nested history fields
   instead of accepting and dropping or echoing them: assistant `content`,
   `reasoning_content`, tool-result `name`/`tool_call_id`, Responses reasoning

--- a/Makefile
+++ b/Makefile
@@ -2222,6 +2222,9 @@ test-makefile-sane:
 		exit 1; \
 	}; \
 	if grep -q 'system(' src/tray.c src/tray_*.c src/tray_*.m; then echo "FAIL: tray launches through a shell"; exit 1; fi; \
+	for f in src/model.c src/engine.c src/completion.c src/server.c src/scheduler.c src/registry.c src/api_responses.c src/api_anthropic.c src/template.c src/schema.c src/jsonmode.c src/tokenizer.c src/sample.c src/envelope.c src/oms.c src/http.c src/json.c src/gguf.c; do \
+	  $(CC) -fsyntax-only -std=gnu11 -Werror=vla -DRUNNER_GPU_CUDA -I src $$f 2>/dev/null || { \
+	    echo "FAIL: $$f declares a variable-length stack array (the forward runs on 512 KB server threads; size by file values goes on the heap)"; exit 1; }; done; \
 	tline=$$($(MAKE) -Bn --no-print-directory T3=1 CFLAGS="-O3 -ffast-math" runner | grep -- ' src/model.c '); \
 	test -n "$$tline" || { echo "FAIL: T3 build has no model.c compile line"; exit 1; }; \
 	case "$$tline" in *" -ffast-math "*) echo "FAIL: T3=1 left -ffast-math in the engine build"; exit 1;; esac; \

--- a/src/ed25519.c
+++ b/src/ed25519.c
@@ -75,7 +75,7 @@ sv car25519(gf o)
     o[i]+=(1LL<<16);
     c=o[i]>>16;
     o[(i+1)*(i<15)]+=c-1+37*(c-1)*(i==15);
-    o[i]-=c<<16;
+    o[i]-=c*65536;   /* not c<<16: c can be negative, and a left shift of a negative value is undefined in C (UBSan) */
   }
 }
 
@@ -387,7 +387,7 @@ sv modL(u8 *r,i64 x[64])
     for (j = i - 32;j < i - 12;++j) {
       x[j] += carry - 16 * x[i] * L[j - (i - 32)];
       carry = (x[j] + 128) >> 8;
-      x[j] -= carry << 8;
+      x[j] -= carry * 256;   /* not carry<<8: carry can be negative (see car25519) */
     }
     x[j] += carry;
     x[i] = 0;

--- a/src/model.c
+++ b/src/model.c
@@ -3754,6 +3754,10 @@ static bool model_alloc_runtime(model_t *m, const model_params *p) {
         m->moe_up     = malloc(sizeof(float) * (size_t)m->n_ff_exp);
         m->moe_dexp   = malloc(sizeof(float) * (size_t)m->n_embd);
         m->moe_out    = malloc(sizeof(float) * (size_t)m->n_embd);
+        if (m->moe_gemma) {
+            m->gemma_scr = malloc(sizeof(float) * 4 * (size_t)m->n_embd);
+            if (!m->gemma_scr) return false;
+        }
         // grouped-by-expert prefill scratch (a whole batch at once)
         size_t nb = (size_t)m->n_batch, ne = (size_t)m->n_embd;
         size_t nf = (size_t)m->n_ff_exp, nu = (size_t)m->n_expert_used;
@@ -3944,6 +3948,7 @@ void model_free(model_t *m) {
     free(m->moe_logits); free(m->moe_sel_scores); free(m->moe_group_score);
     free(m->moe_gate); free(m->moe_up);
     free(m->moe_dexp); free(m->moe_out);
+    free(m->gemma_scr);
     free(m->moe_out_b); free(m->moe_gath); free(m->moe_gate_b);
     free(m->moe_up_b); free(m->moe_dexp_b); free(m->moe_sel);
     free(m->moe_selw); free(m->moe_trace_norms); free(m->moe_gidx); free(m->moe_gw);
@@ -5432,7 +5437,7 @@ static gguf_tensor gemma_gate_up_weight(const layer_t *ly, int e, int n_embd,
 static void gemma_route(model_t *m, const layer_t *ly, const float *h,
                          int n_embd, int ne, int used, int *sel, float *selw,
                          bool dbg_dump) {
-    float rin[n_embd];
+    float *rin = m->gemma_scr + 3 * (size_t)n_embd;
     float inv = 1.0f / sqrtf((float)n_embd);
     float rss = 0.0f;
     for (int i = 0; i < n_embd; i++) rss += h[i] * h[i];
@@ -5471,7 +5476,7 @@ static void gemma_moe_ffn(model_t *m, const layer_t *ly, int n, int xdim) {
     int layer_idx = (int)(ly - m->layers);
     for (int b = 0; b < n; b++) {
         const float *attn = m->x + (size_t)b * n_embd;
-        float xn[n_embd], mlp[n_embd], xn2[n_embd];
+        float *xn = m->gemma_scr, *mlp = xn + n_embd, *xn2 = mlp + n_embd;
         // --- dense shared MLP: rmsnorm(ffn_norm) -> GELU SwiGLU -> post_ffw_norm_1
         rmsnorm(xn, attn, ly->ffn_norm_w, n_embd, m->rms_eps);
         matvec_b(m->tp, m->hb,  dff, ly->w_gate, xn, n_embd, n_embd, dff, NULL, 1);

--- a/src/model.h
+++ b/src/model.h
@@ -194,6 +194,8 @@ typedef struct {
     float    *moe_up;      // [n_ff_exp]
     float    *moe_dexp;    // [n_embd] one expert's down output
     float    *moe_out;     // [n_embd] weighted expert-sum accumulator
+    float    *gemma_scr;   // [4][n_embd] gemma-4 MoE per-token scratch (rin, xn, mlp, xn2);
+                           // heap, not VLAs: the forward runs on 512 KB server threads
     // Grouped-by-expert prefill scratch (sized for a full prompt batch): route
     // all tokens, then run each expert once over ALL its routed tokens as a
     // batched matmul instead of one-at-a-time. Decode (n==1) never uses these.


### PR DESCRIPTION
Sanitizer and static-analysis sweep. Gemma-4 MoE per-token buffers move from variable-length stack arrays (sized by the file's embedding width, on 512 KB server threads) to model-owned heap scratch, byte-identical on the fixtures, with a -Werror=vla gate in test-makefile-sane. Two undefined left shifts of negative values in the Ed25519 carry code become multiplications; known answers pin the bits. Full make test green locally; the whole Python suite ran clean under ASan/UBSan.

Co-Authored-By: Claude Code (Fable 5.1) & Joakimpalm-Zen