### PR TITLE
release: v0.5.1, the new-model release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ names that were true when they were written.
 
 ## Unreleased
 
+## v0.5.1 - 2026-09-06
+
+The new-model release. Granite 4.2 (3B, 8B) and Qwen 3.8 27B are admitted,
+each with its own chat template family rendered from the publisher's
+template and checked token for token, and each measured against the
+publisher's own implementation in float32 rather than only against a
+second engine. That measurement changed how this project certifies: the
+model publisher's reference is now the primary anchor (AGENTS.md), and the
+README and the site say in one sentence why Runner is slower than the
+fastest engines and why that is the point. Two runner fixes came out of
+measuring the backends: an explicit layer split is no longer refused on a
+shared GPU, and the CPU-vs-GPU identity check can no longer report a GPU
+arm that silently ran on the CPU as a pass.
+
 - **Granite 4.2 (3B, 8B) admitted.** The architecture is 4.1's; the header
   and the template are not. The `granite-docling` pre-tokenizer name maps
   to the GPT-2 family rule, which now uses the regex's `\p{L}` letter class
@@ -77,6 +91,20 @@ names that were true when they were written.
 - New BPE fixture cases (curly apostrophe, Devanagari marks, digit runs)
   for the GPT-2, llama3, qwen2 and qwen35 rules, and a
   `vocab-bpe-granite-docling.gguf` fixture.
+- **The provider's reference implementation is the primary anchor**
+  (standing rule, AGENTS.md, with the Granite 4.2 3B proof), and the
+  README's "why" section and the site's landing page carry the one-sentence
+  version: Runner is slower on purpose, it does the model's arithmetic
+  without the shortcuts faster engines take, so its answers stay closer to
+  what the model's makers built, and it can prove what it produced. The
+  evidence page carries the numbers behind that sentence.
+- Backends measured for both families: Granite 4.2 CPU vs CUDA on a
+  Blackwell MIG slice (3B 9/9, 8B 8/9 with the flip on a 0.0019-nat tie)
+  and on an RTX 3070 (8B 9/9, full offload), CPU vs Metal on an M1 (3B 8/9,
+  the flip on a 0.0008-nat tie); Qwen 3.8's `qwen35` CUDA path 9/9 on the
+  pure Q8_0 and plain Q4_0 siblings under explicit splits. The Unsloth
+  UD-Q4_K_M row carries IQ3_S tensors, a CPU-only type here, so a CUDA box
+  runs that file on the CPU; the row says so. `qwen35` has no Metal path.
 
 ## v0.4.10 - 2026-09-06
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ for Linux, macOS, or Windows, or build from source:
 git clone https://github.com/Joakimpalm-Zen/xyntetik-runner
 cd xyntetik-runner
 make
-./runner --version   # -> runner 0.4.10
+./runner --version   # -> runner 0.5.1
 ```
 
 CUDA builds and releases need only an NVIDIA driver at runtime. The CUDA
@@ -223,7 +223,7 @@ Run a GGUF:
 ./runner -m model.gguf --draft-lookup -f transcript.txt -p "Summarize the text above"
 ```
 
-> **Pre-1.0 (`0.4.10`).** APIs, model coverage and certification envelopes may
+> **Pre-1.0 (`0.5.1`).** APIs, model coverage and certification envelopes may
 > change between releases. CI builds and smoke-tests Linux, macOS, and
 > Windows, but the project still has limited hardware coverage. Include
 > `runner --version`, `runner --caps`, the model's exact filename, and the load
@@ -417,7 +417,7 @@ shell, then run `make`.
 
 Each release publishes a CPU image - the same binary on a distroless glibc base,
 nothing else - to `ghcr.io/joakimpalm-zen/xyntetik-runner:v<version>` (the
-tag carries the `v`, e.g. `:v0.4.10`) and `:latest`. Build it yourself with `docker build -t runner .`.
+tag carries the `v`, e.g. `:v0.5.1`) and `:latest`. Build it yourself with `docker build -t runner .`.
 
 The server binds **loopback only** by design (there is no `--host`/`0.0.0.0`
 flag), so it never exposes itself to a network, even in a container - which

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-Runner is **pre-1.0** (`0.4.10`). Only the latest release is
+Runner is **pre-1.0** (`0.5.1`). Only the latest release is
 supported; there are no backports.
 
 ## Threat model

