### PR TITLE
R8.7.4: the Windows suite was red for the harness, not the engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,10 @@ names that were true when they were written.
   `tests/test_lora.py`, self-skipping without a device. Deleting one of the
   seven hooks leaves every relative gate green and only the merged-weights
   comparison red, which is why that one is the anchor.
-- **The suite is green on Windows.** It had not been run there in a while and
-  read 8 failed / 1 error, all of them the harness rather than the engine, and
+- **The suite is green on Windows.** `make OS=Windows_NT -j2 test` exits 0 on
+  the CUDA box again, and the Python suite reads 1130 passed / 67 skipped / 0
+  failed. It had not been run there since 2026-08-13 and read 8 failed / 1
+  error, all of them the harness rather than the engine, and
   all invisible to CI, which builds Windows and does not run `make test`
   there. That box is also the lab's only CUDA device, so the CUDA gates were
   unreachable behind them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,40 @@ names that were true when they were written.
   `tests/test_lora.py`, self-skipping without a device. Deleting one of the
   seven hooks leaves every relative gate green and only the merged-weights
   comparison red, which is why that one is the anchor.
-- **`make test` builds on Windows again.** `tests/test_gpu_identity.c` and
-  `tests/test_moe_mm_ab.c` called `setenv`, which MinGW does not have, so the
-  suite stopped at a compile error on the box that runs the CUDA gates. Both
-  now use the `setenv_compat` shim the other tests use. CI builds Windows but
-  does not run `make test` there, which is why it went unseen.
+- **The suite is green on Windows.** It had not been run there in a while and
+  read 8 failed / 1 error, all of them the harness rather than the engine, and
+  all invisible to CI, which builds Windows and does not run `make test`
+  there. That box is also the lab's only CUDA device, so the CUDA gates were
+  unreachable behind them.
+  - `tests/test_gpu_identity.c` and `tests/test_moe_mm_ab.c` called `setenv`,
+    which MinGW does not have, so the suite stopped at a compile error before
+    running anything. Both now use the `setenv_compat` shim the other tests
+    use.
+  - `scripts/weight-io-bench.py` used `os.pread`, `mmap`'s Unix-only
+    `flags`/`prot` arguments, and page-aligned mapping offsets. It now uses a
+    positioned-read shim that names itself in the output (`read_call`), the
+    portable `access=ACCESS_READ` mapping, `O_BINARY` so a weight file is not
+    newline-translated, and offsets aligned to the mapping granularity, which
+    is 64 KB on Windows and the page size everywhere else, so both measured
+    paths still sample the same regions.
+  - `scripts/kv-quality.py` reached for `os.killpg` in its server teardown.
+    That raises `AttributeError` on Windows, which the `OSError` handler
+    beside it did not catch, so the teardown failed instead of falling back.
+    It now stops the tree with `taskkill /T` there, and writes its log to
+    `tempfile.gettempdir()` rather than `/tmp`. `scripts/compat_matrix.py`
+    had the same gap as a documented no-op, which leaks a served runner per
+    timeout on exactly that box (three were found resident); it uses the same
+    tree kill now.
+  - The conformance harness treated a test-supplied `env` as a full
+    replacement. On Windows a process without `SystemRoot` cannot initialise
+    Winsock and exits 1 before printing anything, so `test_prefill_deadline`
+    read as a broken server. A replaced environment now still carries what
+    the platform requires.
+  - `tool-choice-boundary.py` records the sha of the template TEXT, and the
+    test compared it against the file's BYTES, which differ under CRLF. The
+    text hash is the right one (the prompt is built from the decoded string,
+    so a checkout that rewrote line endings must not change a record's
+    identity); the test and the script now say so.
 - **`scripts/ptx-attribute.py`.** Regenerating the PTX header renumbers
   registers, labels and local depots across the whole file, so the diff cannot
   say which kernels actually changed. The script normalizes that numbering and

--- a/docs/windows-remote-checks.md
+++ b/docs/windows-remote-checks.md
@@ -120,8 +120,9 @@ rather than the engine:
 | `conformance/test_prefill_deadline.py` | a test-supplied `env` replaced the inherited one; without `SystemRoot` a process cannot initialise Winsock and exits 1 before printing anything |
 | `test_caps.py` | `--caps` has advertised NVFP4 on CUDA since 2026-09-06 and the expected list had not admitted it (the check only runs where a backend exists, and CI has no GPU) |
 
