### PR TITLE
Scope the train/infer identity claim, and price what closing it would buy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ names that were true when they were written.
 
 ## Unreleased
 
+- **The train/infer identity claim is scoped, because shipping `--lora` on the
+  GPU narrowed it.** "The policy you sample is the policy you train, by
+  construction" is the CPU codepath's property: the trainer tapes the host
+  forward. Serving that adapter on CUDA is a different forward, agreeing to
+  within the engine's measured envelope (1.255e-3 max |dlogprob| on
+  Qwen2.5-1.5B Q4_K_M) rather than by construction. The combination was
+  impossible while `--lora` refused a GPU-resident model; it is possible now,
+  so the limit is written down on all three surfaces instead of implied.
+- **The remaining CUDA training work is priced.** After the position grid, a
+  7B step is 31.8 s taped forward plus 20.0 s recompute of 64.8 s, both on the
+  CPU; the attention backward is 0.88 s and the optimizer 0.04 s. Measured
+  with `--score` as the instrument (its default path is one solo forward per
+  position, which is what the tape does): the solo forward is 7.3x faster on
+  an RTX 3070 than on 8 CPU threads, the batched forward 2.9x, which puts a
+  step near 23 s. `docs/adaptation-engine.md` carries the table and the two
+  ways to spend it.
+
 - **`--lora` runs on the GPU (R8.7.2).** An offloaded block's activations
   never reach the host, so the adapter used to refuse a GPU-resident model
   outright. Two kernels now apply the same `y += scale*B(Ax)` on the device

--- a/README.md
+++ b/README.md
@@ -318,7 +318,10 @@ used for inference**. There is no FP16 training copy and no separate
 training framework: the serving forward pass is the training forward pass,
 so **the policy you sample is the policy you train** - the train/infer
 numerical mismatch that silently breaks on-policy learning cannot occur
-between two codepaths that are one codepath. And training is deterministic
+between two codepaths that are one codepath. That identity is the CPU
+codepath's: the trainer tapes the host forward, so it holds exactly for an
+adapter served on the CPU, and within the engine's measured CPU/GPU envelope
+(1.255e-3 max \|Δlogprob\| on Qwen2.5-1.5B Q4_K_M) for one served on CUDA. And training is deterministic
 in the strongest sense: same data + same seed + same config produce a
 **byte-identical adapter file**, with a machine-written provenance record
 (base/data/adapter sha256s, seed, full config) beside every adapter -

--- a/docs/adaptation-engine.md
+++ b/docs/adaptation-engine.md
@@ -27,6 +27,20 @@ discipline from "prove what it said" to "prove what it learned from."
 
 Both claims are gated, not asserted (see D5 below).
 
+**The scope of the first claim, stated because it narrowed.** "One codepath"
+means the CPU codepath: the trainer keeps the model CPU-resident and unbound,
+so the forward it tapes is the CPU forward. Serving that adapter on the CPU
+is the case the claim covers exactly. Serving it on CUDA is not: the device
+forward reduces in a different order, measured at 1.255e-3 max |Δlogprob| on
+Qwen2.5-1.5B Q4_K_M against the host path, adapter or no adapter. That gap
+was unreachable while `--lora` refused a GPU-resident model; R8.7.2 made the
+combination possible, so the limit is written here rather than implied. It is
+a property of the base forward, not of the adapter: an adapter trained on the
+CPU and served on CUDA is as correct as the engine's CPU/GPU agreement, which
+is measured and bounded, and is NOT the by-construction identity above.
+Closing it means moving the trainer's forward onto the device, which is a
+separate piece of work with its own reproducibility question.
+
 ## D1 — `--score`: teacher-forced logprobs
 
 Per-token log P(token | prefix) over raw text, plus NLL and perplexity, as
@@ -137,7 +151,11 @@ adjoint fails at relative error 1.36.
 
 Declared scope, fail-closed by property: CPU, dense SiLU transformers, f16
 KV. Recurrent architectures, MoE, sliding windows, per-head norms and head
-transforms refuse with a named reason.
+transforms refuse with a named reason. The CPU in that list is the backward's
+own host, and it is also what scopes the train/infer identity claim above: an
+adapter this backward produced is bit-for-bit the policy a CPU forward
+samples, and within the engine's measured CPU/GPU envelope of the policy a
+CUDA forward samples.
 
 ## D4 — `--train`: the loop
 
@@ -403,6 +421,56 @@ because the forward it tapes has to be the forward inference runs, and
 the CUDA inference path is not bit-identical to the CPU one. Moving it is
 a T1-to-T2 trade (token-exact rather than byte-exact), not an
 optimization, and it belongs to the owner rather than to a profile.