--- a/docs/compat-reports/0.5.1-2026-09-06-blackwell-granite-4.2-3b-q4_k_m.json
+++ b/docs/compat-reports/0.5.1-2026-09-06-blackwell-granite-4.2-3b-q4_k_m.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "xyntetik.runner.model-compat-report.v1",
+  "generated_utc": "2026-09-06T19:48:36Z",
+  "host": {
+    "os": "Linux",
+    "machine": "x86_64"
+  },
+  "runner": {
+    "path": "runner",
+    "version": "runner 0.5.1"
+  },
+  "reference": {
+    "path": "llama-server",
+    "version": "version: 0.4.0-dev (build 1, commit 73a43d1)"
+  },
+  "models": [
+    {
+      "id": "granite-4.2-3b-q4_k_m",
+      "architecture": "granite",
+      "file": "models/granite-4.2-3b-Q4_K_M.gguf",
+      "expected_sha256": "e0406663965846ae22a403456eb826ccce5f450840491f71952f18a7cb78e7d5",
+      "checks": {
+        "load": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 952.8,
+          "stderr_tail": "gpu-split: budget=9.55GB fixed=0.73GB G=40/40 full=1 used=2.95GB\ngpu: CUDA backend on NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition MIG 1g.24gb (2.2 GB weights in VRAM)\ngpu: VRAM 6.91 GB free of 25.37 GB after init (kv 0.34 GB + scratch 0.05 GB this instance)\nloaded /home/lab/workspace/models/granite-4.2/granite-4.2-3b-Q4_K_M.gguf | granite | 40 layers | ctx 4096 | 32 threads | 0.72s\nsampling: generic (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\n\nprompt: 3 tok, 26.89 tok/s | gen: 1 tok, 46.31 tok/s\n"
+        },
+        "tokenizer": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 472.9,
+          "stdout_tail": "\n0/721 strings differ (0 of them begin with whitespace)\nOK\n",
+          "stderr_tail": ""
+        },
+        "cpu_cuda": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 56079.91,
+          "pins": {
+            "RUNNER_CUDA_TC": "0"
+          },
+          "min_prompt_tokens": 85,
+          "cpu_cuda_identity": {
+            "result": "pass",
+            "exact": "9/9",
+            "near_tie_tolerated": 0
+          },
+          "identical": "9/9",
+          "failed_prompts": [],
+          "report": "docs/compat-reports/cpu_cuda/granite-4.2-3b-q4_k_m.json",
+          "output_tail": "'\nok  : 'Q: What is 17 * 23?\\nA:'\nok  : 'The lighthouse keeper recorded the weather every morning: wind direction, cloud cover, and the hour the fog lifted.'\nok  : 'In 1929 the observatory published a revised catalogue listing 4218 objects, of which roughly one in nine turned out on later inspection to be a duplicate entry under a second designation. The correction'\nok  : \"def parse_header(buf, size):\\n    if size < 8:\\n        raise ValueError('short header')\\n    magic, version = struct.unpack('<II', buf[:8])\\n    if magic != GGUF_MAGIC:\\n        raise ValueError('not a gguf file')\\n    return magic, version\\n\\n# The loader above rejects a truncated header before unpacking it, which\"\nok  : 'The city of Lisbon sits on seven hills above the Tagus estuary, and its oldest quarter survived the 1755 earthquake largely intact because the bedrock there is firmer than the reclaimed ground downriver. Rebuilding the lower town took decades, and the grid of streets laid out afterwards was among the first in Europe designed with seismic loads in mind, which is why the district still reads as unusually regular to a visitor who'\n\ncpu_cuda: pass \u2014 9/9 exact, 0 near-tie tolerated (eager routing)\n"
+        },
+        "chat": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 1083.63,
+          "prompt": "What is 2+2?",
+          "gpu": "auto",
+          "failure_reasons": [],
+          "output_tail": "2 + 2 = 4.\n"
+        },
+        "greedy_reference": {
+          "status": "fail",
+          "returncode": 1,
+          "elapsed_ms": 6975.8,
+          "stdout_tail": "{\n  \"schema_version\": \"xyntetik.runner.greedy-reference.v1\",\n  \"generated_utc\": \"2026-09-06T19:49:43Z\",\n  \"runner\": \"runner 0.5.1\",\n  \"reference\": \"version: 0.4.0-dev (build 1, commit 73a43d1)\",\n  \"model\": \"/home/lab/workspace/models/granite-4.2/granite-4.2-3b-Q4_K_M.gguf\",\n  \"tokens\": 8,\n  \"comparison\": \"exact generated UTF-8 text from /v1/completions at temperature 0\",\n  \"comparisons\": [\n    {\n      \"prompt\": \"The capital of France is\",\n      \"runner\": \" Paris.\\\" is true.\\n\\nSentence\",\n      \"reference\": \" Paris.\\\" is true.\\n\\nWe\",\n      \"status\": \"fail\"\n    },\n    {\n      \"prompt\": \"def fibonacci(n):\",\n      \"runner\": \"\\n    if n == 0:\",\n      \"reference\": \"\\n    if n == 0:\",\n      \"status\": \"pass\"\n    },\n    {\n      \"prompt\": \"1 2 3 4 5 6 7 8\",\n      \"runner\": \" 9 10 11 12\",\n      \"reference\": \" 9 10 11 12\",\n      \"status\": \"pass\"\n    },\n    {\n      \"prompt\": \"Once upon a time, in a land far away,\",\n      \"runner\": \" there was a village called Harmony. The\",\n      \"reference\": \" there was a kingdom called...\\\"\\n\\n\",\n      \"status\": \"fail\"\n    },\n    {\n      \"prompt\": \"JSON example: {\\\"name\\\":\",\n      \"runner\": \" \\\"John\\\", \\\"age\\\": 30\",\n      \"reference\": \" \\\"John\\\", \\\"age\\\": 30\",\n      \"status\": \"pass\"\n    }\n  ],\n  \"totals\": {\n    \"passed\": 3,\n    \"failed\": 2\n  }\n}\n",
+          "stderr_tail": ""
+        }
+      },
+      "resolved_file": "models/granite-4.2-3b-Q4_K_M.gguf",
+      "actual_sha256": "e0406663965846ae22a403456eb826ccce5f450840491f71952f18a7cb78e7d5",
+      "file_status": "pass",
+      "complete": false
+    }
+  ],
+  "complete": false,
+  "summary": {
+    "models": 1,
+    "files": {
+      "pass": 1
+    },
+    "checks": {
+      "load": {
+        "pass": 1
+      },
+      "tokenizer": {
+        "pass": 1
+      },
+      "cpu_cuda": {
+        "pass": 1
+      },
+      "chat": {
+        "pass": 1
+      },
+      "greedy_reference": {
+        "fail": 1
+      }
+    }
+  }
+}