-All fixed the same day; the suite reads **1130 passed, 67 skipped, 0 failed**
-here now. The general lesson is the one worth keeping: **CI builds Windows and
+All fixed the same day. `make OS=Windows_NT -j2 test` **exits 0** here again
+(C gates plus 525 + 47 + 28 + 20 passed across the Python legs), and the
+Python suite on its own reads **1130 passed, 67 skipped, 0 failed**. The general lesson is the one worth keeping: **CI builds Windows and
 never runs the suite there**, so a Windows-only harness defect is invisible
 until somebody uses this box, and this box is the only CUDA device in the lab.
 Whether that becomes a CI job or a scheduled run on the box is open (suite

--- a/docs/windows-remote-checks.md
+++ b/docs/windows-remote-checks.md
@@ -103,3 +103,35 @@ at the first object. Build from msys bash instead
 `make` output to a file there, and echo `$?` so the exit code comes back
 on stdout. A fresh checkout at `4731dc0` built this way in under a minute
 with `make OS=Windows_NT -j4 runner`.
+
+## The suite on this box, 2026-09-07
+
+Ran again for the first time since 2026-08-13 and it did not build: `setenv`
+is not in MinGW, so `tests/test_gpu_identity.c` and `tests/test_moe_mm_ab.c`
+stopped `make test` at a compile error. Past that, the Python half read
+**1107 passed, 8 failed, 1 error** on `main`, every one of them the harness
+rather than the engine:
+
+| what | why it is Windows-only |
+|---|---|
+| `test_weight_io_bench.py` x5 | `os.pread` does not exist; `mmap`'s `flags`/`prot` are Unix-only; a mapping offset must be 64 KB-aligned, not page-aligned; `os.open` needs `O_BINARY` or a weight file is newline-translated |
+| `test_kv_quality.py` | `os.killpg` does not exist, and it raises `AttributeError`, which the `OSError` fallback beside it did not catch |
+| `test_tool_choice_boundary.py` | the record hashes the template TEXT, the test hashed the file BYTES, and `write_text` lands CRLF |
+| `conformance/test_prefill_deadline.py` | a test-supplied `env` replaced the inherited one; without `SystemRoot` a process cannot initialise Winsock and exits 1 before printing anything |
+| `test_caps.py` | `--caps` has advertised NVFP4 on CUDA since 2026-09-06 and the expected list had not admitted it (the check only runs where a backend exists, and CI has no GPU) |
+
+All fixed the same day; the suite reads **1130 passed, 67 skipped, 0 failed**
+here now. The general lesson is the one worth keeping: **CI builds Windows and
+never runs the suite there**, so a Windows-only harness defect is invisible
+until somebody uses this box, and this box is the only CUDA device in the lab.
+Whether that becomes a CI job or a scheduled run on the box is open (suite
+plan R8.7.4).
+
+Two operational notes from the same session. Running the suite under
+`schtasks` fails wholesale: the task's session cannot create
+`%LOCALAPPDATA%\Temp\pytest-of-zen`, so every `tmp_path` test errors
+(363 of them) for a reason that has nothing to do with the code. Run it from
+the interactive ssh session instead, and detach only what is genuinely long.
+And check for a leftover `runner.exe` before trusting a conformance failure:
+an interrupted run leaves a server holding its port, and the next run reports
+`runner exited during startup` with an empty log.

--- a/scripts/compat_matrix.py
+++ b/scripts/compat_matrix.py
@@ -36,7 +36,17 @@ SCHEMA_VERSIONS = ("xyntetik.runner.model-compat.v1",
 def _kill_group(pid, grace=2.0):
     """Kill one process GROUP, servers included."""
     if os.name == "nt":
-        return                       # no process groups; Popen.kill is all there is
+        # No process groups to signal, but the grandchildren are the whole
+        # point: `taskkill /T` walks the tree, and without it a timeout on
+        # this box leaks a served runner exactly the way the docstring below
+        # describes for POSIX (observed 2026-09-07: three resident servers).
+        try:
+            subprocess.run(["taskkill", "/T", "/F", "/PID", str(pid)],
+                           stdout=subprocess.DEVNULL,
+                           stderr=subprocess.DEVNULL, timeout=30)
+        except (OSError, subprocess.SubprocessError):
+            pass
+        return
     for sig in (signal.SIGTERM, signal.SIGKILL):
         try:
             os.killpg(os.getpgid(pid), sig)

--- a/scripts/kv-quality.py
+++ b/scripts/kv-quality.py
@@ -47,6 +47,7 @@ import signal
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.request
@@ -333,6 +334,37 @@ def score_tool_call(call, want_name, want_args):
 
 # -------------------------------------------------------------------- http
 
+def stop_tree(proc, hard):
+    """Stop a served runner and anything it spawned.
+
+    POSIX: the child was given its own session, so signalling the group
+    reaches grandchildren a bare terminate() would orphan. Windows has no
+    process groups to signal and no killpg to call at all -- reaching for it
+    there raised AttributeError, which the OSError handler below did not
+    catch, so the teardown failed instead of falling back. `taskkill /T`
+    walks the tree; terminate()/kill() is the last resort.
+    """
+    if hasattr(os, "killpg") and hasattr(os, "getpgid"):
+        try:
+            os.killpg(os.getpgid(proc.pid),
+                      signal.SIGKILL if hard else signal.SIGTERM)
+            return
+        except OSError:
+            pass
+    else:
+        try:
+            subprocess.run(["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                           stdout=subprocess.DEVNULL,
+                           stderr=subprocess.DEVNULL, timeout=30)
+            return
+        except (OSError, subprocess.SubprocessError):
+            pass
+    if hard:
+        proc.kill()
+    else:
+        proc.terminate()
+
+
 class Server:
     def __init__(self, binary, model, ctx, kv, port, gpu="auto", verbose=False):
         self.binary, self.model, self.ctx = binary, model, ctx
@@ -343,7 +375,7 @@ class Server:
         self.model_id = None
 
     def __enter__(self):
-        logdir = Path(os.environ.get("TMPDIR", "/tmp"))
+        logdir = Path(os.environ.get("TMPDIR") or tempfile.gettempdir())
         logpath = logdir / ("kvq-%s-%d.log" % (self.kv, self.port))
         self.log = open(logpath, "w")
         cmd = [str(Path(self.binary).resolve()), "--serve", "--no-tray",
@@ -372,17 +404,11 @@ class Server:
 
     def __exit__(self, *exc):
         if self.proc and self.proc.poll() is None:
-            try:
-                os.killpg(os.getpgid(self.proc.pid), signal.SIGTERM)
-            except OSError:
-                self.proc.terminate()
+            stop_tree(self.proc, hard=False)
             try:
                 self.proc.wait(timeout=60)
             except subprocess.TimeoutExpired:
-                try:
-                    os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
-                except OSError:
-                    self.proc.kill()
+                stop_tree(self.proc, hard=True)
         if self.log:
             self.log.close()
         return False

--- a/scripts/tool-choice-boundary.py
+++ b/scripts/tool-choice-boundary.py
@@ -247,6 +247,10 @@ def cmd_run(args):
         template = open(args.template, encoding="utf-8").read()
         if template.count("%s") != 1:
             sys.exit("--template must contain exactly one %s for the request")
+    # The sha of the template TEXT, not of the file's bytes: the prompt is
+    # built from the decoded string, so two files differing only in line
+    # endings produce the same prompt and must record the same sha. A file
+    # hash would make a record's identity depend on how git checked it out.
     template_sha = hashlib.sha256(template.encode()).hexdigest()
     version = runner_version(args.runner) if args.runner else None
     hashes = {}

--- a/scripts/weight-io-bench.py
+++ b/scripts/weight-io-bench.py
@@ -38,15 +38,47 @@ import time
 
 DEFAULT_SLICE = 8 * 1024 * 1024
 F_NOCACHE = 48  # <sys/fcntl.h>, macOS only
+# Windows opens in text mode by default, which would translate CRLF inside
+# binary weights and make every byte count a lie rather than an error.
+O_BINARY = getattr(os, "O_BINARY", 0)
 
 
 def page_size():
+    """Fault granularity: what one page fault brings in."""
     return mmap.PAGESIZE
+
+
+def map_alignment():
+    """What a mapping offset must be a multiple of.
+
+    The same as the page size everywhere except Windows, where a mapping
+    starts on a 64 KB allocation granule. Both measured paths use offsets
+    aligned to this, because the comparison is only meaningful if the two
+    read the same regions.
+    """
+    return mmap.ALLOCATIONGRANULARITY
+
+
+if hasattr(os, "pread"):
+    READ_CALL = "pread"
+
+    def positioned_read(fd, want, at):
+        return os.pread(fd, want, at)
+else:
+    # No pread on Windows. A seek plus a read is the same bytes from the same
+    # place for this single-threaded loop; it is one extra syscall per part,
+    # which the output names so a cross-platform diff is not read as a
+    # storage difference.
+    READ_CALL = "lseek+read"
+
+    def positioned_read(fd, want, at):
+        os.lseek(fd, at, os.SEEK_SET)
+        return os.read(fd, want)
 
 
 def open_uncached(path):
     """Open for reading and ask the OS not to cache, where that is supported."""
-    fd = os.open(path, os.O_RDONLY | getattr(os, "O_CLOEXEC", 0))
+    fd = os.open(path, os.O_RDONLY | O_BINARY | getattr(os, "O_CLOEXEC", 0))
     uncached = False
     if sys.platform == "darwin":
         try:
@@ -57,22 +89,35 @@ def open_uncached(path):
     return fd, uncached
 
 
+def map_slice(fd, length, offset):
+    """One read-only private mapping of [offset, offset+length).
+
+    The keyword arguments are not portable: Unix takes flags/prot, Windows
+    takes access. ACCESS_READ is the private read-only mapping on both.
+    """
+    return mmap.mmap(fd, length, access=mmap.ACCESS_READ, offset=offset)
+
+
 def offsets(size, slice_bytes, count, stride_seed):
-    """Deterministic page-aligned offsets that do not repeat or cross EOF.
+    """Deterministic aligned offsets that do not repeat or cross EOF.
 
     Scattered rather than sequential, because a run of adjacent reads lets
     readahead answer most of them and measures the cache instead of the device.
     An odd stride coprime with the position count walks the whole file without
     revisiting one, and stays reproducible so a number can be re-derived.
+
+    Aligned to map_alignment() rather than the page size: the mapped path
+    cannot start anywhere else on Windows, and the two paths have to sample
+    the same offsets for their ratio to mean anything.
     """
     span = size - slice_bytes
     if span <= 0:
         raise SystemExit(
             f"file is {size} B, smaller than one {slice_bytes} B slice")
-    page = page_size()
+    page = map_alignment()
     positions = span // page
     if positions < 1:
-        raise SystemExit("file leaves no page-aligned slice offsets")
+        raise SystemExit("file leaves no aligned slice offsets")
     step = stride_seed % positions or 1
     while positions > 1 and _gcd(step, positions) != 1:
         step += 1
@@ -126,7 +171,7 @@ def measure_read(path, slice_bytes, samples, warmup, stride_seed, parts):
                 want = part_bytes
                 at = offset + part * part_bytes
                 while want:
-                    chunk = os.pread(fd, want, at)
+                    chunk = positioned_read(fd, want, at)
                     if not chunk:
                         raise SystemExit(f"short read at offset {at}")
                     buffer[got:got + len(chunk)] = chunk
@@ -139,7 +184,8 @@ def measure_read(path, slice_bytes, samples, warmup, stride_seed, parts):
     finally:
         os.close(fd)
     return _summarize(durations, slice_bytes,
-                      {"parts_per_slice": parts, "uncached": uncached})
+                      {"parts_per_slice": parts, "uncached": uncached,
+                       "read_call": READ_CALL})
 
 
 def measure_faults(path, slice_bytes, samples, warmup, stride_seed):
@@ -147,13 +193,12 @@ def measure_faults(path, slice_bytes, samples, warmup, stride_seed):
     size = os.path.getsize(path)
     page = page_size()
     durations = []
-    fd = os.open(path, os.O_RDONLY | getattr(os, "O_CLOEXEC", 0))
+    fd = os.open(path, os.O_RDONLY | O_BINARY | getattr(os, "O_CLOEXEC", 0))
     try:
         for index, offset in enumerate(
                 offsets(size, slice_bytes, samples + warmup, stride_seed)):
             start = time.perf_counter()
-            view = mmap.mmap(fd, slice_bytes, flags=mmap.MAP_PRIVATE,
-                             prot=mmap.PROT_READ, offset=offset)
+            view = map_slice(fd, slice_bytes, offset)
             try:
                 total = 0
                 for at in range(0, slice_bytes, page):
@@ -191,7 +236,7 @@ def main():
                         help="any large file; a GGUF weight file is typical")
     parser.add_argument("--slice-bytes", type=int, default=DEFAULT_SLICE)
     parser.add_argument("--parts", type=int, default=1,
-                        help="split each slice into N pread calls")
+                        help="split each slice into N positioned reads")
     parser.add_argument("--samples", type=int, default=200)
     parser.add_argument("--warmup", type=int, default=8)
     parser.add_argument("--stride-seed", type=int, default=104729)
@@ -210,6 +255,7 @@ def main():
         "file_bytes": os.path.getsize(args.file),
         "slice_bytes": args.slice_bytes,
         "page_bytes": page_size(),
+        "map_alignment_bytes": map_alignment(),
         "platform": sys.platform,
         "cache_probe": cache_probe(args.file, args.slice_bytes, args.parts),
         "read_path": measure_read(args.file, args.slice_bytes, args.samples,

--- a/tests/conformance/_process.py
+++ b/tests/conformance/_process.py
@@ -92,7 +92,21 @@ class RunnerServer:
         # the reaper's 5 s poll is a wall-clock tax on every TTL/reload gate
         # (32 tests, 3.8 min); a test that needs the shipped cadence passes
         # env with its own RUNNER_TTL_POLL_S
-        env = dict(self.env if self.env is not None else os.environ)
+        # A caller-supplied env REPLACES the inherited one, so a test can pin
+        # exactly the RUNNER_* variables it means. Windows needs a handful of
+        # its own regardless: without SystemRoot the process cannot initialise
+        # Winsock and exits 1 before printing anything, which reads as "the
+        # server is broken here" rather than "the environment was too empty".
+        if self.env is not None:
+            env = dict(self.env)
+            if os.name == "nt":
+                for key in ("SystemRoot", "SystemDrive", "windir", "COMSPEC",
+                            "PATH", "PATHEXT", "TEMP", "TMP",
+                            "NUMBER_OF_PROCESSORS"):
+                    if key not in env and key in os.environ:
+                        env[key] = os.environ[key]
+        else:
+            env = dict(os.environ)
         env.setdefault("RUNNER_TTL_POLL_S", "0.25")
         self.proc = subprocess.Popen(argv, stdout=self._log,
                                      stderr=subprocess.STDOUT, env=env)

--- a/tests/test_tool_choice_boundary.py
+++ b/tests/test_tool_choice_boundary.py
@@ -194,8 +194,11 @@ def test_run_records_every_prompt_per_condition(runner_bin, model, tmp_path):
         assert x["model"] == "test.gguf"
         assert x["runner_version"].startswith("runner ")
         assert x["tools"] == m.TOOLS
+        # the decoded text, which is what the prompt is built from, not the
+        # file bytes: on Windows write_text() lands CRLF and the two differ
+        # while the prompt does not
         assert x["template_sha256"] == hashlib.sha256(
-            template.read_bytes()).hexdigest()
+            template.read_text().encode()).hexdigest()
         assert isinstance(x["all_decisions"], list)
         assert x["n_decisions"] == len(x["all_decisions"])
         assert "decision" in x and "full_call" in x

--- a/tests/test_weight_io_bench.py
+++ b/tests/test_weight_io_bench.py
@@ -25,6 +25,8 @@ spec.loader.exec_module(bench)
 @pytest.fixture
 def sample(tmp_path):
     path = tmp_path / "weights.bin"
+    # comfortably larger than one mapping granule on every platform, so both
+    # paths have offsets to scatter over
     path.write_bytes(os.urandom(4 * 1024 * 1024))
     return path
 
@@ -42,9 +44,12 @@ def test_offsets_are_page_aligned_and_in_bounds():
 
 def test_offsets_do_not_repeat_while_positions_remain():
     # A stride sharing a factor with the position count revisits a handful of
-    # offsets and would measure a warm cache instead of the device.
-    page = bench.page_size()
-    got = bench.offsets(80 * page, 4 * page, 30, 8)
+    # offsets and would measure a warm cache instead of the device. Sized in
+    # mapping granules, not pages: on Windows a granule is 64 KB, and a file
+    # sized in 4 KB pages leaves too few positions for the property to be
+    # about the stride at all.
+    granule = bench.map_alignment()
+    got = bench.offsets(80 * granule, 4 * granule, 30, 8)
     assert len(set(got)) == len(got)
 
 
@@ -56,6 +61,8 @@ def test_offsets_refuse_a_file_smaller_than_one_slice():
 def test_read_path_reports_consistent_totals(sample):
     result = bench.measure_read(str(sample), 64 * 1024, 5, 1, 104729, 1)
     assert result["samples"] == 5
+    # names which call shape produced the number, since Windows has no pread
+    assert result["read_call"] in ("pread", "lseek+read")
     assert result["total_bytes"] == 5 * 64 * 1024
     assert result["min_bytes_per_second"] <= result["p50_bytes_per_second"]
     assert result["p50_bytes_per_second"] <= result["max_bytes_per_second"]


### PR DESCRIPTION
The suite had not been run on ZEN-GAMING since 2026-08-13. It did not build there, and past that read **1107 passed / 8 failed / 1 error** on `main`. Every one of them was the test harness rather than the engine, and every one was invisible to CI, which builds Windows and does not run `make test` there. That box is also the lab's only CUDA device, so the CUDA gates sat behind them.

It now reads **1130 passed, 67 skipped, 0 failed, 0 errors**.

| what | why it was Windows-only |
|---|---|
| `test_gpu_identity.c`, `test_moe_mm_ab.c` | `setenv` is not in MinGW, so `make test` stopped at a compile error (fixed in #54) |
| `test_weight_io_bench.py` x5 | `os.pread`; `mmap`'s Unix-only `flags`/`prot`; a mapping offset must sit on a 64 KB granule, not a page; `os.open` without `O_BINARY` newline-translates a weight file |
| `test_kv_quality.py` | `os.killpg` raises `AttributeError`, which the `OSError` fallback beside it did not catch, so the teardown failed instead of falling back |
| `test_tool_choice_boundary.py` | the record hashes the template TEXT, the test hashed the file BYTES, and `write_text` lands CRLF |
| `conformance/test_prefill_deadline.py` | a test-supplied `env` replaced the inherited one; without `SystemRoot` a process cannot initialise Winsock and exits 1 before printing anything |
| `test_caps.py` | `--caps` has advertised NVFP4 on CUDA since 2026-09-06 and the expected list had not admitted it (fixed in #54) |

## Notes on the two judgement calls

**The positioned read names itself.** Windows has no `pread`, so the read path seeks and reads: the same bytes from the same place for a single-threaded loop, but one more syscall per part. The output carries `read_call` so a cross-platform diff is not read as a storage difference. Both measured paths keep the same offsets, which is the only reason their ratio means anything, so the alignment change applies to both.

**The template sha stays the text hash.** The prompt is built from the decoded string, so two files differing only in line endings produce the same prompt and must record the same sha; a file hash would make a published record's identity depend on how git checked it out. The test was wrong, not the script, and both now say which one it is.

**`compat_matrix.py` came along.** Its Windows branch was a deliberate no-op whose own docstring explains what leaking a served runner per timeout costs. Three were found resident on that box the same day, so it uses the same `taskkill /T` tree kill. No test covered it; this is a latent fix, called out rather than slipped in.

`docs/windows-remote-checks.md` carries the table and the two operational traps found on the way: a `schtasks` session cannot create pytest's temp root, so 363 tests error for a reason unrelated to the code; and a leftover `runner.exe` makes the next conformance run report a server that exited during startup with an empty log.

The structural question is filed as suite R8.7.5 rather than answered here: nineteen days passed between the last Windows run and this one, and nothing in CI would have shortened that.