### PR TITLE
Release v0.4.10: NVFP4 on CUDA and the bugfix rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,10 @@ analytics landed on the way.
   7.8e-5 (`make test-cuda-nvfp4`).
 - Blackwell matrix with the Makefile's own flags (`CFLAGS` unset): granite-4.1-8b
   load, tokenizer, cpu_cuda and chat pass; gemma-4-E4B complete with cpu_cuda
-  pass; Qwen3-30B-A3B: MOE_ROW.
+  pass; Qwen3-30B-A3B on the CPU path, load and chat pass, tool 2/8
+  (pre-existing shape), cpu_cuda not executed: the other project's runner
+  holds 15.4 GB of the MIG slice, so the GPU load was refused with the VRAM
+  message rather than attempted.
 - Local: make test exit 0, conformance 451 passed and 17 skipped,
   release-check 0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,18 @@ analytics landed on the way.
 
 ## Evidence
 
-- (filled by the release run)
+- CUDA smoke on an RTX 3070: PASS, 13 checks, runner 0.4.10
+  (`docs/compat-reports/cuda-smoke-0.4.10-2026-09-06-rtx3070.json`).
+- NVFP4 on CUDA, same box, release binary: fixture and real Qwen3.5-4B
+  NVFP4 file, CPU and CUDA token-identical, logprobs within 1.4e-6 and
+  7.8e-5 (`make test-cuda-nvfp4`).
+- Blackwell matrix with the Makefile's own flags (`CFLAGS` unset): granite-4.1-8b
+  load, tokenizer, cpu_cuda and chat pass; gemma-4-E4B complete with cpu_cuda
+  pass; Qwen3-30B-A3B: MOE_ROW.
+- Local: make test exit 0, conformance 451 passed and 17 skipped,
+  release-check 0.
+
+Binaries: `runner-linux-x86_64`, `runner-macos-arm64`, `runner-windows-x86_64.exe`, with `SHA256SUMS`. Container: `ghcr.io/joakimpalm-zen/xyntetik-runner:v0.4.10`.
 
 ## v0.4.9 - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ names that were true when they were written.
 
 ## Unreleased
 
+## v0.4.10 - 2026-09-06
+
+The NVFP4-on-CUDA release, with two bugfix rounds. NVIDIA's block-scaled FP4
+format now runs on the CUDA backend with the export's per-tensor scale
+companion applied in the kernel, verified on a real Qwen3.5-4B NVFP4 file
+against the CPU path and against upstream llama.cpp. Two sweeps of the tree
+under the static analyzer, sanitizers and mutation runs fixed a stack overflow
+class in the gemma-4 MoE forward, undefined behaviour in the Ed25519 carry
+code, five special-value defects in the T3 build's portable math, a Windows
+receipt-overwrite failure, and a silently-NaN NVFP4 variant that is now
+refused by name. Publication rule enforcement and the site's ensö note and
+analytics landed on the way.
+
 - **NVFP4 runs on CUDA.** Three kernels (`k_mv_nvfp4`, `k_mv_nvfp4_b`,
   `k_moe_mv_nvfp4`) decode ggml type 40 exactly as the CPU does (UE4M3
   sub-block scale, E2M1 codebook, sub-block sums before scaling), and the
@@ -97,6 +110,10 @@ names that were true when they were written.
   as a local commit-msg hook, and `CLAUDE.md` states the rule where Claude
   Code reads it. Seven commits reached `main` on 2026-09-05 with the harness's
   default session trailer before this existed; history stays as it is.
+
+## Evidence
+
+- (filled by the release run)
 
 ## v0.4.9 - 2026-09-05
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ for Linux, macOS, or Windows, or build from source:
 git clone https://github.com/Joakimpalm-Zen/xyntetik-runner
 cd xyntetik-runner
 make