--- a/docs/compat-reports/0.5.1-2026-09-06-blackwell-granite-4.2-8b-q4_k_m.json
+++ b/docs/compat-reports/0.5.1-2026-09-06-blackwell-granite-4.2-8b-q4_k_m.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "xyntetik.runner.model-compat-report.v1",
+  "generated_utc": "2026-09-06T19:49:43Z",
+  "host": {
+    "os": "Linux",
+    "machine": "x86_64"
+  },
+  "runner": {
+    "path": "runner",
+    "version": "runner 0.5.1"
+  },
+  "reference": {
+    "path": "llama-server",
+    "version": "version: 0.4.0-dev (build 1, commit 73a43d1)"
+  },
+  "models": [
+    {
+      "id": "granite-4.2-8b-q4_k_m",
+      "architecture": "granite",
+      "file": "models/granite-4.2-8b-Q4_K_M.gguf",
+      "expected_sha256": "16a9369d0805f80b7377d25d87f937a90c05dc04ad79173a52001e42c9aab311",
+      "checks": {
+        "load": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 1369.4,
+          "stderr_tail": "gpu-split: budget=9.55GB fixed=0.81GB G=40/40 full=1 used=6.26GB\ngpu: CUDA backend on NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition MIG 1g.24gb (5.3 GB weights in VRAM)\ngpu: VRAM 3.47 GB free of 25.37 GB after init (kv 0.67 GB + scratch 0.05 GB this instance)\nloaded /home/lab/workspace/models/granite-4.2/granite-4.2-8b-Q4_K_M.gguf | granite | 40 layers | ctx 4096 | 32 threads | 0.96s\nsampling: generic (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\n\nprompt: 3 tok, 11.33 tok/s | gen: 1 tok, 26.21 tok/s\n"
+        },
+        "tokenizer": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 519.3,
+          "stdout_tail": "\n0/721 strings differ (0 of them begin with whitespace)\nOK\n",
+          "stderr_tail": "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+        },
+        "cpu_cuda": {
+          "status": "fail",
+          "returncode": 1,
+          "elapsed_ms": 111233.77,
+          "pins": {
+            "RUNNER_CUDA_TC": "0"
+          },
+          "min_prompt_tokens": 85,
+          "cpu_cuda_identity": {
+            "result": "fail",
+            "exact": "8/9",
+            "near_tie_tolerated": 0
+          },
+          "identical": "8/9",
+          "failed_prompts": [
+            "'The capital of France is'"
+          ],
+          "report": "docs/compat-reports/cpu_cuda/granite-4.2-8b-q4_k_m.json",
+          "output_tail": "'\nok  : 'Q: What is 17 * 23?\\nA:'\nok  : 'The lighthouse keeper recorded the weather every morning: wind direction, cloud cover, and the hour the fog lifted.'\nok  : 'In 1929 the observatory published a revised catalogue listing 4218 objects, of which roughly one in nine turned out on later inspection to be a duplicate entry under a second designation. The correction'\nok  : \"def parse_header(buf, size):\\n    if size < 8:\\n        raise ValueError('short header')\\n    magic, version = struct.unpack('<II', buf[:8])\\n    if magic != GGUF_MAGIC:\\n        raise ValueError('not a gguf file')\\n    return magic, version\\n\\n# The loader above rejects a truncated header before unpacking it, which\"\nok  : 'The city of Lisbon sits on seven hills above the Tagus estuary, and its oldest quarter survived the 1755 earthquake largely intact because the bedrock there is firmer than the reclaimed ground downriver. Rebuilding the lower town took decades, and the grid of streets laid out afterwards was among the first in Europe designed with seismic loads in mind, which is why the district still reads as unusually regular to a visitor who'\n\ncpu_cuda: fail \u2014 8/9 exact, 0 near-tie tolerated (eager routing)\n"
+        },
+        "chat": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 1707.66,
+          "prompt": "What is 2+2?",
+          "gpu": "auto",
+          "failure_reasons": [],
+          "output_tail": "2 + 2 = 4.\n"
+        },
+        "greedy_reference": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 8292.7,
+          "stdout_tail": "{\n  \"schema_version\": \"xyntetik.runner.greedy-reference.v1\",\n  \"generated_utc\": \"2026-09-06T19:51:49Z\",\n  \"runner\": \"runner 0.5.1\",\n  \"reference\": \"version: 0.4.0-dev (build 1, commit 73a43d1)\",\n  \"model\": \"/home/lab/workspace/models/granite-4.2/granite-4.2-8b-Q4_K_M.gguf\",\n  \"tokens\": 8,\n  \"comparison\": \"exact generated UTF-8 text from /v1/completions at temperature 0\",\n  \"comparisons\": [\n    {\n      \"prompt\": \"The capital of France is\",\n      \"runner\": \" Paris.\\\"\\n\\nBut the user says\",\n      \"reference\": \" Paris.\\\"\\n\\nBut the user says\",\n      \"status\": \"pass\"\n    },\n    {\n      \"prompt\": \"def fibonacci(n):\",\n      \"runner\": \"\\n    if n < 0:\",\n      \"reference\": \"\\n    if n < 0:\",\n      \"status\": \"pass\"\n    },\n    {\n      \"prompt\": \"1 2 3 4 5 6 7 8\",\n      \"runner\": \" 9 10 11 12\",\n      \"reference\": \" 9 10 11 12\",\n      \"status\": \"pass\"\n    },\n    {\n      \"prompt\": \"Once upon a time, in a land far away,\",\n      \"runner\": \" there was a small village nestled in the\",\n      \"reference\": \" there was a small village nestled in the\",\n      \"status\": \"pass\"\n    },\n    {\n      \"prompt\": \"JSON example: {\\\"name\\\":\",\n      \"runner\": \" \\\"John\\\", \\\"age\\\": 30\",\n      \"reference\": \" \\\"John\\\", \\\"age\\\": 30\",\n      \"status\": \"pass\"\n    }\n  ],\n  \"totals\": {\n    \"passed\": 5,\n    \"failed\": 0\n  }\n}\n",
+          "stderr_tail": ""
+        }
+      },
+      "resolved_file": "models/granite-4.2-8b-Q4_K_M.gguf",
+      "actual_sha256": "16a9369d0805f80b7377d25d87f937a90c05dc04ad79173a52001e42c9aab311",
+      "file_status": "pass",
+      "complete": false
+    }
+  ],
+  "complete": false,
+  "summary": {
+    "models": 1,
+    "files": {
+      "pass": 1
+    },
+    "checks": {
+      "load": {
+        "pass": 1
+      },
+      "tokenizer": {
+        "pass": 1
+      },
+      "cpu_cuda": {
+        "fail": 1
+      },
+      "chat": {
+        "pass": 1
+      },
+      "greedy_reference": {
+        "pass": 1
+      }
+    }
+  }
+}

