### PR TITLE
A refused run should not leave a tray holding the executable

### DIFF
--- a/docs/windows-remote-checks.md
+++ b/docs/windows-remote-checks.md
@@ -136,3 +136,14 @@ the interactive ssh session instead, and detach only what is genuinely long.
 And check for a leftover `runner.exe` before trusting a conformance failure:
 an interrupted run leaves a server holding its port, and the next run reports
 `runner exited during startup` with an empty log.
+
+One such leftover was not an interrupted run. `tests/test_draft_required.py`
+exercises `-i --draft-required`, and an interactive run whose stdin is a
+terminal raises the detached tray at `main.c`'s `tray_ensure_running()`
+BEFORE the check that refuses the flag combination, so a run that failed its
+own arguments left a `runner --tray` resident, holding the executable open
+against the next relink. The test now passes `--no-tray` like every other. The
+ordering itself is an engine question and is filed rather than changed here:
+the comment beside that call already says a process that is about to be short
+should not leave a menu-bar icon behind it, and a refused invocation is the
+shortest one there is. It only shows on a tty, so CI cannot see it either.

--- a/tests/test_draft_required.py
+++ b/tests/test_draft_required.py
@@ -53,9 +53,15 @@ def unusable_draft(tmp_path_factory):
 
 
 def _run(runner_bin, model, extra):
+    # --no-tray: one of these runs is interactive (-i), and an interactive
+    # run whose stdin is a terminal raises the detached tray BEFORE the
+    # --draft-required check refuses it. Under an ssh session with a tty that
+    # left a `runner --tray` resident after the suite, holding the executable
+    # open against the next relink. The ordering is the engine's to fix; these
+    # tests never wanted a tray.
     return subprocess.run(
         [runner_bin, "-m", str(model), "-p", PROMPT, "-n", "1",
-         "-t", "2", "--gpu", "off", *extra],
+         "-t", "2", "--gpu", "off", "--no-tray", *extra],
         cwd=ROOT, env=dict(os.environ),
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=120)
 


### PR DESCRIPTION
The suite ran green on the Windows box and still left one `runner --tray` resident.

It was not an interrupted run. `tests/test_draft_required.py` exercises `-i --draft-required`, and an interactive run whose stdin is a terminal reaches `tray_ensure_running()` in `main.c` **before** the check that refuses that flag combination. The tray is detached, so it outlived the suite and held `runner.exe` open against the next relink, which is the same failure `aa359e2` fixed once from a different direction.

The test passes `--no-tray` now, like every other test that starts the runner. It never wanted a tray.

**The ordering is the engine's and is written down rather than changed here.** The comment beside that call already states the intent it violates: "a two-second process should not leave a menu-bar icon behind it", and an invocation refused by its own argument check is the shortest one there is. Moving the raise past the remaining validation would change when the icon appears for legitimate runs too, which is a product decision with its own gates (`test_tray_core.c`, R9.4), so it is a note in `docs/windows-remote-checks.md` and not a change in this PR.

It only reproduces where stdin or stdout is a terminal, so CI cannot see it either way.

Verified on the box: full Python suite 1130 passed / 67 skipped / 0 failed, and `tasklist` clean afterwards.