-./runner --version   # -> runner 0.4.9
+./runner --version   # -> runner 0.4.10
 ```
 
 CUDA builds and releases need only an NVIDIA driver at runtime. The CUDA
@@ -211,7 +211,7 @@ Run a GGUF:
 ./runner -m model.gguf --draft-lookup -f transcript.txt -p "Summarize the text above"
 ```
 
-> **Pre-1.0 (`0.4.9`).** APIs, model coverage and certification envelopes may
+> **Pre-1.0 (`0.4.10`).** APIs, model coverage and certification envelopes may
 > change between releases. CI builds and smoke-tests Linux, macOS, and
 > Windows, but the project still has limited hardware coverage. Include
 > `runner --version`, `runner --caps`, the model's exact filename, and the load
@@ -405,7 +405,7 @@ shell, then run `make`.
 
 Each release publishes a CPU image - the same binary on a distroless glibc base,
 nothing else - to `ghcr.io/joakimpalm-zen/xyntetik-runner:v<version>` (the
-tag carries the `v`, e.g. `:v0.4.9`) and `:latest`. Build it yourself with `docker build -t runner .`.
+tag carries the `v`, e.g. `:v0.4.10`) and `:latest`. Build it yourself with `docker build -t runner .`.
 
 The server binds **loopback only** by design (there is no `--host`/`0.0.0.0`
 flag), so it never exposes itself to a network, even in a container - which

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-Runner is **pre-1.0** (`0.4.9`). Only the latest release is
+Runner is **pre-1.0** (`0.4.10`). Only the latest release is
 supported; there are no backports.
 
 ## Threat model

--- a/docs/compat-reports/0.4.10-2026-09-06-blackwell-gemma-4-e4b-it-q4_k_m.json
+++ b/docs/compat-reports/0.4.10-2026-09-06-blackwell-gemma-4-e4b-it-q4_k_m.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "xyntetik.runner.model-compat-report.v1",
+  "generated_utc": "2026-09-06T13:53:17Z",
+  "host": {
+    "os": "Linux",
+    "machine": "x86_64"
+  },
+  "runner": {
+    "path": "runner",
+    "version": "runner 0.4.10"
+  },
+  "reference": {
+    "path": null,
+    "version": null
+  },
+  "models": [
+    {
+      "id": "gemma-4-e4b-it-q4_k_m",
+      "architecture": "gemma4",
+      "file": "models/gemma-4-E4B-it-Q4_K_M.gguf",
+      "expected_sha256": "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87",
+      "checks": {
+        "load": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 1907.2,
+          "stderr_tail": "gemma4: E-series (per-layer embeddings + shared KV) \u2014 verified against llama.cpp at the Q4_K noise floor rather than token-identically\nrope: using model frequency factors (rope_freqs.weight)\ngpu-split: budget=9.55GB fixed=0.93GB G=42/42 full=1 used=3.76GB\ngpu: CUDA backend on NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition MIG 1g.24gb (5.0 GB weights in VRAM)\ngpu: VRAM 4.29 GB free of 25.37 GB after init (kv 0.23 GB + scratch 0.02 GB this instance)\nloaded /home/lab/workspace/models/gemma-4-E4B-it-Q4_K_M/gemma-4-E4B-it-Q4_K_M.gguf | gemma4 | 42 layers | ctx 4096 | 32 threads | 1.58s\nsampling: gemma3 (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\n\nprompt: 4 tok, 22.04 tok/s | gen: 1 tok, 28.89 tok/s\n"
+        },
+        "cpu_cuda": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 76463.58,
+          "pins": {
+            "RUNNER_CUDA_TC": "0",
+            "RUNNER_MOE_EAGER": "1"
+          },
+          "min_prompt_tokens": 85,
+          "cpu_cuda_identity": {
+            "result": "pass",
+            "exact": "9/9",
+            "near_tie_tolerated": 0
+          },
+          "identical": "9/9",
+          "failed_prompts": [],
+          "report": "docs/compat-reports/cpu_cuda/gemma-4-e4b-it-q4_k_m.json",
+          "output_tail": "'\nok  : 'Q: What is 17 * 23?\\nA:'\nok  : 'The lighthouse keeper recorded the weather every morning: wind direction, cloud cover, and the hour the fog lifted.'\nok  : 'In 1929 the observatory published a revised catalogue listing 4218 objects, of which roughly one in nine turned out on later inspection to be a duplicate entry under a second designation. The correction'\nok  : \"def parse_header(buf, size):\\n    if size < 8:\\n        raise ValueError('short header')\\n    magic, version = struct.unpack('<II', buf[:8])\\n    if magic != GGUF_MAGIC:\\n        raise ValueError('not a gguf file')\\n    return magic, version\\n\\n# The loader above rejects a truncated header before unpacking it, which\"\nok  : 'The city of Lisbon sits on seven hills above the Tagus estuary, and its oldest quarter survived the 1755 earthquake largely intact because the bedrock there is firmer than the reclaimed ground downriver. Rebuilding the lower town took decades, and the grid of streets laid out afterwards was among the first in Europe designed with seismic loads in mind, which is why the district still reads as unusually regular to a visitor who'\n\ncpu_cuda: pass \u2014 9/9 exact, 0 near-tie tolerated (eager routing)\n"
+        },
+        "chat": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 2133.67,
+          "prompt": "What is 2+2?",
+          "gpu": "auto",
+          "failure_reasons": [],
+          "output_tail": "2 + 2 equals **4**.\n"
+        }
+      },
+      "resolved_file": "models/gemma-4-E4B-it-Q4_K_M.gguf",
+      "actual_sha256": "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87",
+      "file_status": "pass",
+      "complete": true
+    }
+  ],
+  "complete": true,
+  "summary": {
+    "models": 1,
+    "files": {
+      "pass": 1
+    },
+    "checks": {
+      "load": {
+        "pass": 1
+      },
+      "cpu_cuda": {
+        "pass": 1
+      },
+      "chat": {
+        "pass": 1
+      }
+    }
+  }
+}

