### PR TITLE
shadow: the evidence contract and the protected verifier (R14.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ names that were true when they were written.
 
 ## Unreleased
 
+- **Shadow mode, the instrument half (R14.1): an evidence contract and a
+  protected verifier in the Python client.** `xyntetik_runner.shadow` is
+  stdlib-only and answers one question about a local model honestly: did an
+  attempt independently pass checks it could not see or change. The contract
+  gives every observed episode one disposition from a closed list
+  (`ineligible`, `not_attempted_resource`, `unreplayable`,
+  `verifier_inconclusive`, `local_failed`, `verified_local_attempt`,
+  `agreement_only`) and an identity partition of the whole stack (model
+  hash, quant, adapter, runner build, backend, harness, verifier,
+  environment), and it refuses by construction a record that claims
+  `verified_local_attempt` without a passing verifier outcome, or one that
+  loaded frontier content. The summary prints counts first and both
+  denominators (verified over eligible, verified over observed) and prints
+  no percentage before thirty independent eligible episodes. The verifier
+  keeps its tests outside the workspace under a hashed manifest, copies the
+  workspace to a scratch directory, writes the frozen tests over whatever is
+  there, runs pytest under its own configuration file, and reads a JUnit
+  report; a no-op, a changed protected test, a changed `conftest.py` or
+  pytest configuration, a skip, or a missing test cannot count as success,
+  and a timeout is inconclusive rather than a pass. Calibration is the gate
+  on the gate: a protected set that passes on the untouched baseline is
+  refused as an instrument. Proven red on a frozen repair task
+  (`python/tests/fixtures/repair_task_v1`): a wrong patch that passes the
+  visible tests, a rewritten test file, a monkeypatching `conftest.py` that
+  fools both the visible and the frozen tests, an injected `pytest.ini`, a
+  module-level skip and a hang are each rejected for the stated reason,
+  and the one correct patch is verified. Found on the way: pytest builds
+  JUnit classnames from the `-c` file's directory, so the verifier's ini
+  sits at the workspace root or every expected test reads as missing. Not a
+  sandbox: the tests run as the calling user with the network reachable;
+  OS isolation is a separate story.
+
 - **A forward matvec on CUDA that is bit-identical to the CPU, not close to
   it (R8.7.1 slice 1).** `gpu_mvcanon` computes `y = W.x` in exactly the
   association `vec_dot` uses under `RUNNER_CANON_KERNELS`, gated by `memcmp`

--- a/python/README.md
+++ b/python/README.md
@@ -25,3 +25,29 @@ Transport-level breakage is translated too: a peer holding the port that is not
 speaking HTTP, or a body cut short mid-stream, raises `RunnerProtocolError`
 rather than a raw `http.client` exception — so `RunnerEndpoint.healthy()` reports
 False for a squatting service instead of raising through `ManagedRunner.start()`.
+
+## Shadow mode: `xyntetik_runner.shadow`
+
+The instrument half of shadow mode (plan epic R14), stdlib only. It does not
+route requests, train, or sandbox.
+
+- `evidence`: one `EpisodeEvidence` record per observed episode with a
+  `Disposition` from a closed list, an `Identity` of the whole measured stack
+  and a `VerifierOutcome`. A record cannot claim `verified_local_attempt`
+  without a passing verifier outcome and cannot carry frontier content;
+  both are refused in `__post_init__`. `summarize` and `render` print counts
+  first and both denominators, and no percentage before thirty independent
+  eligible episodes.
+- `baseline`: `Baseline.capture` hashes a tree; `changes` and `patch_sha256`
+  give a patch its identity against that baseline.
+- `verifier`: `ProtectedTests.freeze` / `load` keep the deciding tests outside
+  the workspace under a hashed manifest; `calibrate` refuses a protected set
+  that passes on the untouched baseline; `verify` runs the frozen tests over a
+  scratch copy of the workspace with the verifier's own pytest configuration
+  and returns a `VerifierOutcome`. A no-op, a changed protected test file, a
+  changed `conftest.py` or pytest configuration file, a skipped or missing
+  expected test cannot pass; a timeout is `passed=None`.
+
+The negative controls that prove the verifier can fail live in
+`python/tests/test_shadow_verifier.py` against the frozen repair task in
+`python/tests/fixtures/repair_task_v1`.

--- a/python/src/xyntetik_runner/shadow/__init__.py
+++ b/python/src/xyntetik_runner/shadow/__init__.py
@@ -1,0 +1,59 @@
+"""Shadow mode (plan epic R14): evidence about what a local model can do.
+
+Two things live here and nothing else. The evidence contract
+(`evidence`): one record per observed episode with a disposition from a
+closed list, an identity partition, and a verifier outcome, plus a summary
+that shows counts and both denominators and refuses a headline percentage
+before thirty independent eligible episodes. The protected verifier
+(`verifier`): frozen tests that live outside the workspace, run on a fresh
+copy of it, and cannot be satisfied by a no-op, a tampered test file, an
+injected pytest configuration or a skip.
+
+Stdlib only. This package does not route requests, does not train, and
+does not sandbox: the verifier runs the workspace's tests on the host in a
+scratch copy, and OS isolation is a separate story (R14.3).
+"""
+
+from xyntetik_runner.shadow.baseline import Baseline, Changes, file_sha256, tree_hashes, tree_sha256
+from xyntetik_runner.shadow.evidence import (
+    HEADLINE_MIN_EPISODES,
+    SCHEMA_VERSION,
+    Disposition,
+    EpisodeEvidence,
+    Identity,
+    Summary,
+    VerifierOutcome,
+    render,
+    summarize,
+)
+from xyntetik_runner.shadow.verifier import (
+    CONFIG_BASENAMES,
+    Calibration,
+    InstrumentError,
+    ProtectedTests,
+    calibrate,
+    verify,
+)
+
+__all__ = [
+    "CONFIG_BASENAMES",
+    "HEADLINE_MIN_EPISODES",
+    "SCHEMA_VERSION",
+    "Baseline",
+    "Calibration",
+    "Changes",
+    "Disposition",
+    "EpisodeEvidence",
+    "Identity",
+    "InstrumentError",
+    "ProtectedTests",
+    "Summary",
+    "VerifierOutcome",
+    "calibrate",
+    "file_sha256",
+    "render",
+    "summarize",
+    "tree_hashes",
+    "tree_sha256",
+    "verify",
+]

--- a/python/src/xyntetik_runner/shadow/baseline.py
+++ b/python/src/xyntetik_runner/shadow/baseline.py
@@ -1,0 +1,95 @@
+"""Content identity of a workspace before and after a local attempt.
+
+A baseline is a map of relative path to sha256 over the files of a tree.
+Everything the verifier says about a patch is said against a baseline: the
+no-op check is "the tree did not change", the tamper check is "a protected
+or configuration file is among the changes", and the patch identity that
+goes into an evidence record is a hash over the changed paths and their
+new contents, so two attempts that produce the same bytes get the same id
+regardless of how they got there.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+IGNORED_DIRS = frozenset({".git", "__pycache__", ".pytest_cache", ".mypy_cache", ".venv",
+                          ".ruff_cache", "node_modules"})
+
+
+def file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 16), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def tree_hashes(root: Path, *, ignored_dirs: Iterable[str] = IGNORED_DIRS) -> dict[str, str]:
+    """Relative POSIX path to sha256 for every regular file under ``root``.
+
+    Symlinks are skipped: a link that points outside the tree would let a
+    "workspace" hash bytes it does not contain.
+    """
+    ignored = frozenset(ignored_dirs)
+    out: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink() or not path.is_file():
+            continue
+        rel = path.relative_to(root)
+        if any(part in ignored for part in rel.parts[:-1]):
+            continue
+        out[rel.as_posix()] = file_sha256(path)
+    return out
+
+
+def tree_sha256(hashes: Mapping[str, str]) -> str:
+    """One digest for a whole tree: the canonical JSON of its path->hash map."""
+    canonical = json.dumps(dict(sorted(hashes.items())), separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+@dataclass(frozen=True)
+class Changes:
+    added: tuple[str, ...]
+    removed: tuple[str, ...]
+    modified: tuple[str, ...]
+
+    @property
+    def paths(self) -> tuple[str, ...]:
+        return tuple(sorted({*self.added, *self.removed, *self.modified}))
+
+    def __bool__(self) -> bool:
+        return bool(self.added or self.removed or self.modified)
+
+
+@dataclass(frozen=True)
+class Baseline:
+    """A captured tree: its file hashes and their combined digest."""
+
+    files: Mapping[str, str]
+    sha256: str
+
+    @classmethod
+    def capture(cls, root: Path) -> Baseline:
+        hashes = tree_hashes(root)
+        return cls(files=dict(hashes), sha256=tree_sha256(hashes))
+
+    def changes(self, root: Path) -> Changes:
+        now = tree_hashes(root)
+        added = tuple(sorted(p for p in now if p not in self.files))
+        removed = tuple(sorted(p for p in self.files if p not in now))
+        modified = tuple(sorted(p for p in now if p in self.files and now[p] != self.files[p]))
+        return Changes(added=added, removed=removed, modified=modified)
+
+    def patch_sha256(self, root: Path) -> str:
+        """Identity of what the attempt changed: canonical JSON of the changed
+        paths with their new hashes (``None`` for a removed file)."""
+        now = tree_hashes(root)
+        record = {p: now.get(p) for p in self.changes(root).paths}
+        canonical = json.dumps(record, separators=(",", ":"), sort_keys=True)
+        return hashlib.sha256(canonical.encode()).hexdigest()

--- a/python/src/xyntetik_runner/shadow/evidence.py
+++ b/python/src/xyntetik_runner/shadow/evidence.py
@@ -1,0 +1,224 @@
+"""The evidence contract for shadow mode (R14.1).
+
+One record per observed episode. The disposition is a closed list so that
+every episode lands somewhere and the denominators are complete: an episode
+the instrument could not evaluate is counted as such, never dropped. The
+identity partition names the subject actually measured (model, quant,
+adapter, runner build, backend, harness, verifier, environment), because a
+new adapter or verifier opens a new cohort and old evidence becomes history.
+
+Two invariants are enforced by construction rather than by review:
+
+* a record cannot claim ``verified_local_attempt`` unless it carries a
+  verifier outcome that passed with no tamper finding, and cannot claim
+  ``local_failed`` unless the verifier failed or found tampering;
+* a record cannot carry frontier content: the flag exists so that an
+  importer has to state it, and stating it true refuses the record.
+
+The summary shows counts first and both denominators (verified over
+eligible, verified over everything observed). It refuses to print a
+percentage before thirty independent eligible episodes, and it never
+prints one over the observed total at all: "N of your tasks" is a count.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+SCHEMA_VERSION = "xyntetik.shadow.evidence.v1"
+HEADLINE_MIN_EPISODES = 30
+
+
+class Disposition(str, Enum):
+    INELIGIBLE = "ineligible"
+    NOT_ATTEMPTED_RESOURCE = "not_attempted_resource"
+    UNREPLAYABLE = "unreplayable"
+    VERIFIER_INCONCLUSIVE = "verifier_inconclusive"
+    LOCAL_FAILED = "local_failed"
+    VERIFIED_LOCAL_ATTEMPT = "verified_local_attempt"
+    AGREEMENT_ONLY = "agreement_only"
+
+
+ELIGIBLE = frozenset({
+    Disposition.NOT_ATTEMPTED_RESOURCE,
+    Disposition.VERIFIER_INCONCLUSIVE,
+    Disposition.LOCAL_FAILED,
+    Disposition.VERIFIED_LOCAL_ATTEMPT,
+    Disposition.AGREEMENT_ONLY,
+})
+ATTEMPTED = ELIGIBLE - {Disposition.NOT_ATTEMPTED_RESOURCE}
+CHECKED = frozenset({Disposition.LOCAL_FAILED, Disposition.VERIFIED_LOCAL_ATTEMPT})
+
+
+@dataclass(frozen=True)
+class Identity:
+    """The subject measured. Not the model name: the whole stack."""
+
+    project: str
+    task_class: str
+    context_band: str
+    tool_set: tuple[str, ...]
+    verifier_id: str
+    environment_id: str
+    model_sha256: str
+    quant: str
+    template_sha256: str
+    runner_build: str
+    backend: str
+    harness_version: str
+    adapter_sha256: str | None = None
+    adapter_scale: float | None = None
+
+    def cohort_key(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True, separators=(",", ":"))
+
+
+@dataclass(frozen=True)
+class VerifierOutcome:
+    """What the protected verifier saw. ``passed`` is ``None`` when the
+    verifier could not reach a verdict (timeout, crash)."""
+
+    verifier_id: str
+    passed: bool | None
+    expected: int
+    passed_count: int
+    failed: int
+    skipped: int
+    missing: int
+    tamper: tuple[str, ...] = ()
+    reasons: tuple[str, ...] = ()
+    output_sha256: str = ""
+    duration_s: float = 0.0
+
+
+@dataclass(frozen=True)
+class EpisodeEvidence:
+    episode_id: str
+    source: str
+    observed_at: str
+    disposition: Disposition
+    identity: Identity
+    baseline_sha256: str
+    patch_sha256: str | None
+    changed_paths: tuple[str, ...]
+    verifier: VerifierOutcome | None
+    wall_s: float
+    resources: Mapping[str, float] = field(default_factory=dict)
+    reasons: tuple[str, ...] = ()
+    frontier_content_loaded: bool = False
+    schema_version: str = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.frontier_content_loaded:
+            raise ValueError("a record that loaded frontier content is refused: "
+                             "the importer reads boundary, request, directory and time only")
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(f"unknown schema_version {self.schema_version!r}")
+        v = self.verifier
+        d = self.disposition
+        if d is Disposition.VERIFIED_LOCAL_ATTEMPT:
+            if v is None or v.passed is not True or v.tamper or v.skipped or v.missing:
+                raise ValueError("verified_local_attempt needs a verifier outcome that passed "
+                                 "with no tamper, skipped or missing tests")
+        elif d is Disposition.LOCAL_FAILED:
+            if v is None or v.passed is None or (v.passed and not v.tamper):
+                raise ValueError("local_failed needs a verifier outcome that failed or found "
+                                 "tampering")
+        elif d is Disposition.VERIFIER_INCONCLUSIVE:
+            if v is not None and v.passed is not None:
+                raise ValueError("verifier_inconclusive cannot carry a verdict")
+        elif v is not None:
+            raise ValueError(f"{d.value} carries no verifier outcome")
+
+    def to_json(self) -> str:
+        data = asdict(self)
+        data["disposition"] = self.disposition.value
+        return json.dumps(data, sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def from_json(cls, text: str) -> EpisodeEvidence:
+        data: dict[str, Any] = json.loads(text)
+        ident = data.pop("identity")
+        ident["tool_set"] = tuple(ident["tool_set"])
+        ver = data.pop("verifier")
+        if ver is not None:
+            ver["tamper"] = tuple(ver["tamper"])
+            ver["reasons"] = tuple(ver["reasons"])
+        return cls(
+            identity=Identity(**ident),
+            verifier=VerifierOutcome(**ver) if ver is not None else None,
+            disposition=Disposition(data.pop("disposition")),
+            changed_paths=tuple(data.pop("changed_paths")),
+            reasons=tuple(data.pop("reasons")),
+            **data,
+        )
+
+
+@dataclass(frozen=True)
+class Summary:
+    observed: int
+    eligible: int
+    attempted: int
+    checked: int
+    verified: int
+    failed: int
+    inconclusive: int
+    agreement_only: int
+    cohorts: int
+    by_disposition: Mapping[str, int]
+
+    @property
+    def headline_allowed(self) -> bool:
+        return self.eligible >= HEADLINE_MIN_EPISODES
+
+
+def summarize(records: Iterable[EpisodeEvidence]) -> Summary:
+    by: dict[str, int] = {d.value: 0 for d in Disposition}
+    cohorts: set[str] = set()
+    n = 0
+    for r in records:
+        n += 1
+        by[r.disposition.value] += 1
+        cohorts.add(r.identity.cohort_key())
+    count = {d: by[d.value] for d in Disposition}
+    return Summary(
+        observed=n,
+        eligible=sum(count[d] for d in ELIGIBLE),
+        attempted=sum(count[d] for d in ATTEMPTED),
+        checked=sum(count[d] for d in CHECKED),
+        verified=count[Disposition.VERIFIED_LOCAL_ATTEMPT],
+        failed=count[Disposition.LOCAL_FAILED],
+        inconclusive=count[Disposition.VERIFIER_INCONCLUSIVE],
+        agreement_only=count[Disposition.AGREEMENT_ONLY],
+        cohorts=len(cohorts),
+        by_disposition=by,
+    )
+
+
+def render(s: Summary) -> str:
+    """Counts first, both denominators, no percentage before the floor."""
+    lines = [
+        f"{s.observed} episodes observed",
+        f"{s.eligible} eligible for replay",
+        f"{s.attempted} attempted",
+        f"{s.verified} passed independent checks",
+        f"{s.failed} failed checks",
+        f"{s.inconclusive} could not be evaluated",
+        f"{s.agreement_only} agreement only (not evidence)",
+        f"{s.observed - s.eligible} outside this evaluation's scope",
+        f"{s.cohorts} identity cohorts",
+    ]
+    if s.eligible:
+        ratio = f"verified over eligible: {s.verified} of {s.eligible}"
+        if s.headline_allowed:
+            ratio += f" ({100 * s.verified / s.eligible:.0f}%)"
+        lines.append(ratio)
+    if s.observed:
+        lines.append(f"verified over observed: {s.verified} of {s.observed}")
+    if not s.headline_allowed:
+        lines.append(f"(no percentage before {HEADLINE_MIN_EPISODES} independent eligible episodes)")
+    return "\n".join(lines)

--- a/python/src/xyntetik_runner/shadow/verifier.py
+++ b/python/src/xyntetik_runner/shadow/verifier.py
@@ -1,0 +1,285 @@
+"""The protected verifier: frozen tests the attempt cannot reach.
+
+The tests that decide an episode live in a directory OUTSIDE the workspace,
+frozen by a manifest of hashes. Verification copies the workspace to a
+scratch directory, writes the frozen tests over whatever the workspace has
+at those paths, runs pytest with the verifier's own configuration file so
+the workspace's cannot change collection, and reads a JUnit report.
+
+What cannot count as success, each with its own reason string:
+
+* a no-op (the workspace is byte-identical to its baseline);
+* a changed protected test file or a changed pytest configuration file
+  (``conftest.py``, ``pytest.ini``, ``pyproject.toml``, ``setup.cfg``,
+  ``tox.ini``): the run still happens, the result is a tamper finding;
+* a skipped or missing expected test;
+* a timeout: the verdict is ``None`` (inconclusive), never a pass.
+
+Calibration is the gate on the gate: the frozen tests must fail on the
+untouched baseline. A protected set that passes on the baseline cannot
+reject a no-op, and ``calibrate`` refuses it rather than trusting it.
+
+Not a sandbox. The scratch copy contains only regular files (no symlinks),
+the environment handed to pytest is minimal, and the process group is
+killed on timeout, but the tests run as the calling user with the network
+reachable. OS isolation is R14.3.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import xml.etree.ElementTree as ET
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from xyntetik_runner.shadow.baseline import Baseline, file_sha256, tree_hashes, tree_sha256
+from xyntetik_runner.shadow.evidence import VerifierOutcome
+
+MANIFEST = "manifest.json"
+MANIFEST_SCHEMA = "xyntetik.shadow.protected.v1"
+CONFIG_BASENAMES = frozenset({"conftest.py", "pytest.ini", ".pytest.ini", "pyproject.toml",
+                              "setup.cfg", "tox.ini"})
+VERIFIER_INI = "[pytest]\naddopts =\n"
+VERIFIER_INI_NAME = ".xyntetik-shadow-verifier.ini"
+_ENV_PASSTHROUGH = ("PATH", "LANG", "LC_ALL", "SYSTEMROOT", "SystemRoot", "TEMP", "TMP",
+                    "PYTHONIOENCODING")
+
+
+class InstrumentError(RuntimeError):
+    """The verifier itself is wrong, and no verdict from it may be used."""
+
+
+def _classname(rel: str) -> str:
+    return rel[:-3].replace("/", ".") if rel.endswith(".py") else rel.replace("/", ".")
+
+
+@dataclass(frozen=True)
+class ProtectedTests:
+    """Frozen test files at their workspace-relative paths, plus the tests
+    each is expected to contain."""
+
+    source: Path
+    verifier_id: str
+    files: Mapping[str, str]
+    expected: tuple[tuple[str, str], ...]
+
+    @classmethod
+    def load(cls, source: Path) -> ProtectedTests:
+        try:
+            m = json.loads((source / MANIFEST).read_text(encoding="utf-8"))
+        except (OSError, ValueError) as e:
+            raise InstrumentError(f"protected manifest unreadable: {source / MANIFEST}: {e}") from e
+        if m.get("schema_version") != MANIFEST_SCHEMA:
+            raise InstrumentError(f"protected manifest schema {m.get('schema_version')!r} unknown")
+        files: dict[str, str] = dict(m["files"])
+        for rel, sha in files.items():
+            p = source / rel
+            if not p.is_file():
+                raise InstrumentError(f"protected file missing: {rel}")
+            if file_sha256(p) != sha:
+                raise InstrumentError(f"protected file differs from its manifest: {rel}")
+        expected = tuple((rel, name) for rel, names in m["expected"].items() for name in names)
+        if not expected:
+            raise InstrumentError("protected manifest lists no expected tests")
+        for rel, _ in expected:
+            if rel not in files:
+                raise InstrumentError(f"expected tests in a file the manifest does not freeze: {rel}")
+        vid = str(m.get("verifier_id") or f"protected:{tree_sha256(files)[:16]}")
+        return cls(source=source, verifier_id=vid, files=files, expected=expected)
+
+    @classmethod
+    def freeze(cls, source: Path, expected: Mapping[str, Sequence[str]], *,
+               verifier_id: str | None = None) -> ProtectedTests:
+        """Write the manifest for every file under ``source`` and load it."""
+        files = {p.relative_to(source).as_posix(): file_sha256(p)
+                 for p in sorted(source.rglob("*")) if p.is_file() and p.name != MANIFEST}
+        manifest = {
+            "schema_version": MANIFEST_SCHEMA,
+            "verifier_id": verifier_id or f"protected:{tree_sha256(files)[:16]}",
+            "files": files,
+            "expected": {rel: list(names) for rel, names in expected.items()},
+        }
+        (source / MANIFEST).write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                                       encoding="utf-8")
+        return cls.load(source)
+
+    @property
+    def test_files(self) -> tuple[str, ...]:
+        return tuple(sorted({rel for rel, _ in self.expected}))
+
+
+@dataclass(frozen=True)
+class _Run:
+    outcomes: Mapping[tuple[str, str], str]
+    report_sha256: str
+    duration_s: float
+    timed_out: bool
+    returncode: int
+
+
+def _copy_tree(src: Path, dst: Path) -> None:
+    for rel in tree_hashes(src):
+        target = dst / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src / rel, target)
+
+
+def _kill(proc: subprocess.Popen[bytes]) -> None:
+    try:
+        if os.name == "posix":
+            os.killpg(proc.pid, signal.SIGKILL)
+        else:
+            proc.kill()
+    except OSError:
+        pass
+
+
+def _run_protected(protected: ProtectedTests, tree: Path, *, timeout_s: float,
+                   python: str) -> _Run:
+    scratch = Path(tempfile.mkdtemp(prefix="xyntetik-shadow-"))
+    try:
+        ws = scratch / "ws"
+        ws.mkdir()
+        _copy_tree(tree, ws)
+        for rel in protected.files:
+            target = ws / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(protected.source / rel, target)
+        # The verifier's own ini sits at the workspace root: pytest takes the
+        # rootdir from the -c file's directory, and with the ini elsewhere the
+        # JUnit classnames come out empty and every expected test reads as
+        # missing. Being named on -c also makes it the only ini pytest reads,
+        # so a pytest.ini or pyproject the attempt wrote cannot change
+        # collection (the change is still flagged as tamper).
+        ini = ws / VERIFIER_INI_NAME
+        if ini.exists():
+            raise InstrumentError(f"workspace already contains {VERIFIER_INI_NAME}")
+        ini.write_text(VERIFIER_INI, encoding="utf-8")
+        report = scratch / "report.xml"
+        cmd = [python, "-m", "pytest", "-q", "-p", "no:cacheprovider", "-c", VERIFIER_INI_NAME,
+               "-o", "junit_family=xunit2", "--junit-xml", str(report), *protected.test_files]
+        env = {k: os.environ[k] for k in _ENV_PASSTHROUGH if k in os.environ}
+        env.update({"HOME": str(scratch), "PYTHONDONTWRITEBYTECODE": "1",
+                    "PYTHONPATH": str(ws)})
+        t0 = time.monotonic()
+        proc = subprocess.Popen(cmd, cwd=ws, env=env, stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                                start_new_session=(os.name == "posix"))
+        timed_out = False
+        try:
+            out, _ = proc.communicate(timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            _kill(proc)
+            out, _ = proc.communicate()
+        duration = time.monotonic() - t0
+        outcomes: dict[tuple[str, str], str] = {}
+        digest = hashlib.sha256(out or b"").hexdigest()
+        if report.is_file():
+            data = report.read_bytes()
+            digest = hashlib.sha256(data).hexdigest()
+            for case in ET.fromstring(data).iter("testcase"):
+                key = (case.get("classname", ""), case.get("name", ""))
+                if case.find("failure") is not None or case.find("error") is not None:
+                    outcomes[key] = "failed"
+                elif case.find("skipped") is not None:
+                    outcomes[key] = "skipped"
+                else:
+                    outcomes[key] = "passed"
+        return _Run(outcomes=outcomes, report_sha256=digest, duration_s=duration,
+                    timed_out=timed_out, returncode=proc.returncode)
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+
+def _judge(protected: ProtectedTests, run: _Run) -> tuple[int, int, int, int]:
+    passed = failed = skipped = missing = 0
+    for rel, name in protected.expected:
+        state = run.outcomes.get((_classname(rel), name))
+        if state == "passed":
+            passed += 1
+        elif state == "failed":
+            failed += 1
+        elif state == "skipped":
+            skipped += 1
+        else:
+            missing += 1
+    return passed, failed, skipped, missing
+
+
+@dataclass(frozen=True)
+class Calibration:
+    failing: int
+    passing: int
+    missing: int
+    report_sha256: str
+
+
+def calibrate(protected: ProtectedTests, baseline_root: Path, *, timeout_s: float = 600.0,
+              python: str = sys.executable) -> Calibration:
+    """Prove the instrument can fail: the frozen tests must not pass on the
+    untouched baseline. Raises ``InstrumentError`` otherwise."""
+    run = _run_protected(protected, baseline_root, timeout_s=timeout_s, python=python)
+    if run.timed_out:
+        raise InstrumentError(f"protected tests timed out on the baseline after {timeout_s}s")
+    passed, failed, skipped, missing = _judge(protected, run)
+    if failed == 0 and missing == 0 and skipped == 0:
+        raise InstrumentError("protected tests pass on the untouched baseline; the instrument "
+                              "cannot reject a no-op and its verdicts are worthless")
+    if skipped:
+        raise InstrumentError(f"{skipped} protected test(s) skip on the baseline; a skip is not "
+                              "a failure the fix can turn into a pass")
+    if run.returncode == 0:
+        raise InstrumentError("pytest exited 0 on the baseline while the report shows failures; "
+                              "the report and the process disagree")
+    return Calibration(failing=failed, passing=passed, missing=missing,
+                       report_sha256=run.report_sha256)
+
+
+def verify(workspace: Path, protected: ProtectedTests, baseline: Baseline, *,
+           timeout_s: float = 600.0, python: str = sys.executable) -> VerifierOutcome:
+    """Verdict on the workspace as it stands, against its baseline."""
+    changes = baseline.changes(workspace)
+    n_expected = len(protected.expected)
+    if not changes:
+        return VerifierOutcome(verifier_id=protected.verifier_id, passed=False,
+                               expected=n_expected, passed_count=0, failed=0, skipped=0,
+                               missing=n_expected,
+                               reasons=("no_op: workspace identical to its baseline",))
+    tamper: list[str] = []
+    for rel in changes.paths:
+        if rel in protected.files:
+            tamper.append(f"protected test file changed: {rel}")
+        elif Path(rel).name in CONFIG_BASENAMES:
+            tamper.append(f"test configuration changed: {rel}")
+    run = _run_protected(protected, workspace, timeout_s=timeout_s, python=python)
+    passed, failed, skipped, missing = _judge(protected, run)
+    reasons: list[str] = []
+    verdict: bool | None
+    if run.timed_out:
+        verdict = None
+        reasons.append(f"timeout after {timeout_s:g}s")
+    else:
+        verdict = failed == 0 and skipped == 0 and missing == 0 and not tamper
+        if failed:
+            reasons.append(f"{failed} expected test(s) failed")
+        if skipped:
+            reasons.append(f"{skipped} expected test(s) skipped")
+        if missing:
+            reasons.append(f"{missing} expected test(s) not run")
+        if tamper:
+            reasons.append("tamper")
+    return VerifierOutcome(verifier_id=protected.verifier_id, passed=verdict,
+                           expected=n_expected, passed_count=passed, failed=failed,
+                           skipped=skipped, missing=missing, tamper=tuple(tamper),
+                           reasons=tuple(reasons), output_sha256=run.report_sha256,
+                           duration_s=round(run.duration_s, 3))

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,4 @@
+# The shadow fixtures carry real pytest files on purpose (a frozen repair
+# task and its protected tests); the verifier runs those in a scratch copy.
+# They are not this suite's tests, so collection must not descend into them.
+collect_ignore_glob = ["fixtures/*"]

--- a/python/tests/fixtures/repair_task_v1/protected/manifest.json
+++ b/python/tests/fixtures/repair_task_v1/protected/manifest.json
@@ -1,0 +1,17 @@
+{
+  "expected": {
+    "tests/test_money.py": [
+      "test_plain",
+      "test_thousands_separator",
+      "test_float_trap",
+      "test_negative",
+      "test_currency_prefix",
+      "test_whitespace"
+    ]
+  },
+  "files": {
+    "tests/test_money.py": "87acbf8adf6a1fc3933e60b89aaa712e41c0c06b338f569a49fe5f9a98e9d23b"
+  },
+  "schema_version": "xyntetik.shadow.protected.v1",
+  "verifier_id": "repair_task_v1"
+}

--- a/python/tests/fixtures/repair_task_v1/protected/tests/test_money.py
+++ b/python/tests/fixtures/repair_task_v1/protected/tests/test_money.py
@@ -1,0 +1,28 @@
+"""Protected tests: a superset of the visible ones. The attempt never sees
+this file; the verifier writes it over the workspace copy before running."""
+from calc.money import parse_amount
+
+
+def test_plain() -> None:
+    assert parse_amount("12.34") == 1234
+
+
+def test_thousands_separator() -> None:
+    assert parse_amount("1,234.50") == 123450
+
+
+def test_float_trap() -> None:
+    assert parse_amount("0.29") == 29
+
+
+def test_negative() -> None:
+    assert parse_amount("-12") == -1200
+
+
+def test_currency_prefix() -> None:
+    assert parse_amount("EUR 3.10") == 310
+    assert parse_amount("€ 3.10") == 310
+
+
+def test_whitespace() -> None:
+    assert parse_amount(" 7.05 ") == 705

--- a/python/tests/fixtures/repair_task_v1/task.md
+++ b/python/tests/fixtures/repair_task_v1/task.md
@@ -1,0 +1,8 @@
+# Repair task v1 (frozen)
+
+`calc.money.parse_amount` must return the amount in integer cents for money
+strings a ledger export contains: plain decimals ("12.34"), thousands
+separators ("1,234.50"), negatives ("-12"), a currency prefix ("EUR 3.10",
+"€ 3.10") and surrounding whitespace. Today it only handles plain decimals,
+and it rounds through binary floating point. Make `tests/test_money.py`
+pass without changing the tests.

--- a/python/tests/fixtures/repair_task_v1/workspace/calc/__init__.py
+++ b/python/tests/fixtures/repair_task_v1/workspace/calc/__init__.py
@@ -1,0 +1,1 @@
+"""Ledger helpers."""

--- a/python/tests/fixtures/repair_task_v1/workspace/calc/money.py
+++ b/python/tests/fixtures/repair_task_v1/workspace/calc/money.py
@@ -1,0 +1,6 @@
+"""Money parsing for the ledger importer."""
+
+
+def parse_amount(text: str) -> int:
+    """Return the amount in integer cents for a decimal money string."""
+    return int(float(text) * 100)

--- a/python/tests/fixtures/repair_task_v1/workspace/tests/test_money.py
+++ b/python/tests/fixtures/repair_task_v1/workspace/tests/test_money.py
@@ -1,0 +1,9 @@
+from calc.money import parse_amount
+
+
+def test_plain() -> None:
+    assert parse_amount("12.34") == 1234
+
+
+def test_thousands_separator() -> None:
+    assert parse_amount("1,234.50") == 123450

--- a/python/tests/test_shadow_evidence.py
+++ b/python/tests/test_shadow_evidence.py
@@ -1,0 +1,106 @@
+"""The evidence contract: a record cannot claim what its verifier did not
+see, cannot carry frontier content, and the summary never headlines a
+percentage before the floor."""
+from __future__ import annotations
+
+import pytest
+
+from xyntetik_runner.shadow import (
+    HEADLINE_MIN_EPISODES,
+    Disposition,
+    EpisodeEvidence,
+    Identity,
+    VerifierOutcome,
+    render,
+    summarize,
+)
+
+IDENT = Identity(project="p", task_class="repair", context_band="<8k", tool_set=("read", "write"),
+                 verifier_id="repair_task_v1", environment_id="host", model_sha256="m" * 64,
+                 quant="Q4_K_M", template_sha256="t" * 64, runner_build="0.5.1", backend="cpu",
+                 harness_version="shadow-0.1")
+
+
+def passing(**kw: object) -> VerifierOutcome:
+    base = dict(verifier_id="repair_task_v1", passed=True, expected=6, passed_count=6,
+                failed=0, skipped=0, missing=0)
+    base.update(kw)
+    return VerifierOutcome(**base)  # type: ignore[arg-type]
+
+
+def record(disposition: Disposition, verifier: VerifierOutcome | None, **kw: object) -> EpisodeEvidence:
+    fields = dict(episode_id="e1", source="manual", observed_at="2026-09-08T00:00:00Z",
+                  disposition=disposition, identity=IDENT, baseline_sha256="b" * 64,
+                  patch_sha256="p" * 64, changed_paths=("calc/money.py",), verifier=verifier,
+                  wall_s=1.0)
+    fields.update(kw)
+    return EpisodeEvidence(**fields)  # type: ignore[arg-type]
+
+
+def test_verified_needs_a_clean_pass() -> None:
+    record(Disposition.VERIFIED_LOCAL_ATTEMPT, passing())
+    for bad in (None, passing(passed=False), passing(tamper=("x",)), passing(skipped=1),
+                passing(missing=1), passing(passed=None)):
+        with pytest.raises(ValueError):
+            record(Disposition.VERIFIED_LOCAL_ATTEMPT, bad)
+
+
+def test_local_failed_needs_a_failure_or_tamper() -> None:
+    record(Disposition.LOCAL_FAILED, passing(passed=False, failed=1))
+    record(Disposition.LOCAL_FAILED, passing(passed=True, tamper=("conftest.py",)))
+    for bad in (None, passing(), passing(passed=None)):
+        with pytest.raises(ValueError):
+            record(Disposition.LOCAL_FAILED, bad)
+
+
+def test_inconclusive_carries_no_verdict_and_others_carry_no_verifier() -> None:
+    record(Disposition.VERIFIER_INCONCLUSIVE, None)
+    record(Disposition.VERIFIER_INCONCLUSIVE, passing(passed=None))
+    with pytest.raises(ValueError):
+        record(Disposition.VERIFIER_INCONCLUSIVE, passing())
+    for d in (Disposition.INELIGIBLE, Disposition.UNREPLAYABLE, Disposition.AGREEMENT_ONLY,
+              Disposition.NOT_ATTEMPTED_RESOURCE):
+        record(d, None)
+        with pytest.raises(ValueError):
+            record(d, passing())
+
+
+def test_frontier_content_is_refused_by_construction() -> None:
+    with pytest.raises(ValueError, match="frontier content"):
+        record(Disposition.INELIGIBLE, None, frontier_content_loaded=True)
+
+
+def test_json_round_trip() -> None:
+    r = record(Disposition.VERIFIED_LOCAL_ATTEMPT, passing(reasons=("ok",)),
+               resources={"rss_mb": 12.5}, reasons=("fine",))
+    assert EpisodeEvidence.from_json(r.to_json()) == r
+
+
+def test_summary_counts_both_denominators_and_withholds_the_percentage() -> None:
+    recs = [record(Disposition.VERIFIED_LOCAL_ATTEMPT, passing(), episode_id=f"v{i}")
+            for i in range(4)]
+    recs += [record(Disposition.LOCAL_FAILED, passing(passed=False, failed=1), episode_id=f"f{i}")
+             for i in range(2)]
+    recs += [record(Disposition.INELIGIBLE, None, episode_id="i0"),
+             record(Disposition.UNREPLAYABLE, None, episode_id="u0"),
+             record(Disposition.VERIFIER_INCONCLUSIVE, None, episode_id="q0"),
+             record(Disposition.AGREEMENT_ONLY, None, episode_id="a0"),
+             record(Disposition.NOT_ATTEMPTED_RESOURCE, None, episode_id="n0")]
+    s = summarize(recs)
+    assert (s.observed, s.eligible, s.attempted, s.checked, s.verified, s.failed) == (11, 9, 8, 6, 4, 2)
+    assert s.inconclusive == 1 and s.agreement_only == 1 and s.cohorts == 1
+    text = render(s)
+    assert "verified over eligible: 4 of 9" in text
+    assert "verified over observed: 4 of 11" in text
+    assert "%" not in text.split("(no percentage")[0]
+    assert f"no percentage before {HEADLINE_MIN_EPISODES}" in text
+
+
+def test_percentage_appears_only_at_the_floor_and_only_over_eligible() -> None:
+    recs = [record(Disposition.VERIFIED_LOCAL_ATTEMPT, passing(), episode_id=f"v{i}")
+            for i in range(HEADLINE_MIN_EPISODES)]
+    recs += [record(Disposition.INELIGIBLE, None, episode_id=f"i{i}") for i in range(10)]
+    text = render(summarize(recs))
+    assert f"verified over eligible: {HEADLINE_MIN_EPISODES} of {HEADLINE_MIN_EPISODES} (100%)" in text
+    assert f"verified over observed: {HEADLINE_MIN_EPISODES} of {HEADLINE_MIN_EPISODES + 10}\n" in text + "\n"
+    assert "no percentage" not in text

--- a/python/tests/test_shadow_verifier.py
+++ b/python/tests/test_shadow_verifier.py
@@ -1,0 +1,168 @@
+"""The protected verifier proven red on every way an attempt could look
+like a success without being one, and green on the one way it can be."""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from xyntetik_runner.shadow import Baseline, InstrumentError, ProtectedTests, calibrate, verify
+
+FIXTURE = Path(__file__).parent / "fixtures" / "repair_task_v1"
+
+CORRECT = '''"""Money parsing for the ledger importer."""
+from decimal import ROUND_HALF_UP, Decimal
+
+
+def parse_amount(text: str) -> int:
+    """Return the amount in integer cents for a decimal money string."""
+    cleaned = "".join(ch for ch in text if ch.isdigit() or ch in "-.")
+    return int((Decimal(cleaned) * 100).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+'''
+
+# Passes both visible tests; fails the float trap and the currency prefix.
+WRONG = '''"""Money parsing for the ledger importer."""
+
+
+def parse_amount(text: str) -> int:
+    """Return the amount in integer cents for a decimal money string."""
+    return int(float(text.replace(",", "")) * 100)
+'''
+
+MONKEYPATCH_CONFTEST = '''import pytest
+from decimal import Decimal
+
+TABLE = {"12.34": 1234, "1,234.50": 123450, "0.29": 29, "-12": -1200, "EUR 3.10": 310,
+         "€ 3.10": 310, " 7.05 ": 705}
+
+
+@pytest.fixture(autouse=True)
+def _rig(monkeypatch, request):
+    # The tests bind the name at import, so patch the test module itself.
+    monkeypatch.setattr(request.module, "parse_amount", lambda s: TABLE[s], raising=False)
+'''
+
+
+@pytest.fixture
+def task(tmp_path: Path) -> tuple[Path, Baseline, ProtectedTests]:
+    ws = tmp_path / "ws"
+    shutil.copytree(FIXTURE / "workspace", ws)
+    return ws, Baseline.capture(ws), ProtectedTests.load(FIXTURE / "protected")
+
+
+def visible_tests_pass(ws: Path) -> bool:
+    """What the attempt itself would see: the workspace's own tests."""
+    env = {k: v for k, v in os.environ.items() if k in ("PATH", "SYSTEMROOT", "SystemRoot")}
+    env["PYTHONPATH"] = str(ws)
+    r = subprocess.run([sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", "tests"],
+                       cwd=ws, capture_output=True, env=env)
+    return r.returncode == 0
+
+
+def test_manifest_is_frozen_and_checked(tmp_path: Path) -> None:
+    src = tmp_path / "protected"
+    shutil.copytree(FIXTURE / "protected", src)
+    ProtectedTests.load(src)
+    (src / "tests" / "test_money.py").write_text("def test_plain():\n    assert True\n")
+    with pytest.raises(InstrumentError, match="differs from its manifest"):
+        ProtectedTests.load(src)
+
+
+def test_calibration_proves_the_baseline_fails(task: tuple[Path, Baseline, ProtectedTests]) -> None:
+    ws, _, protected = task
+    cal = calibrate(protected, ws)
+    assert cal.failing >= 1 and cal.passing >= 1 and cal.missing == 0
+
+
+def test_calibration_refuses_a_protected_set_that_cannot_fail(tmp_path: Path) -> None:
+    ws = tmp_path / "ws"
+    shutil.copytree(FIXTURE / "workspace", ws)
+    src = tmp_path / "protected"
+    (src / "tests").mkdir(parents=True)
+    (src / "tests" / "test_money.py").write_text(
+        "from calc.money import parse_amount\n\n\ndef test_plain():\n    assert parse_amount('12.34') == 1234\n")
+    protected = ProtectedTests.freeze(src, {"tests/test_money.py": ["test_plain"]})
+    with pytest.raises(InstrumentError, match="cannot reject a no-op"):
+        calibrate(protected, ws)
+
+
+def test_correct_patch_is_verified(task: tuple[Path, Baseline, ProtectedTests]) -> None:
+    ws, base, protected = task
+    (ws / "calc" / "money.py").write_text(CORRECT)
+    out = verify(ws, protected, base)
+    assert out.passed is True and out.passed_count == 6 and not out.tamper and not out.reasons
+    assert out.output_sha256 and out.duration_s > 0
+    assert base.changes(ws).modified == ("calc/money.py",)
+
+
+def test_wrong_patch_passes_visible_tests_and_fails_protected(task: tuple[Path, Baseline, ProtectedTests]) -> None:
+    ws, base, protected = task
+    (ws / "calc" / "money.py").write_text(WRONG)
+    assert visible_tests_pass(ws), "the control must fool the attempt's own tests"
+    out = verify(ws, protected, base)
+    assert out.passed is False and out.failed >= 2 and not out.tamper
+
+
+def test_no_op_is_rejected_without_running(task: tuple[Path, Baseline, ProtectedTests]) -> None:
+    ws, base, protected = task
+    out = verify(ws, protected, base)
+    assert out.passed is False and out.duration_s == 0 and out.missing == out.expected
+    assert any(r.startswith("no_op") for r in out.reasons)
+
+
+def test_tampered_test_file_is_flagged_and_frozen_copy_runs(task: tuple[Path, Baseline, ProtectedTests]) -> None:
+    ws, base, protected = task
+    (ws / "tests" / "test_money.py").write_text("def test_plain():\n    assert True\n")
+    assert visible_tests_pass(ws)
+    out = verify(ws, protected, base)
+    assert out.passed is False
+    assert out.tamper == ("protected test file changed: tests/test_money.py",)
+    assert out.failed >= 1, "the frozen copy ran, not the tampered one"
+
+
+def test_conftest_injection_is_flagged_even_though_it_would_pass(task: tuple[Path, Baseline, ProtectedTests]) -> None:
+    ws, base, protected = task
+    (ws / "tests" / "conftest.py").write_text(MONKEYPATCH_CONFTEST)
+    assert visible_tests_pass(ws), "the control must fool a naive verifier"
+    out = verify(ws, protected, base)
+    assert out.passed is False
+    assert out.tamper == ("test configuration changed: tests/conftest.py",)
+    assert out.failed == 0 and out.passed_count == 6, "it fooled the frozen tests too; only the flag caught it"
+
+
+def test_config_injection_is_flagged(task: tuple[Path, Baseline, ProtectedTests]) -> None:
+    ws, base, protected = task
+    (ws / "calc" / "money.py").write_text(CORRECT)
+    (ws / "pytest.ini").write_text("[pytest]\naddopts = -k nothing_matches_this\n")
+    out = verify(ws, protected, base)
+    assert out.passed is False and "test configuration changed: pytest.ini" in out.tamper
+    assert out.passed_count == 6, "the verifier's own ini was used, the injected one ignored"
+
+
+def test_skip_cannot_count_as_success(task: tuple[Path, Baseline, ProtectedTests]) -> None:
+    ws, base, protected = task
+    (ws / "calc" / "money.py").write_text(
+        'import pytest\npytest.skip("skipping the module under test", allow_module_level=True)\n')
+    out = verify(ws, protected, base)
+    assert out.passed is False and (out.skipped + out.missing) == out.expected
+
+
+def test_timeout_is_inconclusive_never_a_pass(task: tuple[Path, Baseline, ProtectedTests]) -> None:
+    ws, base, protected = task
+    (ws / "calc" / "money.py").write_text("import time\ntime.sleep(60)\n")
+    out = verify(ws, protected, base, timeout_s=3)
+    assert out.passed is None and out.reasons == ("timeout after 3s",)
+    assert out.duration_s < 30
+
+
+def test_scratch_copy_leaves_the_workspace_untouched(task: tuple[Path, Baseline, ProtectedTests]) -> None:
+    ws, base, protected = task
+    (ws / "calc" / "money.py").write_text(CORRECT)
+    before = Baseline.capture(ws)
+    verify(ws, protected, base)
+    assert Baseline.capture(ws) == before
+    assert not (ws / "report.xml").exists() and not (ws / "verifier.ini").exists()


### PR DESCRIPTION
Shadow mode's instrument half, in the Python client, stdlib-only: `xyntetik_runner.shadow`.

- **Evidence contract**: one record per observed episode with a closed disposition list and an identity partition of the whole measured stack; a record cannot claim `verified_local_attempt` without a passing verifier outcome and cannot carry frontier content (both refused in `__post_init__`). The summary prints counts and both denominators and no percentage before thirty independent eligible episodes.
- **Protected verifier**: frozen tests outside the workspace under a hashed manifest, run over a scratch copy under the verifier's own pytest configuration, read from a JUnit report. A no-op, a changed protected test, a changed `conftest.py` or pytest config, a skip or a missing test cannot pass; a timeout is inconclusive. Calibration refuses a protected set that passes on the untouched baseline.
- **Proven red** on a frozen repair task: wrong patch that passes the visible tests, rewritten test file, monkeypatching `conftest.py` that fools both visible and frozen tests, injected `pytest.ini`, module-level skip, hang. The one correct patch is verified.
- Found on the way: pytest derives JUnit classnames from the `-c` file's directory, so the verifier's ini sits at the workspace root.

Gates: `python/tests/` 69 passed (19 new), mypy strict clean on the package. Not a sandbox; OS isolation is a separate story.
