### PR TITLE
pages: rebuild the site when CHANGELOG.md changes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - "site/**"
       - ".github/workflows/pages.yml"
+      # the site takes its version and release date from the changelog
+      - "CHANGELOG.md"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The site takes its version and release date from CHANGELOG.md, but the pages workflow only ran on site/ changes, so v0.4.10 left xyntetik.com on v0.4.9 until a manual dispatch. CHANGELOG.md joins the trigger paths.

Co-Authored-By: Claude Code (Fable 5.1) & Joakimpalm-Zen