--- a/docs/compat-reports/0.4.10-2026-09-06-blackwell-granite-4.1-8b-q4_0.json
+++ b/docs/compat-reports/0.4.10-2026-09-06-blackwell-granite-4.1-8b-q4_0.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "xyntetik.runner.model-compat-report.v1",
+  "generated_utc": "2026-09-06T13:49:56Z",
+  "host": {
+    "os": "Linux",
+    "machine": "x86_64"
+  },
+  "runner": {
+    "path": "runner",
+    "version": "runner 0.4.10"
+  },
+  "reference": {
+    "path": null,
+    "version": null
+  },
+  "models": [
+    {
+      "id": "granite-4.1-8b-q4_0",
+      "architecture": "granite",
+      "file": "models/granite-4.1-8b-Q4_0.gguf",
+      "expected_sha256": "5adf9b6b78921093bd4a805e1060f85d7f744c3eafc14d1ca449364d1e721a1a",
+      "checks": {
+        "load": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 6963.0,
+          "stderr_tail": "gpu-split: budget=9.55GB fixed=0.81GB G=40/40 full=1 used=5.97GB\ngpu: CUDA backend on NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition MIG 1g.24gb (5.1 GB weights in VRAM)\ngpu: VRAM 3.76 GB free of 25.37 GB after init (kv 0.67 GB + scratch 0.05 GB this instance)\nloaded /home/lab/workspace/models/granite-4.1-8b-Q4_0/granite-4.1-8b-Q4_0.gguf | granite | 40 layers | ctx 4096 | 32 threads | 3.06s\nsampling: generic (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\n\nprompt: 3 tok, 0.79 tok/s | gen: 1 tok, 61.80 tok/s\n"
+        },
+        "tokenizer": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 2353.3,
+          "stdout_tail": "\n0/721 strings differ (0 of them begin with whitespace)\nOK\n",
+          "stderr_tail": "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+        },
+        "cpu_cuda": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 176354.86,
+          "pins": {
+            "RUNNER_CUDA_TC": "0"
+          },
+          "min_prompt_tokens": 85,
+          "cpu_cuda_identity": {
+            "result": "pass",
+            "exact": "9/9",
+            "near_tie_tolerated": 0
+          },
+          "identical": "9/9",
+          "failed_prompts": [],
+          "report": "docs/compat-reports/cpu_cuda/granite-4.1-8b-q4_0.json",
+          "output_tail": "'\nok  : 'Q: What is 17 * 23?\\nA:'\nok  : 'The lighthouse keeper recorded the weather every morning: wind direction, cloud cover, and the hour the fog lifted.'\nok  : 'In 1929 the observatory published a revised catalogue listing 4218 objects, of which roughly one in nine turned out on later inspection to be a duplicate entry under a second designation. The correction'\nok  : \"def parse_header(buf, size):\\n    if size < 8:\\n        raise ValueError('short header')\\n    magic, version = struct.unpack('<II', buf[:8])\\n    if magic != GGUF_MAGIC:\\n        raise ValueError('not a gguf file')\\n    return magic, version\\n\\n# The loader above rejects a truncated header before unpacking it, which\"\nok  : 'The city of Lisbon sits on seven hills above the Tagus estuary, and its oldest quarter survived the 1755 earthquake largely intact because the bedrock there is firmer than the reclaimed ground downriver. Rebuilding the lower town took decades, and the grid of streets laid out afterwards was among the first in Europe designed with seismic loads in mind, which is why the district still reads as unusually regular to a visitor who'\n\ncpu_cuda: pass \u2014 9/9 exact, 0 near-tie tolerated (eager routing)\n"
+        },
+        "chat": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 2221.92,
+          "prompt": "What is 2+2?",
+          "gpu": "auto",
+          "failure_reasons": [],
+          "output_tail": "The answer to the mathematical expression 2 + 2 is 4.\n"
+        },
+        "greedy_reference": {
+          "status": "not_executed",
+          "reason": "reference_binary_not_provided"
+        }
+      },
+      "resolved_file": "models/granite-4.1-8b-Q4_0.gguf",
+      "actual_sha256": "5adf9b6b78921093bd4a805e1060f85d7f744c3eafc14d1ca449364d1e721a1a",
+      "file_status": "pass",
+      "complete": false
+    }
+  ],
+  "complete": false,
+  "summary": {
+    "models": 1,
+    "files": {
+      "pass": 1
+    },
+    "checks": {
+      "load": {
+        "pass": 1
+      },
+      "tokenizer": {
+        "pass": 1
+      },
+      "cpu_cuda": {
+        "pass": 1
+      },
+      "chat": {
+        "pass": 1
+      },
+      "greedy_reference": {
+        "not_executed": 1
+      }
+    }
+  }
+}