--- a/docs/compat-reports/0.5.1-2026-09-06-blackwell-qwen3.8-27b-ud-q4_k_m.json
+++ b/docs/compat-reports/0.5.1-2026-09-06-blackwell-qwen3.8-27b-ud-q4_k_m.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "xyntetik.runner.model-compat-report.v1",
+  "generated_utc": "2026-09-06T19:51:49Z",
+  "host": {
+    "os": "Linux",
+    "machine": "x86_64"
+  },
+  "runner": {
+    "path": "runner",
+    "version": "runner 0.5.1"
+  },
+  "reference": {
+    "path": "llama-server",
+    "version": "version: 0.4.0-dev (build 1, commit 73a43d1)"
+  },
+  "models": [
+    {
+      "id": "qwen3.8-27b-ud-q4_k_m",
+      "architecture": "qwen35",
+      "file": "models/Qwen3.8-27B-UD-Q4_K_M.gguf",
+      "expected_sha256": "322e194ff79741c7baa497c240f677f54b201b0efab44ca8e50f122b39123482",
+      "checks": {
+        "load": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 590.9,
+          "stderr_tail": "loaded /home/lab/workspace/models/qwen3.8/Qwen3.8-27B-UD-Q4_K_M.gguf | qwen35 | 64 layers | ctx 4096 | 32 threads | 0.03s\nmtp: 1 predictor block(s) declared, excluded from the backbone; not consumed (pass --mtp to draft from it)\nsampling: qwen3 (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\n\nprompt: 3 tok, 7.78 tok/s | gen: 1 tok, 6.27 tok/s\n"
+        },
+        "tokenizer": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 638.4,
+          "stdout_tail": "\n0/721 strings differ (0 of them begin with whitespace)\nOK\n",
+          "stderr_tail": "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+        },
+        "cpu_cuda": {
+          "status": "not_executed",
+          "reason": "insufficient_vram",
+          "detail": "error: 17.5GB of VRAM requested on GPU-399aa5c7-bb47-5ccb-b688-54fefec06647, but only 9.6GB is available",
+          "elapsed_ms": 200609.38,
+          "pins": {
+            "RUNNER_CUDA_TC": "0"
+          },
+          "report": "docs/compat-reports/cpu_cuda/qwen3.8-27b-ud-q4_k_m.json"
+        },
+        "chat": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 2876.13,
+          "prompt": "What is 2+2?",
+          "gpu": "off",
+          "failure_reasons": [],
+          "output_tail": "2 + 2 = **4**\n"
+        },
+        "greedy_reference": {
+          "status": "pass",
+          "returncode": 0,
+          "elapsed_ms": 25181.2,
+          "stdout_tail": "{\n  \"schema_version\": \"xyntetik.runner.greedy-reference.v1\",\n  \"generated_utc\": \"2026-09-06T19:55:46Z\",\n  \"runner\": \"runner 0.5.1\",\n  \"reference\": \"version: 0.4.0-dev (build 1, commit 73a43d1)\",\n  \"model\": \"/home/lab/workspace/models/qwen3.8/Qwen3.8-27B-UD-Q4_K_M.gguf\",\n  \"tokens\": 8,\n  \"comparison\": \"exact generated UTF-8 text from /v1/completions at temperature 0\",\n  \"comparisons\": [\n    {\n      \"prompt\": \"The capital of France is\",\n      \"runner\": \" Paris.\\nThe capital of Germany is\",\n      \"reference\": \" Paris.\\nThe capital of Germany is\",\n      \"status\": \"pass\"\n    },\n    {\n      \"prompt\": \"def fibonacci(n):\",\n      \"runner\": \"\\n    if n <= 0:\",\n      \"reference\": \"\\n    if n <= 0:\",\n      \"status\": \"pass\"\n    },\n    {\n      \"prompt\": \"1 2 3 4 5 6 7 8\",\n      \"runner\": \" 9 10 11\",\n      \"reference\": \" 9 10 11\",\n      \"status\": \"pass\"\n    },\n    {\n      \"prompt\": \"Once upon a time, in a land far away,\",\n      \"runner\": \" there was a young adventurer named Lily.\",\n      \"reference\": \" there was a young adventurer named Lily.\",\n      \"status\": \"pass\"\n    },\n    {\n      \"prompt\": \"JSON example: {\\\"name\\\":\",\n      \"runner\": \" \\\"John\\\", \\\"age\\\": 3\",\n      \"reference\": \" \\\"John\\\", \\\"age\\\": 3\",\n      \"status\": \"pass\"\n    }\n  ],\n  \"totals\": {\n    \"passed\": 5,\n    \"failed\": 0\n  }\n}\n",
+          "stderr_tail": ""
+        }
+      },
+      "resolved_file": "models/Qwen3.8-27B-UD-Q4_K_M.gguf",
+      "actual_sha256": "322e194ff79741c7baa497c240f677f54b201b0efab44ca8e50f122b39123482",
+      "file_status": "pass",
+      "complete": false
+    }
+  ],
+  "complete": false,
+  "summary": {
+    "models": 1,
+    "files": {
+      "pass": 1
+    },
+    "checks": {
+      "load": {
+        "pass": 1
+      },
+      "tokenizer": {
+        "pass": 1
+      },
+      "cpu_cuda": {
+        "not_executed": 1
+      },
+      "chat": {
+        "pass": 1
+      },
+      "greedy_reference": {
+        "pass": 1
+      }
+    }
+  }
+}

