### PR TITLE
windows-suite: green, and five reasons it was not

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Files whose BYTES are the point.
+#
+# git's Windows checkout translates LF to CRLF for anything it decides is
+# text, which changes the bytes on disk. Most of the time that is harmless.
+# It is not harmless where a test asserts a sha256, because the file then
+# fails to be itself on one platform and passes on another -- which is what
+# stopped the suite the first time it ran on a GitHub Windows runner
+# (2026-09-07), with the external boundary bank hashing to the wrong value
+# through no fault of anyone who touched it.
+#
+# `-text` means: never translate, in either direction. The rule is narrow on
+# purpose. A file belongs here when something compares it byte for byte,
+# not merely because it is data.
+
+# The John6666 boundary bank, asserted byte-for-byte against upstream
+# (tests/test_tool_choice_boundary.py::test_bank_is_the_upstream_bank_byte_for_byte).
+scripts/tool-choice-boundary-bank.jsonl -text
+
+# Fuzz corpora and crash reproductions are raw byte sequences by definition;
+# a translated one is a different input and stops reproducing what it was
+# saved for.
+tests/fuzz/corpus/** -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: ci
 
 on:
+  # runnable on demand, on any branch: windows-suite is off the pull-request
+  # path, so without this the only way to exercise it is to merge and find out
+  workflow_dispatch:
   schedule:
     # 04:23 UTC daily, for the jobs that are too slow to sit on a pull request
     # but whose absence is what let the Windows suite rot for nineteen days

--- a/scripts/check-generated.py
+++ b/scripts/check-generated.py
@@ -36,6 +36,22 @@ SOURCES = {
 }
 
 
+def _normalized(data: bytes) -> bytes:
+    """Line endings are the checkout's business, not staleness.
+
+    The embed scripts always write LF (`newline="\n"`), while a Windows
+    checkout with core.autocrlf=true has the COMMITTED header on disk as
+    CRLF. Comparing raw bytes then reports permanent drift on any such
+    machine, which is what it did the first time this suite ran on a
+    GitHub Windows runner: two headers whose content is identical and whose
+    line endings are not.
+
+    Normalizing cannot hide the thing this check is for. A source that
+    actually changed produces different CONTENT, and content survives this.
+    """
+    return data.replace(b"\r\n", b"\n")
+
+
 def check(script: str, header: str) -> bool:
     committed = os.path.join(ROOT, header)
     if not os.path.exists(committed):
@@ -52,9 +68,9 @@ def check(script: str, header: str) -> bool:
         subprocess.run([sys.executable, os.path.join(ROOT, "scripts", script)],
                        check=True, cwd=ROOT, env=env, stdout=subprocess.DEVNULL)
         with open(tmp_path, "rb") as f:
-            regenerated = f.read()
+            regenerated = _normalized(f.read())
         with open(committed, "rb") as f:
-            on_disk = f.read()
+            on_disk = _normalized(f.read())
     finally:
         os.unlink(tmp_path)
     if regenerated != on_disk:

--- a/scripts/device-evidence.py
+++ b/scripts/device-evidence.py
@@ -129,9 +129,20 @@ def record(doc, cls_id, ran, result, caps_path, evidence, now):
                 "refusing to record %s: --caps came from the wrong machine (%s)"
                 % (cls_id, ", ".join("%s is %r, expected %r" % (k, got, exp)
                                      for k, (got, exp) in wrong.items())))
-    commit = subprocess.run(["git", "rev-parse", "HEAD"], cwd=ROOT,
-                            stdout=subprocess.PIPE, text=True,
-                            check=True).stdout.strip()
+    # The commit is provenance, not the point: the row's claim is that THIS
+    # machine ran THAT command and passed, which the caps fingerprint and the
+    # date carry. A recording made where git is not on PATH (an msys2 shell
+    # without it, a release tarball) records a null commit and says so, rather
+    # than refusing to record anything at all.
+    commit = None
+    try:
+        r = subprocess.run(["git", "rev-parse", "HEAD"], cwd=ROOT,
+                           stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                           text=True)
+        if r.returncode == 0:
+            commit = r.stdout.strip() or None
+    except (OSError, subprocess.SubprocessError):
+        commit = None
     cls["last_verified"] = {
         "date": now.isoformat(),
         "commit": commit,

--- a/src/model.c
+++ b/src/model.c
@@ -1013,6 +1013,14 @@ bool model_file_identity(const char *path, const char *registry,
     // are whole seconds, which can alias two GGUF revisions written in the
     // same second. Native file information gives the stable 64-bit file index
     // and the filesystem's 100 ns timestamps without hashing multi-GB files.
+    //
+    // The residual, accepted rather than hashed away: Windows stamps the write
+    // time from the cached system time, which advances on the timer tick
+    // (about 15.6 ms), so two writes inside one tick share a timestamp to the
+    // last bit and this identity cannot tell them apart. Reading the file to
+    // distinguish them is the thing this function exists to avoid. Found
+    // 2026-09-07, when the same check passed on one Windows machine and
+    // failed on a faster one.
     HANDLE h = CreateFileA(path, FILE_READ_ATTRIBUTES,
                            FILE_SHARE_READ | FILE_SHARE_WRITE |
                            FILE_SHARE_DELETE, NULL, OPEN_EXISTING,

--- a/tests/test_envelope.c
+++ b/tests/test_envelope.c
@@ -9,13 +9,43 @@
 #include <stdlib.h>
 #include <string.h>
 
-static const char *MODEL = "/tmp/xyntetik-envelope-test.gguf";
+// Fixture paths, built at run time rather than baked in. They used to be
+// "/tmp/..." literals, which on Windows resolve to C:\tmp -- a directory that
+// happens to exist on the lab box and does not on a fresh CI runner, so
+// `assert(f)` in write_manifest fired and the whole suite stopped at exit 127.
+// Every sibling test here (instances, instances_oom, tray_core, vram_rollback)
+// already branches on TEMP; this file was the one that did not.
+static char MODEL[512];
+static char RECORD_PATH[512];
+
+static void init_paths(void) {
+    const char *base = NULL;
+#ifdef _WIN32
+    base = getenv("TEMP");
+    if (!base || !*base) base = getenv("TMP");
+    const char sep = '\\';
+#else
+    base = getenv("TMPDIR");
+    if (!base || !*base) base = "/tmp";
+    const char sep = '/';
+#endif
+    // "." is always writable where the other fixtures already live, and is
+    // the honest fallback rather than a path that may not exist
+    if (!base || !*base) base = ".";
+    snprintf(MODEL, sizeof MODEL, "%s%cxyntetik-envelope-test.gguf", base, sep);
+    snprintf(RECORD_PATH, sizeof RECORD_PATH,
+             "%s%cxyntetik-transcript-test.json", base, sep);
+}
 
 static void write_manifest(const char *body) {
     char path[512];
     snprintf(path, sizeof path, "%s.envelope.json", MODEL);
     FILE *f = fopen(path, "wb");
-    assert(f);
+    if (!f) {
+        fprintf(stderr, "cannot write %s: the fixture directory is not "
+                "writable\n", path);
+        abort();
+    }
     fputs(body, f);
     fclose(f);
 }
@@ -67,6 +97,7 @@ static const char *ZERO_SHA =
 
 int main(void) {
     char out[256];
+    init_paths();
 
     // No sidecar -> silent, unclassified (transitional/legacy, not experimental).
     rm_manifest();
@@ -246,7 +277,7 @@ int main(void) {
     // grammar. A quote/control byte there must be escaped like paths and
     // prompt text or a successful run writes an unparsable transcript.
     {
-        static const char *record_path = "/tmp/xyntetik-transcript-test.json";
+        const char *record_path = RECORD_PATH;
         int32_t prompt_tok[] = { 1 };
         int32_t output_tok[] = { 2 };
         transcript_info ti = {

--- a/tests/test_envelope.c
+++ b/tests/test_envelope.c
@@ -15,8 +15,12 @@
 // `assert(f)` in write_manifest fired and the whole suite stopped at exit 127.
 // Every sibling test here (instances, instances_oom, tray_core, vram_rollback)
 // already branches on TEMP; this file was the one that did not.
-static char MODEL[512];
-static char RECORD_PATH[512];
+// 256, not 512: every derived path is `char[512]` and the compiler has to be
+// able to PROVE the suffix fits (the Windows build is -Werror=format-truncation).
+// A 512-byte source into a 512-byte destination is not provable; a 256-byte
+// one plus a 17-character suffix is.
+static char MODEL[256];
+static char RECORD_PATH[256];
 
 static void init_paths(void) {
     const char *base = NULL;

--- a/tests/test_prefix.c
+++ b/tests/test_prefix.c
@@ -21,6 +21,11 @@
 // and it used to be false on the context-overflow path.
 #include "runner.h"
 
+#ifdef _WIN32
+#include <io.h>
+#include <windows.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -352,6 +357,19 @@ static bool flip_unsampled_weight_byte(const char *path) {
     if (fseek(f, off, SEEK_SET) != 0) { fclose(f); return false; }
     unsigned char b = (unsigned char)c ^ 1u;
     bool ok = fwrite(&b, 1, 1, f) == 1;
+    // Commit it before anyone asks the OS about the file. NTFS updates a
+    // directory entry's last-write time lazily, so a fresh handle opened
+    // right after this can still read the pre-edit timestamp -- and the
+    // identity this test is about is built from that timestamp. Flushing
+    // makes the test ask about the engine rather than about how busy the
+    // filesystem was.
+    if (ok) ok = fflush(f) == 0;
+#ifdef _WIN32
+    if (ok) {
+        HANDLE h = (HANDLE)_get_osfhandle(_fileno(f));
+        if (h != INVALID_HANDLE_VALUE) FlushFileBuffers(h);
+    }
+#endif
     fclose(f);
     return ok;
 }
@@ -380,8 +398,24 @@ static void test_key_changes_after_in_place_weight_edit(void) {
 
     slot after;
     if (slot_open(&after, &p)) {
-        ck(after.e.model_key != old_key,
-           "model identity changes after an in-place weight edit");
+        bool changed = after.e.model_key != old_key;
+        if (!changed) {
+            // Name what the OS actually reported rather than leaving the
+            // reader to guess which of the four inputs went stale. The
+            // identity is (size, file index, mtime, ctime); a byte edited in
+            // place moves none of them except the write time.
+            uint64_t sz = 0, ino = 0;
+            int64_t mt = 0, ct = 0;
+            if (model_file_identity(tmp, NULL, &sz, &ino, &mt, &ct))
+                fprintf(stderr, "  identity after the edit: size=%llu "
+                        "ino=%llu mtime=%lld ctime=%lld (key unchanged at "
+                        "%llu)\n", (unsigned long long)sz,
+                        (unsigned long long)ino, (long long)mt, (long long)ct,
+                        (unsigned long long)old_key);
+            else
+                fprintf(stderr, "  model_file_identity() refused the file\n");
+        }
+        ck(changed, "model identity changes after an in-place weight edit");
         slot_close(&after);
     } else {
         ck(0, "load identity fixture after edit");

--- a/tests/test_prefix.c
+++ b/tests/test_prefix.c
@@ -20,6 +20,7 @@
 // occupies [0, e->pos). engine_rewind and the prefix cache both trust that,
 // and it used to be false on the context-overflow path.
 #include "runner.h"
+#include "compat.h"
 
 #ifdef _WIN32
 #include <io.h>
@@ -374,6 +375,35 @@ static bool flip_unsampled_weight_byte(const char *path) {
     return ok;
 }
 
+// Windows stamps a file's last-write time from the cached system time, which
+// advances on the timer tick (about 15.6 ms), so two writes inside one tick
+// share a timestamp to the last bit. The identity is (size, file index,
+// mtime, ctime) and an in-place edit moves only the write time, so an edit
+// made in the same tick as the copy that preceded it is invisible to it.
+//
+// That is a fact about the clock, not about the engine, and it is why this
+// check passed on one Windows machine and failed on a faster one: on the
+// slower box the model load between the copy and the edit crossed a tick.
+// Edit, then wait for the stamp to actually move, writing again if the wait
+// alone did not do it. What is being tested is whether the engine notices a
+// file whose recorded state has changed.
+static bool edit_until_the_stamp_moves(const char *path) {
+    uint64_t sz = 0, ino = 0;
+    int64_t before = 0, ct = 0;
+    if (!model_file_identity(path, NULL, &sz, &ino, &before, &ct)) return false;
+    for (int attempt = 0; attempt < 20; attempt++) {
+        if (!flip_unsampled_weight_byte(path)) return false;
+        for (int wait = 0; wait < 10; wait++) {
+            int64_t now = 0;
+            if (model_file_identity(path, NULL, &sz, &ino, &now, &ct) &&
+                now != before)
+                return true;
+            plat_sleep_ms(5);
+        }
+    }
+    return false;
+}
+
 static void test_key_changes_after_in_place_weight_edit(void) {
     const char *orig = g_path;
     const char *tmp = "prefix-key-replaced.gguf";
@@ -394,7 +424,8 @@ static void test_key_changes_after_in_place_weight_edit(void) {
     uint64_t old_key = before.e.model_key;
     slot_close(&before);
 
-    ck(flip_unsampled_weight_byte(tmp), "edit an unsampled weight byte in place");
+    ck(edit_until_the_stamp_moves(tmp),
+       "edit an unsampled weight byte in place, and see the stamp move");
 
     slot after;
     if (slot_open(&after, &p)) {


### PR DESCRIPTION
`windows-suite` failed on its first real run on `main` — the job doing exactly what it was added for. Five distinct causes, none of them the engine, all of them invisible to the lab box because that machine's git and clock differ from a CI runner's. **Two Windows environments disagreeing is more information than one.**

## What it found

| | |
|---|---|
| `test-prefix` identity | Windows stamps a file's write time from the cached system time, which advances on the **timer tick** (~15.6 ms). Two writes inside one tick share a timestamp to the last bit, so an edit made in the same tick as the copy before it is invisible to an identity built from that timestamp. The lab box's model load crosses a tick; a faster runner's does not. |
| `test-envelope` | The one test file still baking in `/tmp` literals. On Windows that is `C:\tmp`, which exists on the box and not on a fresh runner. Its four siblings already branch on `TEMP`. |
| `check-generated` | The embed scripts always write LF, deliberately. A checkout with `core.autocrlf=true` has the **committed** header on disk as CRLF. Comparing raw bytes reported permanent drift between two headers whose content is identical. |
| `test_tool_choice_boundary` | The external boundary bank is asserted byte-for-byte against upstream, and a translated checkout made it hash to the wrong value through no fault of anyone who touched it. |
| `test_device_evidence` | Mine, from this morning: the recorder shelled out to `git` for the commit and treated failure as fatal, so recording was impossible in an msys2 shell without git on PATH. |

## How each was decided rather than guessed

The first one I got **wrong first**: I diagnosed lazy NTFS metadata and added a flush, which made it flaky rather than green. The diagnostic I added in the same commit is what corrected me on the next run — mtime and ctime came back 0.55 ms apart, so the stamp *was* being written; it just matched the one from the copy. The test now waits for the stamp to actually move, and the residual is written where the identity is built: an identity of size, file index and timestamps cannot distinguish two writes inside one tick, and reading the file to tell them apart is what that function exists to avoid.

`.gitattributes` marks the bank and the fuzz corpora `-text`. The rule is deliberately narrow — a file belongs there when something compares it byte for byte, not merely because it is data.

The drift check normalizes both sides now, and the commit asserts both directions: identical content with different line endings compares equal, and changed content still does not.

## And the thing that made this possible at all

`ci.yml` gains `workflow_dispatch`. `windows-suite` is off the pull-request path on purpose, so without it the only way to exercise a change to that job is to merge and find out — which is precisely how the original failure reached `main`.

Six dispatched runs to get here, each one reading the previous one's evidence.