--- a/docs/compat-reports/0.4.10-2026-09-06-blackwell-qwen3-30b-a3b-q4_k_m.json
+++ b/docs/compat-reports/0.4.10-2026-09-06-blackwell-qwen3-30b-a3b-q4_k_m.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "xyntetik.runner.model-compat-report.v1",
+  "generated_utc": "2026-09-06T14:12:42Z",
+  "host": {
+    "os": "Linux",
+    "machine": "x86_64"
+  },
+  "runner": {
+    "path": "runner",
+    "version": "runner 0.4.10"
+  },
+  "reference": {
+    "path": null,
+    "version": null
+  },
+  "models": [
+    {
+      "id": "qwen3-30b-a3b-q4_k_m",
+      "architecture": "qwen3moe",
+      "file": "models/Qwen3-30B-A3B-Q4_K_M.gguf",
+      "expected_sha256": "0d003f6662faee786ed5da3e31b29c978de5ae5d275c8794c606a7f3c01aa8f5",
+      "checks": {
+        "load": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 178.1,
+          "stderr_tail": "loaded /home/lab/workspace/models/Qwen3-30B-A3B-Q4_K_M/Qwen3-30B-A3B-Q4_K_M.gguf | qwen3moe | 48 layers | ctx 4096 | 32 threads | 0.02s\nsampling: qwen3 (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\n\nprompt: 3 tok, 25.33 tok/s | gen: 1 tok, 30.63 tok/s\n"
+        },
+        "cpu_cuda": {
+          "status": "not_executed",
+          "reason": "insufficient_vram",
+          "detail": "error: 19.3GB of VRAM requested on GPU-399aa5c7-bb47-5ccb-b688-54fefec06647, but only 9.6GB is available",
+          "elapsed_ms": 35587.82,
+          "pins": {
+            "RUNNER_CUDA_TC": "0",
+            "RUNNER_MOE_EAGER": "1"
+          },
+          "report": "docs/compat-reports/cpu_cuda/qwen3-30b-a3b-q4_k_m.json"
+        },
+        "chat": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 581.47,
+          "prompt": "What is 2+2?",
+          "gpu": "off",
+          "failure_reasons": [],
+          "output_tail": "2 + 2 = 4.\n"
+        },
+        "tool": {
+          "status": "fail",
+          "returncode": 1,
+          "elapsed_ms": 21215.04,
+          "scenario_matrix": "agent-torture",
+          "totals": {
+            "requests": 8,
+            "passed": 2,
+            "failed": 6
+          },
+          "report": "docs/compat-reports/tool/qwen3-30b-a3b-q4_k_m.json",
+          "output_tail": "report: docs/compat-reports/tool/qwen3-30b-a3b-q4_k_m/report.json\nraw: docs/compat-reports/tool/qwen3-30b-a3b-q4_k_m/raw.jsonl\nruntime=runner requests=8 passed=2 failed=6\n"
+        },
+        "greedy_reference": {
+          "status": "not_executed",
+          "reason": "reference_binary_not_provided"
+        },
+        "long_context": {
+          "status": "not_executed",
+          "reason": "check_class_not_executable"
+        }
+      },
+      "resolved_file": "models/Qwen3-30B-A3B-Q4_K_M.gguf",
+      "actual_sha256": "0d003f6662faee786ed5da3e31b29c978de5ae5d275c8794c606a7f3c01aa8f5",
+      "file_status": "pass",
+      "complete": false
+    }
+  ],
+  "complete": false,
+  "summary": {
+    "models": 1,
+    "files": {
+      "pass": 1
+    },
+    "checks": {
+      "load": {
+        "pass": 1
+      },
+      "cpu_cuda": {
+        "not_executed": 1
+      },
+      "chat": {
+        "pass": 1
+      },
+      "tool": {
+        "fail": 1
+      },
+      "greedy_reference": {
+        "not_executed": 1
+      },
+      "long_context": {
+        "not_executed": 1
+      }
+    }
+  }
+}