--- a/docs/compat-reports/cuda-smoke-0.5.1-2026-09-06-rtx3070.json
+++ b/docs/compat-reports/cuda-smoke-0.5.1-2026-09-06-rtx3070.json
@@ -1,0 +1,103 @@
+{
+  "checks": [
+    {
+      "check": "cuda_backend_present",
+      "detail": "caps.gpu.backend = 'cuda' (expected 'cuda'; absent means the CUDA driver never initialised)",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "version_matches",
+      "detail": "caps.version = '0.5.1', expected '0.5.1'",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_memory_is_boolean",
+      "detail": "caps.gpu.unified_memory = False",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_memory_agrees_with_pool_sizes",
+      "detail": "unified_memory=False with vram_bytes=8589279232 and ram_bytes=17109143552 (vram/ram = 0.502, one pool expected >= 0.85)",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_flag_not_suspiciously_false",
+      "detail": "unified_memory=False with vram/ram = 0.502",
+      "ok": true,
+      "severity": "warn"
+    },
+    {
+      "check": "vram_reported",
+      "detail": "vram_bytes = 8589279232",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "gpu_quants_present",
+      "detail": "gpu_quants has 17 entries",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "gpu_quants_subset_of_quants",
+      "detail": "every gpu_quant is loadable",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "generation_exit_zero",
+      "detail": "runner exited 0",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "gpu_engaged_for_generation",
+      "detail": "load output carries the CUDA backend line",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "tokens_generated",
+      "detail": "generated 24 tokens",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "layers_offloaded",
+      "detail": "gpu-split G=28/28",
+      "ok": true,
+      "severity": "fail"
+    },
+    {
+      "check": "unified_notice_matches_caps",
+      "detail": "load output omits the unified-memory notice while caps said False",
+      "ok": true,
+      "severity": "fail"
+    }
+  ],
+  "generation_output": "gpu-split: budget=7.46GB fixed=0.72GB G=28/28 full=1 used=1.66GB\r\ngpu: CUDA backend on NVIDIA GeForce RTX 3070 (0.6 GB weights in VRAM)\r\ngpu: VRAM 6.32 GB free of 8.59 GB after init (kv 0.47 GB + scratch 0.02 GB this instance)\r\nloaded C:/Users/zen/qwen3-0.6b-q8_0.gguf | qwen3 | 28 layers | ctx 4096 | 4 threads | 0.50s\r\nsampling: qwen3 (temp 0.00 \u2014 greedy argmax; top_p/top_k/min_p/repeat_penalty inactive)\r\nThe capital of France is Paris. The capital of France is also the capital of the Republic of France. The capital of France is also the capital\r\nprompt: 5 tok, 188.48 tok/s | gen: 24 tok, 259.15 tok/s\r\n\r\n",
+  "gpu": {
+    "backend": "cuda",
+    "eseries": true,
+    "kv_q8": true,
+    "min_compute_capability": "7.5",
+    "min_gpu": "NVIDIA Turing / compute capability 7.5 or newer",
+    "moe": true,
+    "name": "NVIDIA GeForce RTX 3070",
+    "ptx_target": "sm_75",
+    "unified_memory": false,
+    "vram_bytes": 8589279232,
+    "vram_free_bytes": 7459569664
+  },
+  "host": {
+    "arch": "x86_64",
+    "os": "windows",
+    "ram_bytes": 17109143552
+  },
+  "passed": true,
+  "runner_version": "0.5.1"
+}

