### PR TITLE
device evidence: the Windows row now points at the suite that ran the new gate

### DIFF
--- a/docs/device-evidence.json
+++ b/docs/device-evidence.json
@@ -20,8 +20,8 @@
       },
       "last_verified": {
         "date": "2026-09-07",
-        "commit": "835400fc5fb13d5ca0df4cdf86c160ef16d96c1b",
-        "ran": "make OS=Windows_NT -j2 test (pass) and scripts/cuda-smoke-remote.sh (13 checks, 0 warnings)",
+        "commit": "92ff27563f8d5bc1b1d2d9bc307661d843c30d00",
+        "ran": "make OS=Windows_NT -j2 test (exit 0), including test-mvcanon on real Q8_0 weights",
         "result": "pass",
         "caps": {
           "version": "0.5.1",


### PR DESCRIPTION
Re-records `windows-x86_64-cuda` from the box's own `--caps` against merged main, where `make OS=Windows_NT -j2 test` exits 0 including `test-mvcanon` on real Q8_0 weights. The ledger row is what a release check reads, so it should name the run that actually covered the new kernels.