--- a/docs/compat-reports/cuda-smoke-0.4.10-2026-09-06-rtx3070.json
+++ b/docs/compat-reports/cuda-smoke-0.4.10-2026-09-06-rtx3070.json
@@ -1,0 +1,103 @@
+{
+  "checks": [
+    {
+      "check": "cuda_backend_present",
+      "detail": "caps.gpu.backend = 'cuda' (expected 'cuda'; absent means the CUDA driver never initialised)",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "version_matches",
+      "detail": "caps.version = '0.4.10', expected '0.4.10'",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_memory_is_boolean",
+      "detail": "caps.gpu.unified_memory = False",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_memory_agrees_with_pool_sizes",
+      "detail": "unified_memory=False with vram_bytes=8589279232 and ram_bytes=17109143552 (vram/ram = 0.502, one pool expected >= 0.85)",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_flag_not_suspiciously_false",
+      "detail": "unified_memory=False with vram/ram = 0.502",
+      "ok": true,
+      "severity": "warn"
+    },
+    {
+      "check": "vram_reported",
+      "detail": "vram_bytes = 8589279232",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "gpu_quants_present",
+      "detail": "gpu_quants has 17 entries",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "gpu_quants_subset_of_quants",
+      "detail": "every gpu_quant is loadable",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "generation_exit_zero",
+      "detail": "runner exited 0",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "gpu_engaged_for_generation",
+      "detail": "load output carries the CUDA backend line",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "tokens_generated",
+      "detail": "generated 24 tokens",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "layers_offloaded",
+      "detail": "gpu-split G=28/28",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_notice_matches_caps",
+      "detail": "load output omits the unified-memory notice while caps said False",
+      "ok": true,
+      "severity": "fail"
+    }
+  ],
+  "generation_output": "gpu-split: budget=7.46GB fixed=0.72GB G=28/28 full=1 used=1.66GB\r\ngpu: CUDA backend on NVIDIA GeForce RTX 3070 (0.6 GB weights in VRAM)\r\ngpu: VRAM 6.32 GB free of 8.59 GB after init (kv 0.47 GB + scratch 0.02 GB this instance)\r\nloaded C:/Users/zen/qwen3-0.6b-q8_0.gguf | qwen3 | 28 layers | ctx 4096 | 4 threads | 0.48s\r\nsampling: qwen3 (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\r\nThe capital of France is Paris. The capital of France is also the capital of the Republic of France. The capital of France is also the capital\r\nprompt: 5 tok, 185.53 tok/s | gen: 24 tok, 270.21 tok/s\r\n\r\n",
+  "gpu": {
+    "backend": "cuda",
+    "eseries": true,
+    "kv_q8": true,
+    "min_compute_capability": "7.5",
+    "min_gpu": "NVIDIA Turing / compute capability 7.5 or newer",
+    "moe": true,
+    "name": "NVIDIA GeForce RTX 3070",
+    "ptx_target": "sm_75",
+    "unified_memory": false,
+    "vram_bytes": 8589279232,
+    "vram_free_bytes": 7459569664
+  },
+  "host": {
+    "arch": "x86_64",
+    "os": "windows",
+    "ram_bytes": 17109143552
+  },
+  "passed": true,
+  "runner_version": "0.4.10"
+}