--- a/docs/moe-support.md
+++ b/docs/moe-support.md
@@ -1,7 +1,7 @@
 # Sparse-MoE support — implementation and test report
 
 Date: 2026-07-24
-Runner: v0.4.10 (core support plus the follow-ups at the end of this doc)
+Runner: v0.5.1 (core support plus the follow-ups at the end of this doc)
 Hardware: NVIDIA RTX PRO 6000 Blackwell, **24 GB MIG slice** (`MIG 1g.24gb`),
 CPU fallback on the same host (64 threads).
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xyntetik-runner-client"
-version = "0.4.10"
+version = "0.5.1"
 description = "Python client and process boundary for Xyntetik Runner"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/runner.h
+++ b/src/runner.h
@@ -2,7 +2,7 @@
 #ifndef RUNNER_H
 #define RUNNER_H
 
-#define RUNNER_VERSION "0.4.10"
+#define RUNNER_VERSION "0.5.1"
 #define RUNNER_CUDA_NVCC_ARCH "compute_75"
 #define RUNNER_CUDA_PTX_TARGET "sm_75"
 #define RUNNER_CUDA_MIN_CC "7.5"


### PR DESCRIPTION
v0.5.1: Granite 4.2 (3B, 8B) and Qwen 3.8 27B admitted with their own chat template families, the provider-reference rule, the landing-page sentence, the VRAM split fix and the identity-check hardening. Everything was already on main; this branch carries the pins, the changelog section and the release evidence.

Gates on the release build:
- `make test` green on the M1; conformance 451 passed, 17 skipped.
- CUDA smoke gate on the RTX 3070: PASS, 13 checks (`docs/compat-reports/cuda-smoke-0.5.1-2026-09-06-rtx3070.json`); NVFP4 gate ok (fixture 1.4e-6, real file 7.8e-5); Windows pytest leg 15 passed.
- Blackwell matrix rows executed for the three new files (`docs/compat-reports/0.5.1-2026-09-06-blackwell-*.json`).
- `make release-check` exit 0.