+
+## D8 slice 5, priced not built: the forward is the whole remaining bill
+
+After slice 4, a training step is not backward-bound. Measured on the same
+RTX 3070 box (Qwen2.5-7B Q4_K_M, rank 8, ctx 128, `RUNNER_TRAIN_PROF=1`), the
+64.8 s step is 31.8 s taped forward plus 20.0 s recompute, both of them on
+the CPU because the trainer keeps the model unbound, and 12.8 s of everything
+else. The attention backward is 0.88 s of it and the AdamW step 0.04 s, so
+the piece a plan would naturally reach for next is worth about 1%.
+
+What the device would buy was measured rather than estimated, using `--score`
+as the instrument: its default path runs ONE SOLO FORWARD PER POSITION, which
+is exactly what the tape does, and `RUNNER_SCORE_CHUNKED=1` runs the batched
+pass the recompute resembles. 152 positions, same file, same host, two runs
+each:
+
+| phase, and its proxy | CPU, 8 threads | RTX 3070 | ratio |
+|---|---:|---:|---:|
+| solo forwards (the tape) | 36 s | 5 s | **7.3x** |
+| batched forward (the recompute) | 13 s | 4.5 s | **2.9x** |
+
+Scaled onto the 128-position step: the taped forward would go 31.8 s to about
+4.2 s and the recompute 20.0 s to about 6 s, putting a step near **23 s**,
+which is 2.8x today's GPU-assisted 64.8 s and 3.3x the 76.5 s CPU-only run.
+Both proxies include model load and are therefore conservative.
+
+That prize is not free, and the cost is the reproducibility tier rather than
+the work. The trainer's forward is CPU-resident on purpose (see the scope
+note at the top), and the device forward reduces in a different order. There
+are two ways to spend it and they are genuinely different products:
+
+- **Take T2.** Use the shipped CUDA forward. Adapters stop being byte-identical
+  to a CPU run and become token-exact instead. The identity claim moves from
+  the CPU to CUDA, which is where a GPU owner serves anyway.
+- **Keep T1.** Build a reference-exact forward the way slices 1 and 4 built
+  the backward's: a serial fmaf chain per output element, parallelised over
+  the dimensions that are free (output rows, and positions where the call has
+  them), tiled through shared memory so the global loads still coalesce. The
+  reason to expect this to cost little is that a batch-1 forward is
+  bandwidth-bound, not reduction-bound: a 7B Q4_K_M forward reads about 4.4 GB
+  of weights, so 128 of them move ~560 GB, and the 3070's 448 GB/s puts the
+  floor near 1.3 s whatever order the accumulation runs in. The industry's
+  determinism tax (batch-invariant kernels, roughly 61.5% of throughput) is a
+  large-batch serving number and does not obviously apply here.
+
+Slice 1 already established the harder half of the second option: a GPU
+kernel bit-identical to a CPU reference, on seven weight types. It is a
+stronger property than the same-device reproducibility the literature aims
+at, and it is the one this engine is for. Which option to take is the
+owner's, and the number above is what it is being spent on.
 
 ## D9 — `--merge-lora`: folding the adapter into the base
 

--- a/site/pages/index.html
+++ b/site/pages/index.html
@@ -143,7 +143,7 @@ bare: yes
           </tr>
           <tr>
             <td>Train a LoRA through the quantized file you serve, reproducibly</td>
-            <td><span class="y win">Yes. Same forward pass as serving; same data, seed and config write a byte-identical adapter</span></td>
+            <td><span class="y win">Yes. Same forward pass as serving on the CPU, and within the measured CPU/GPU envelope on CUDA; same data, seed and config write a byte-identical adapter</span></td>
             <td><span class="p">Runner-trained adapters load and score identically in stock llama.cpp; community F16 adapters load back into Runner</span></td>
             <td><span class="n">Not measured</span></td>
           </tr>


### PR DESCRIPTION
## The claim narrowed yesterday and nobody said so

"The policy you sample is the policy you train, **by construction**" is the CPU codepath's property. The trainer keeps the model CPU-resident and unbound on purpose, so the forward it tapes is the host forward.

While `--lora` refused a GPU-resident model, nobody could serve an adapter through a forward the trainer had not taped. **R8.7.2 made that combination possible yesterday**, so the sentence now has a case it does not cover: an adapter trained on the CPU and served on CUDA agrees to within the engine's measured CPU/GPU envelope (1.255e-3 max |Δlogprob| on Qwen2.5-1.5B Q4_K_M), which is a bounded claim, not the by-construction one.

This is my own gap from PR #54. README, `docs/adaptation-engine.md` and the site's comparison row all move together.

## And prices what closing it would buy

`--score` is the right instrument, because its default path runs **one solo forward per position** — exactly what the tape does — and `RUNNER_SCORE_CHUNKED=1` runs the batched pass the recompute resembles. Same file, same host, two runs each, 152 positions:

| phase, and its proxy | CPU, 8 threads | RTX 3070 | ratio |
|---|---:|---:|---:|
| solo forwards (the tape) | 36 s | 5 s | **7.3×** |
| batched forward (the recompute) | 13 s | 4.5 s | **2.9×** |

Scaled onto the 128-position step: 31.8 s → ~4.2 s and 20.0 s → ~6 s, putting a step near **23 s**, which is 2.8× today's 64.8 s and 3.3× the CPU-only 76.5 s. Both proxies include model load and are conservative.

For contrast, the item the plan had queued next — attention backward plus optimizer — is 0.88 s and 0.04 s of that step. About 1%.

## The choice it hands over

- **Take T2**: use the shipped CUDA forward. Adapters become token-exact rather than byte-identical to a CPU run, and the identity claim moves to CUDA, which is where a GPU owner serves anyway.
- **Keep T1**: build a reference-exact forward the way slices 1 and 4 built the backward's — serial fmaf chain per output element, parallelised over the free dimensions, tiled so global loads still coalesce. The doc argues why this may cost far less here than the literature's batch-invariance tax (~61.5% of throughput) suggests: a batch-1 forward reads ~4.4 GB of weights and is bandwidth-bound, so the accumulation order is nearly free.

Slice 1 already established the harder half of the second option — a GPU kernel bit-identical to a *CPU reference*, on seven weight types, which is a stronger property than the same-device reproducibility the literature aims at.

Docs and measurement only; no behaviour changes.