--- a/docs/moe-support.md
+++ b/docs/moe-support.md
@@ -1,7 +1,7 @@
 # Sparse-MoE support — implementation and test report
 
 Date: 2026-07-24
-Runner: v0.4.9 (core support plus the follow-ups at the end of this doc)
+Runner: v0.4.10 (core support plus the follow-ups at the end of this doc)
 Hardware: NVIDIA RTX PRO 6000 Blackwell, **24 GB MIG slice** (`MIG 1g.24gb`),
 CPU fallback on the same host (64 threads).
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xyntetik-runner-client"
-version = "0.4.9"
+version = "0.4.10"
 description = "Python client and process boundary for Xyntetik Runner"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/runner.h
+++ b/src/runner.h
@@ -2,7 +2,7 @@
 #ifndef RUNNER_H
 #define RUNNER_H
 
-#define RUNNER_VERSION "0.4.9"
+#define RUNNER_VERSION "0.4.10"
 #define RUNNER_CUDA_NVCC_ARCH "compute_75"
 #define RUNNER_CUDA_PTX_TARGET "sm_75"
 #define RUNNER_CUDA_MIN_CC "7.5"


### PR DESCRIPTION
Version pins, the v0.4.10 changelog entry with its evidence, and the compat reports: CUDA smoke PASS 13 checks on the RTX 3070 (runner 0.4.10), NVFP4 CUDA gate green on the fixture and a real Qwen3.5-4B file, Blackwell matrix granite-4.1-8b (cpu_cuda 9/9) and gemma-4-E4B complete, Qwen3-30B-A3B on the CPU path (the other project holds the MIG slice's VRAM). Local make test exit 0, conformance 451 passed 17 skipped, release-check 0. Tag follows the merge.

Co-Authored-By: Claude Code (Fable 5.1) & Joakimpalm-Zen