### PR TITLE
shadow: import, replay, report, and the prospective capture path (R14.2 to R14.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ names that were true when they were written.
 
 ## Unreleased
 
+- **Shadow mode runs end to end (R14.2 to R14.5): `python -m
+  xyntetik_runner.shadow import | replay | report`.** The importer reads the
+  Codex and Claude Code session files already on the machine and takes from
+  each task boundary the working directory, the timestamps and the user's
+  own request; it never reads an assistant message, a tool argument or a
+  tool result, and a record that loaded frontier content is refused by the
+  contract. The repository, not the trace, supplies the task: the commits
+  in the episode's window (in any repository at or under the working
+  directory) give a pre-state, a post-state and the touched files; a fix
+  commit is attributed to one prompt, the repository's own over a parent
+  directory, then the latest before the fix. A task is admitted when the
+  range touched pytest test files and Python source and nothing that needs
+  a build, the post-state's test files collect and pass on the post-state
+  tree, and the same frozen files fail on the pre-state tree; every other
+  episode gets its disposition and reason in the ledger first, so the
+  denominator is complete before any model runs. The attempt harness gives
+  the model a scratch worktree at the pre-state, the request, the names of
+  the visible test files, and five tools (list, read, write, run the
+  visible tests, finish), no shell, every path confined to the copy, and a
+  budget on turns, tool calls, wall clock and test runs; it keeps the
+  transcript and final diff beside the task. `tool_choice` is required on
+  every turn, because without it Qwen2.5-Coder wrote its calls as JSON
+  code blocks and made none. The verdict is the frozen tests, all or
+  nothing; beside it the record says how many of the tests that failed at
+  base the attempt turned green, which is the number a reader wants.
+  `report` prints counts, both denominators and no percentage before
+  thirty independent eligible episodes; `--tasks` lists each admitted task
+  with its request and every attempt on it. Not a sandbox: the attempt's
+  test runs and the verifier run as the calling user with the network
+  reachable; OS isolation is a separate story. Found on the way: JUnit
+  keys methods by `module.Class`, so an expected `Class::test` id must be
+  joined the same way or whole suites read as missing; a solution's own
+  test edits are not tampering, so admission checks the post-state without
+  the baseline logic; and the first pairing heuristic gave one task a
+  request about a planning document, which is why attribution is now by
+  closest prompt and fixed-at-base counts are reported.
+
 - **Shadow mode, the instrument half (R14.1): an evidence contract and a
   protected verifier in the Python client.** `xyntetik_runner.shadow` is
   stdlib-only and answers one question about a local model honestly: did an

--- a/README.md
+++ b/README.md
@@ -1772,6 +1772,62 @@ the user request, so use at least a 16k context for that workflow. Runner does
 not implement a response store; clients must send history each turn rather
 than use `previous_response_id`.
 
+## Shadow mode: what could your local model have done?
+
+`python -m xyntetik_runner.shadow` answers one question about the coding
+work you already paid a frontier agent for: given the same request and the
+same repository state, could a local model have done it, judged by tests it
+could not see or change. It reads the Codex and Claude Code session files
+already on your machine, takes from each task only the working directory,
+the timestamps and your own request (never the assistant's answer, tool
+arguments or tool results), pairs the task with the commits it produced,
+freezes the tests those commits added or changed as the verifier, and
+requires them to fail before the fix and pass after it. A local model then
+gets a scratch copy at the pre-fix state, your request, and five tools
+(list, read, write, run the visible tests, finish), with no shell and every
+path confined to the copy. The frozen tests decide, all or nothing, and the
+record also says how many of the tests that failed before the fix the
+attempt turned green.
+
+```sh
+pip install ./python                                   # the client package
+python -m xyntetik_runner.shadow import --python "$(which python3)"
+runner -m model.gguf --serve --port 8080 --no-tray     # any supported model
+python -m xyntetik_runner.shadow replay --endpoint http://127.0.0.1:8080
+python -m xyntetik_runner.shadow report --tasks
+```
+
+The report prints counts and both denominators (verified over the episodes
+that could be replayed, and over everything observed) and refuses to print
+a percentage before thirty independent eligible episodes, because a
+percentage over a handful of tasks is not a measurement. What this is not:
+a router, a training loop, or a sandbox. The attempt's test runs and the
+verifier run as you, with the network reachable; treat the scratch copy as
+you would any code you run locally.
+
+Two limits found on the first real run, both properties of history rather
+than of any model. Agentic sessions commit many turns after the request,
+so the last prompt before a commit is often a side remark and the fix
+cannot be attributed to its request from the timeline alone. And a terse
+request ("check why CI fails and fix it") carries no failing signal the
+model can see, because the tests that fail at the pre-fix state are the
+new ones. Both are addressed by capturing prospectively: a prompt hook and
+a stop hook record the request with the repository HEAD at both ends, so
+the task's commit range is exact.
+
+```json
+{"hooks": {
+  "UserPromptSubmit": [{"hooks": [{"type": "command",
+    "command": "python3 -m xyntetik_runner.shadow capture --event prompt"}]}],
+  "Stop": [{"hooks": [{"type": "command",
+    "command": "python3 -m xyntetik_runner.shadow capture --event stop"}]}]}}
+```
+
+Only your request, the directory, the time and the commit id are written;
+the file is `~/.xyntetik/shadow/capture.jsonl` and `import` reads it beside
+the session files. Design, gates and the negative controls that prove the
+verifier can fail: [python/README.md](python/README.md).
+
 ## Desktop tray
 
 macOS and Windows ship a menu-bar / notification-area controller. It lists

--- a/python/README.md
+++ b/python/README.md
@@ -51,3 +51,26 @@ route requests, train, or sandbox.
 The negative controls that prove the verifier can fail live in
 `python/tests/test_shadow_verifier.py` against the frozen repair task in
 `python/tests/fixtures/repair_task_v1`.
+
+- `importer`: `scan_all` reads the Codex (`~/.codex/sessions`) and Claude Code
+  (`~/.claude/projects`) session files and yields one `Episode` per task
+  boundary: source, session, turn, working directory, start and end, the
+  user's request. Never an assistant message, tool argument or tool result.
+- `tasks`: `pair` finds the commit ranges an episode's window covers in any
+  repository at or under its directory; `choose` gives each fix commit to one
+  prompt; `build_task` freezes the post-state test files, requires them to
+  pass on the post-state and fail on the pre-state, and writes a `RepairTask`
+  that records which tests fail at base. The source diff is never given to
+  the attempt.
+- `attempt`: `Workspace` confines paths to a scratch worktree and offers
+  `list_files`, `read_file`, `write_file`, `run_tests`; `attempt` drives a
+  model through `finish` under a `Budget` and keeps the transcript.
+- `cli`: `python -m xyntetik_runner.shadow import --out DIR --python PY` scans
+  and admits; `replay --out DIR --endpoint URL` attempts each admitted task
+  against a runner and verifies it; `report --out DIR [--by-reason] [--tasks]`
+  prints counts and both denominators. Pass `--python` the interpreter that
+  can run the repositories' tests.
+
+The pipeline is exercised without a model in `python/tests/test_shadow_pipeline.py`
+on synthetic traces and a synthetic repository; a scripted chat function
+proves the plumbing and the confinement, the pilot measures the model.

--- a/python/src/xyntetik_runner/shadow/__init__.py
+++ b/python/src/xyntetik_runner/shadow/__init__.py
@@ -32,6 +32,7 @@ from xyntetik_runner.shadow.verifier import (
     InstrumentError,
     ProtectedTests,
     calibrate,
+    check,
     verify,
 )
 
@@ -50,6 +51,7 @@ __all__ = [
     "Summary",
     "VerifierOutcome",
     "calibrate",
+    "check",
     "file_sha256",
     "render",
     "summarize",

--- a/python/src/xyntetik_runner/shadow/__init__.py
+++ b/python/src/xyntetik_runner/shadow/__init__.py
@@ -33,6 +33,7 @@ from xyntetik_runner.shadow.verifier import (
     ProtectedTests,
     calibrate,
     check,
+    fixed_ids,
     verify,
 )
 
@@ -52,6 +53,7 @@ __all__ = [
     "VerifierOutcome",
     "calibrate",
     "check",
+    "fixed_ids",
     "file_sha256",
     "render",
     "summarize",

--- a/python/src/xyntetik_runner/shadow/__init__.py
+++ b/python/src/xyntetik_runner/shadow/__init__.py
@@ -18,6 +18,7 @@ from xyntetik_runner.shadow.baseline import Baseline, Changes, file_sha256, tree
 from xyntetik_runner.shadow.evidence import (
     HEADLINE_MIN_EPISODES,
     SCHEMA_VERSION,
+    CohortSummary,
     Disposition,
     EpisodeEvidence,
     Identity,
@@ -44,6 +45,7 @@ __all__ = [
     "Baseline",
     "Calibration",
     "Changes",
+    "CohortSummary",
     "Disposition",
     "EpisodeEvidence",
     "Identity",

--- a/python/src/xyntetik_runner/shadow/__main__.py
+++ b/python/src/xyntetik_runner/shadow/__main__.py
@@ -1,0 +1,3 @@
+from xyntetik_runner.shadow.cli import main
+
+raise SystemExit(main())

--- a/python/src/xyntetik_runner/shadow/attempt.py
+++ b/python/src/xyntetik_runner/shadow/attempt.py
@@ -1,0 +1,324 @@
+"""A bounded local attempt: the model, a scratch copy, four tools, a budget.
+
+The attempt sees the pre-state tree, the user's request and the names of the
+test files that existed at the pre-state. It gets four tools: list files,
+read a file, write a file, run the visible tests; and ``finish``. There is
+no shell. Every path is resolved inside the scratch copy and a path that
+escapes it is refused, so the attempt cannot read or write the original
+repository. The budget bounds turns, tool calls, wall clock and test runs;
+running out of any of them ends the attempt with that reason and the
+verifier then judges whatever is in the tree.
+
+Not a sandbox: ``run_tests`` executes the tests, and therefore the code the
+model wrote, as the calling user with the network reachable. That is the
+same exposure the verifier has and is the subject of R14.3.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from xyntetik_runner.shadow.baseline import IGNORED_DIRS
+
+ChatFn = Callable[[list[dict[str, Any]], list[dict[str, Any]]], dict[str, Any]]
+"""``chat(messages, tools) -> assistant message`` (``content``, optional
+``tool_calls`` in the OpenAI shape, optional ``usage``)."""
+
+TOOLS: list[dict[str, Any]] = [
+    {"type": "function", "function": {
+        "name": "list_files", "description": "List files under the workspace matching a glob "
+        "(default: everything). Directories like .git and __pycache__ are hidden.",
+        "parameters": {"type": "object", "properties": {"pattern": {"type": "string"}},
+                       "required": []}}},
+    {"type": "function", "function": {
+        "name": "read_file", "description": "Read a UTF-8 text file from the workspace. "
+        "Long files are returned in windows: pass offset (line, 0-based) to continue.",
+        "parameters": {"type": "object", "properties": {
+            "path": {"type": "string"}, "offset": {"type": "integer"}},
+            "required": ["path"]}}},
+    {"type": "function", "function": {
+        "name": "write_file", "description": "Write the complete new content of a file in the "
+        "workspace, creating it if needed.",
+        "parameters": {"type": "object", "properties": {
+            "path": {"type": "string"}, "content": {"type": "string"}},
+            "required": ["path", "content"]}}},
+    {"type": "function", "function": {
+        "name": "run_tests", "description": "Run the visible test files with pytest and return "
+        "the tail of the output.",
+        "parameters": {"type": "object", "properties": {}, "required": []}}},
+    {"type": "function", "function": {
+        "name": "finish", "description": "Declare the task done. Call this when the tests pass "
+        "or when you cannot make further progress.",
+        "parameters": {"type": "object", "properties": {"summary": {"type": "string"}},
+                       "required": []}}},
+]
+
+SYSTEM_PROMPT = (
+    "You are a software engineer fixing a repository checked out at the workspace root. "
+    "Work only through the tools. Read before you edit, change only what the task needs, "
+    "write complete files, run the tests to check your work, and call finish when the "
+    "tests pass or you cannot make further progress. Never ask the user questions."
+)
+
+
+@dataclass(frozen=True)
+class Budget:
+    max_turns: int = 12
+    max_tool_calls: int = 40
+    wall_s: float = 900.0
+    max_tokens: int = 1500
+    test_runs: int = 4
+    test_timeout_s: float = 120.0
+    read_lines: int = 200
+    read_chars: int = 12000
+    list_entries: int = 200
+    output_chars: int = 3000
+
+
+@dataclass(frozen=True)
+class AttemptResult:
+    turns: int
+    tool_calls: int
+    test_runs: int
+    prompt_tokens: int
+    completion_tokens: int
+    wall_s: float
+    stop_reason: str
+    finished: bool
+    summary: str = ""
+    tool_names: tuple[str, ...] = ()
+    transcript: tuple[dict[str, Any], ...] = ()
+    """Every message of the attempt, the local model's own words and the
+    tool results it saw. Kept as evidence: it is what the record explains."""
+
+
+class Workspace:
+    """Path confinement and the four tools over one directory."""
+
+    def __init__(self, root: Path, *, visible_tests: Sequence[str], pythonpath: Sequence[str],
+                 python: str, budget: Budget):
+        self.root = root.resolve()
+        self.visible_tests = tuple(visible_tests)
+        self.pythonpath = tuple(pythonpath)
+        self.python = python
+        self.budget = budget
+        self.test_runs = 0
+
+    def resolve(self, rel: str) -> Path:
+        if not isinstance(rel, str) or not rel or rel.startswith(("/", "\\")) or ":" in rel[:3]:
+            raise ValueError("path must be relative to the workspace")
+        target = (self.root / rel).resolve()
+        if target != self.root and self.root not in target.parents:
+            raise ValueError("path escapes the workspace")
+        return target
+
+    def list_files(self, pattern: str = "**/*") -> str:
+        pattern = pattern or "**/*"
+        if pattern.startswith(("/", "\\")) or ".." in pattern:
+            return "error: pattern must be relative and may not contain .."
+        out: list[str] = []
+        for p in sorted(self.root.glob(pattern)):
+            rel = p.relative_to(self.root)
+            if any(part in IGNORED_DIRS for part in rel.parts):
+                continue
+            if p.is_file():
+                out.append(rel.as_posix())
+            if len(out) >= self.budget.list_entries:
+                out.append(f"... (truncated at {self.budget.list_entries} entries)")
+                break
+        return "\n".join(out) if out else "(no files match)"
+
+    def read_file(self, path: str, offset: int = 0) -> str:
+        try:
+            target = self.resolve(path)
+        except ValueError as e:
+            return f"error: {e}"
+        if not target.is_file():
+            return "error: no such file"
+        try:
+            lines = target.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError) as e:
+            return f"error: {e}"
+        offset = max(0, int(offset or 0))
+        window = lines[offset:offset + self.budget.read_lines]
+        text = "\n".join(f"{offset + i + 1}: {line}" for i, line in enumerate(window))
+        if len(text) > self.budget.read_chars:
+            text = text[:self.budget.read_chars] + "\n... (truncated)"
+        remaining = len(lines) - (offset + len(window))
+        if remaining > 0:
+            text += f"\n... {remaining} more line(s); call again with offset={offset + len(window)}"
+        return text or "(empty file)"
+
+    def write_file(self, path: str, content: str) -> str:
+        try:
+            target = self.resolve(path)
+        except ValueError as e:
+            return f"error: {e}"
+        if not isinstance(content, str):
+            return "error: content must be a string"
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+        except OSError as e:
+            return f"error: {e}"
+        return f"wrote {len(content)} chars to {path}"
+
+    def run_tests(self) -> str:
+        if self.test_runs >= self.budget.test_runs:
+            return f"error: test-run budget of {self.budget.test_runs} exhausted"
+        self.test_runs += 1
+        targets = [t for t in self.visible_tests if (self.root / t).is_file()]
+        if not targets:
+            targets = ["tests"] if (self.root / "tests").is_dir() else ["."]
+        env = {k: os.environ[k] for k in ("PATH", "SYSTEMROOT", "SystemRoot", "TEMP", "TMP")
+               if k in os.environ}
+        env.update({"HOME": str(self.root), "PYTHONDONTWRITEBYTECODE": "1",
+                    "PYTHONPATH": os.pathsep.join([str(self.root)] +
+                                                  [str(self.root / r) for r in self.pythonpath])})
+        cmd = [self.python, "-m", "pytest", "-q", "-x", "-p", "no:cacheprovider", *targets]
+        proc = subprocess.Popen(cmd, cwd=self.root, env=env, stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT, start_new_session=(os.name == "posix"))
+        try:
+            out, _ = proc.communicate(timeout=self.budget.test_timeout_s)
+        except subprocess.TimeoutExpired:
+            try:
+                if os.name == "posix":
+                    os.killpg(proc.pid, signal.SIGKILL)
+                else:
+                    proc.kill()
+            except OSError:
+                pass
+            out, _ = proc.communicate()
+            return f"error: tests timed out after {self.budget.test_timeout_s:g}s"
+        text = (out or b"").decode("utf-8", errors="replace")
+        if len(text) > self.budget.output_chars:
+            text = "...\n" + text[-self.budget.output_chars:]
+        return f"exit code {proc.returncode}\n{text}"
+
+
+def _fn(call: dict[str, Any]) -> dict[str, Any]:
+    fn = call.get("function")
+    return fn if isinstance(fn, dict) else call
+
+
+def _args(call: dict[str, Any]) -> dict[str, Any]:
+    raw = _fn(call).get("arguments", {})
+    if isinstance(raw, dict):
+        return raw
+    try:
+        parsed = json.loads(raw) if isinstance(raw, str) and raw.strip() else {}
+    except ValueError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _name(call: dict[str, Any]) -> str:
+    return str(_fn(call).get("name") or "")
+
+
+def attempt(request: str, workspace: Workspace, chat: ChatFn, *, budget: Budget | None = None
+            ) -> AttemptResult:
+    budget = budget or workspace.budget
+    listing = workspace.list_files("*")
+    user = (f"Task:\n{request.strip()}\n\nVisible test files: "
+            f"{', '.join(workspace.visible_tests) or '(none at this state; look for tests/)'}\n\n"
+            f"Top-level files:\n{listing}")
+    messages: list[dict[str, Any]] = [{"role": "system", "content": SYSTEM_PROMPT},
+                                      {"role": "user", "content": user}]
+    t0 = time.monotonic()
+    turns = calls = ptoks = ctoks = 0
+    nudged = False
+    names: list[str] = []
+    while True:
+        if turns >= budget.max_turns:
+            return _done(turns, calls, workspace, ptoks, ctoks, t0, "turn budget", False, names,
+                         messages=messages)
+        if time.monotonic() - t0 > budget.wall_s:
+            return _done(turns, calls, workspace, ptoks, ctoks, t0, "wall clock", False, names,
+                         messages=messages)
+        turns += 1
+        try:
+            reply = chat(messages, TOOLS)
+        except Exception as e:  # the model side failed; the tree is still judged
+            return _done(turns, calls, workspace, ptoks, ctoks, t0,
+                         f"model error: {type(e).__name__}", False, names, messages=messages)
+        usage_raw = reply.get("usage")
+        usage: dict[str, Any] = usage_raw if isinstance(usage_raw, dict) else {}
+        ptoks += int(usage.get("prompt_tokens", 0) or 0)
+        ctoks += int(usage.get("completion_tokens", 0) or 0)
+        calls_raw = reply.get("tool_calls")
+        tool_calls: list[dict[str, Any]] = [c for c in calls_raw if isinstance(c, dict)] \
+            if isinstance(calls_raw, list) else []
+        assistant: dict[str, Any] = {"role": "assistant", "content": reply.get("content") or ""}
+        if tool_calls:
+            assistant["tool_calls"] = tool_calls
+        messages.append(assistant)
+        if not tool_calls:
+            if nudged:
+                return _done(turns, calls, workspace, ptoks, ctoks, t0, "no tool call", False, names,
+                             messages=messages)
+            nudged = True
+            messages.append({"role": "user", "content": "Use the tools to make the change, run "
+                             "the tests, then call finish."})
+            continue
+        for call in tool_calls:
+            calls += 1
+            if calls > budget.max_tool_calls:
+                return _done(turns, calls, workspace, ptoks, ctoks, t0, "tool-call budget", False,
+                             names, messages=messages)
+            name, args = _name(call), _args(call)
+            names.append(name)
+            if name == "finish":
+                return _done(turns, calls, workspace, ptoks, ctoks, t0, "finish", True, names,
+                             str(args.get("summary") or ""), messages=messages)
+            if name == "list_files":
+                result = workspace.list_files(str(args.get("pattern") or "**/*"))
+            elif name == "read_file":
+                result = workspace.read_file(str(args.get("path") or ""), int(args.get("offset") or 0))
+            elif name == "write_file":
+                result = workspace.write_file(str(args.get("path") or ""), args.get("content"))  # type: ignore[arg-type]
+            elif name == "run_tests":
+                result = workspace.run_tests()
+            else:
+                result = f"error: unknown tool {name!r}"
+            messages.append({"role": "tool", "tool_call_id": str(call.get("id") or f"call_{calls}"),
+                             "name": name, "content": result})
+
+
+def _done(turns: int, calls: int, ws: Workspace, ptoks: int, ctoks: int, t0: float, reason: str,
+          finished: bool, names: list[str], summary: str = "",
+          messages: Sequence[dict[str, Any]] = ()) -> AttemptResult:
+    return AttemptResult(turns=turns, tool_calls=calls, test_runs=ws.test_runs,
+                         prompt_tokens=ptoks, completion_tokens=ctoks,
+                         wall_s=round(time.monotonic() - t0, 3), stop_reason=reason,
+                         finished=finished, summary=summary, tool_names=tuple(sorted(set(names))),
+                         transcript=tuple(messages))
+
+
+def runner_chat(post_json: Callable[..., dict[str, Any]], model: str, *, max_tokens: int,
+                temperature: float = 0.0) -> ChatFn:
+    """Adapt ``RunnerEndpoint.post_json`` to the ``ChatFn`` shape."""
+    def chat(messages: list[dict[str, Any]], tools: list[dict[str, Any]]) -> dict[str, Any]:
+        # "required" constrains every turn to a real tool call through the
+        # runner's schema-driven decoding; finish is a tool, so the loop can
+        # still end. Without it Qwen2.5-Coder wrote its calls as JSON code
+        # blocks in the text and the runner rightly returned no tool call.
+        payload = {"model": model, "messages": messages, "tools": tools,
+                   "tool_choice": "required", "max_tokens": max_tokens,
+                   "temperature": temperature}
+        data = post_json("/v1/chat/completions", payload)
+        choice = data["choices"][0]
+        msg = dict(choice["message"])
+        if isinstance(data.get("usage"), dict):
+            msg["usage"] = data["usage"]
+        return msg
+    return chat
+

--- a/python/src/xyntetik_runner/shadow/cli.py
+++ b/python/src/xyntetik_runner/shadow/cli.py
@@ -84,6 +84,7 @@ def cmd_import(args: argparse.Namespace) -> int:
           f"{n} episodes", flush=True)
     evidence = out / "evidence.jsonl"
     known = {r.episode_id for r in _read_records(evidence)}
+    known |= {t.episode_id for t in _tasks(out, None)}
     counts: dict[str, int] = {}
     admitted = 0
 
@@ -125,6 +126,10 @@ def cmd_import(args: argparse.Namespace) -> int:
         if isinstance(result, RepairTask):
             admitted += 1
             counts["admitted"] = counts.get("admitted", 0) + 1
+            # Eligible and waiting for a model: the record exists now so the
+            # denominator is complete before any replay.
+            record(c.episode, Rejection(Disposition.NOT_ATTEMPTED_RESOURCE,
+                                        f"admitted as {result.task_id}; not attempted yet"))
             print(f"  admitted {result.task_id}: {result.expected_tests} frozen tests, "
                   f"{result.baseline_failing} fail at base, {result.src_files} source file(s)",
                   flush=True)
@@ -176,6 +181,7 @@ def cmd_replay(args: argparse.Namespace) -> int:
         backend=str(caps.get("backend") or "unknown"), harness_version=HARNESS_VERSION)
     done = {(r.episode_id, r.identity.model_sha256) for r in _read_records(evidence)
             if r.verifier is not None}
+    # A resumed import must not re-import an admitted episode as a new one.
     ran = 0
     for task in _tasks(out, args.task):
         if args.limit and ran >= args.limit:

--- a/python/src/xyntetik_runner/shadow/cli.py
+++ b/python/src/xyntetik_runner/shadow/cli.py
@@ -33,7 +33,7 @@ from xyntetik_runner.shadow.evidence import (
     render,
     summarize,
 )
-from xyntetik_runner.shadow.importer import Episode, read_episodes, scan_all, write_episodes
+from xyntetik_runner.shadow.importer import CAPTURE_FILE, Episode, read_episodes, scan_all, write_episodes
 from xyntetik_runner.shadow.tasks import Candidate, RepairTask, Rejection, build_task, choose, pair
 from xyntetik_runner.shadow.verifier import ProtectedTests, fixed_ids, verify
 
@@ -250,6 +250,32 @@ def _keep_attempt(out: Path, task: RepairTask, ident: Identity, result: Any, ws_
     (d / f"{stem}.diff").write_text(diff.stdout, encoding="utf-8")
 
 
+def cmd_capture(args: argparse.Namespace) -> int:
+    """Append one prompt or stop line from a hook. Reads the hook's JSON on
+    stdin (Claude Code passes ``session_id``, ``cwd`` and, on prompt
+    submission, ``prompt``); records the request, the directory, the time
+    and the repository HEAD, and nothing the assistant produced."""
+    try:
+        data = json.loads(sys.stdin.read() or "{}")
+    except ValueError:
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+    cwd = str(args.cwd or data.get("cwd") or Path.cwd())
+    head = subprocess.run(["git", "-C", cwd, "rev-parse", "HEAD"], capture_output=True,
+                          text=True).stdout.strip()
+    rec: dict[str, Any] = {"event": args.event, "timestamp": _now(),
+                           "session_id": str(args.session or data.get("session_id") or ""),
+                           "cwd": cwd, "head": head, "tool": args.tool}
+    if args.event == "prompt":
+        rec["prompt"] = str(data.get("prompt") or args.prompt or "")
+    path = Path(args.file) if args.file else Path.home() / CAPTURE_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(rec, sort_keys=True) + "\n")
+    return 0
+
+
 def cmd_report(args: argparse.Namespace) -> int:
     out = Path(args.out)
     records = _read_records(out / "evidence.jsonl")
@@ -312,6 +338,14 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--test-runs", type=int, default=4)
     p.add_argument("--wall", type=float, default=900.0)
     p.set_defaults(fn=cmd_replay)
+    p = sub.add_parser("capture", help="append a prompt or stop event from an agent hook")
+    p.add_argument("--event", choices=["prompt", "stop"], required=True)
+    p.add_argument("--tool", default="claude_code")
+    p.add_argument("--cwd", default="")
+    p.add_argument("--session", default="")
+    p.add_argument("--prompt", default="")
+    p.add_argument("--file", default="")
+    p.set_defaults(fn=cmd_capture)
     p = sub.add_parser("report", help="counts and both denominators")
     p.add_argument("--out", default=str(DEFAULT_OUT))
     p.add_argument("--by-reason", action="store_true")

--- a/python/src/xyntetik_runner/shadow/cli.py
+++ b/python/src/xyntetik_runner/shadow/cli.py
@@ -1,0 +1,265 @@
+"""``python -m xyntetik_runner.shadow``: import, replay, report.
+
+``import`` scans the frontier traces on this machine, pairs each episode with
+the commits in its window, admits the ones that can be verified, and writes
+one evidence record for every episode it could not admit, so the
+denominator is complete before any model runs. ``replay`` runs the bounded
+attempt on each admitted task against a runner endpoint and verifies it
+with the frozen tests. ``report`` prints counts and both denominators.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from xyntetik_runner.endpoint import RunnerEndpoint
+from xyntetik_runner.shadow.attempt import Budget, Workspace, attempt, runner_chat
+from xyntetik_runner.shadow.baseline import Baseline
+from xyntetik_runner.shadow.evidence import (
+    Disposition,
+    EpisodeEvidence,
+    Identity,
+    VerifierOutcome,
+    render,
+    summarize,
+)
+from xyntetik_runner.shadow.importer import Episode, read_episodes, scan_all, write_episodes
+from xyntetik_runner.shadow.tasks import RepairTask, Rejection, admit
+from xyntetik_runner.shadow.verifier import ProtectedTests, verify
+
+HARNESS_VERSION = "shadow-0.1"
+DEFAULT_OUT = Path.home() / ".xyntetik" / "shadow"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _band(chars: int) -> str:
+    return "<2k" if chars < 2000 else "<8k" if chars < 8000 else ">=8k"
+
+
+def _instrument_identity(verifier_id: str) -> Identity:
+    """The identity of an episode no model touched: the instrument alone."""
+    return Identity(project="", task_class="repair", context_band="", tool_set=(),
+                    verifier_id=verifier_id, environment_id=platform.node(), model_sha256="none",
+                    quant="none", template_sha256="none", runner_build="none", backend="none",
+                    harness_version=HARNESS_VERSION)
+
+
+def _append(path: Path, record: EpisodeEvidence) -> None:
+    with path.open("a", encoding="utf-8") as f:
+        f.write(record.to_json() + "\n")
+
+
+def _read_records(path: Path) -> list[EpisodeEvidence]:
+    if not path.is_file():
+        return []
+    out: list[EpisodeEvidence] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            out.append(EpisodeEvidence.from_json(line))
+    return out
+
+
+def cmd_import(args: argparse.Namespace) -> int:
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    tasks_dir = out / "tasks"
+    tasks_dir.mkdir(exist_ok=True)
+    report = scan_all(Path(args.home) if args.home else None)
+    episodes = [e for e in report.episodes if not args.source or e.source == args.source]
+    n = write_episodes(episodes, out / "episodes.jsonl")
+    print(f"scanned {report.files_read} trace files ({len(report.files_skipped)} unreadable), "
+          f"{n} episodes", flush=True)
+    evidence = out / "evidence.jsonl"
+    known = {r.episode_id for r in _read_records(evidence)}
+    seen: set[tuple[str, str]] = set()
+    counts: dict[str, int] = {}
+    admitted = 0
+    for e in episodes:
+        if e.episode_id in known:
+            continue
+        result = admit(e, out_dir=tasks_dir, python=args.python, timeout_s=args.timeout, seen=seen)
+        if isinstance(result, RepairTask):
+            admitted += 1
+            counts["admitted"] = counts.get("admitted", 0) + 1
+            print(f"  admitted {result.task_id}: {result.expected_tests} frozen tests, "
+                  f"{result.baseline_failing} fail at base, {result.src_files} source file(s)",
+                  flush=True)
+            continue
+        rec = EpisodeEvidence(
+            episode_id=e.episode_id, source=e.source, observed_at=e.started_at,
+            disposition=result.disposition, identity=_instrument_identity("none"),
+            baseline_sha256="", patch_sha256=None, changed_paths=(), verifier=None, wall_s=0.0,
+            reasons=(result.reason,))
+        _append(evidence, rec)
+        counts[result.disposition.value] = counts.get(result.disposition.value, 0) + 1
+    print("dispositions at import:", json.dumps(counts, sort_keys=True), flush=True)
+    print(f"{admitted} task(s) admitted under {tasks_dir}", flush=True)
+    return 0
+
+
+def _tasks(out: Path, only: str | None) -> list[RepairTask]:
+    tasks = [RepairTask.load(p) for p in sorted((out / "tasks").glob("*/task.json"))]
+    return [t for t in tasks if not only or t.task_id == only]
+
+
+def _worktree(task: RepairTask) -> Path:
+    d = Path(tempfile.mkdtemp(prefix="xyntetik-shadow-attempt-"))
+    proc = subprocess.run(["git", "-C", task.repo, "worktree", "add", "--detach", "-q", str(d),
+                           task.base_sha], capture_output=True, text=True)
+    if proc.returncode != 0:
+        shutil.rmtree(d, ignore_errors=True)
+        raise RuntimeError(f"git worktree add failed: {proc.stderr.strip()[:200]}")
+    return d
+
+
+def _drop(task: RepairTask, d: Path) -> None:
+    subprocess.run(["git", "-C", task.repo, "worktree", "remove", "--force", str(d)],
+                   capture_output=True)
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def cmd_replay(args: argparse.Namespace) -> int:
+    out = Path(args.out)
+    evidence = out / "evidence.jsonl"
+    endpoint = RunnerEndpoint(args.endpoint, timeout=args.request_timeout)
+    caps = endpoint.capabilities()
+    models = [m.get("id") for m in caps.get("models", []) if isinstance(m, dict)]
+    model = args.model or (str(models[0]) if models else "")
+    if not model:
+        print("error: the endpoint reports no model; pass --model", file=sys.stderr)
+        return 2
+    budget = Budget(max_turns=args.max_turns, wall_s=args.wall, max_tokens=args.max_tokens,
+                    test_runs=args.test_runs)
+    base_identity = Identity(
+        project="", task_class="repair", context_band="", tool_set=(),
+        verifier_id="", environment_id=f"{platform.node()}|{args.endpoint}",
+        model_sha256=args.model_sha256 or f"unknown:{model}", quant=args.quant or "unknown",
+        template_sha256="unknown", runner_build=str(caps.get("version") or "unknown"),
+        backend=str(caps.get("backend") or "unknown"), harness_version=HARNESS_VERSION)
+    done = {(r.episode_id, r.identity.model_sha256) for r in _read_records(evidence)
+            if r.verifier is not None}
+    ran = 0
+    for task in _tasks(out, args.task):
+        if args.limit and ran >= args.limit:
+            break
+        ident = replace(base_identity, project=Path(task.repo).name,
+                        context_band=_band(len(task.request)),
+                        tool_set=("list_files", "read_file", "write_file", "run_tests"),
+                        verifier_id=f"commit-tests:{task.task_id}")
+        if (task.episode_id, ident.model_sha256) in done:
+            continue
+        ran += 1
+        print(f"[{task.task_id}] attempt with {model} ...", flush=True)
+        ws_dir = _worktree(task)
+        try:
+            baseline = Baseline.capture(ws_dir)
+            ws = Workspace(ws_dir, visible_tests=task.visible_test_files,
+                           pythonpath=task.pythonpath, python=args.python, budget=budget)
+            chat = runner_chat(endpoint.post_json, model, max_tokens=budget.max_tokens)
+            result = attempt(task.request, ws, chat, budget=budget)
+            protected = ProtectedTests.load(Path(task.protected_dir))
+            outcome = verify(ws_dir, protected, baseline, timeout_s=args.timeout,
+                             python=args.python, pythonpath=task.pythonpath)
+            changes = baseline.changes(ws_dir)
+            if outcome.passed is True:
+                disposition = Disposition.VERIFIED_LOCAL_ATTEMPT
+            elif outcome.passed is False:
+                disposition = Disposition.LOCAL_FAILED
+            else:
+                disposition = Disposition.VERIFIER_INCONCLUSIVE
+            rec = EpisodeEvidence(
+                episode_id=task.episode_id, source=task.episode_id.split(":")[0],
+                observed_at=_now(), disposition=disposition, identity=ident,
+                baseline_sha256=baseline.sha256,
+                patch_sha256=baseline.patch_sha256(ws_dir) if changes else None,
+                changed_paths=changes.paths, verifier=outcome, wall_s=result.wall_s,
+                resources={"prompt_tokens": float(result.prompt_tokens),
+                           "completion_tokens": float(result.completion_tokens),
+                           "turns": float(result.turns), "tool_calls": float(result.tool_calls),
+                           "test_runs": float(result.test_runs)},
+                reasons=(f"attempt: {result.stop_reason}", *outcome.reasons))
+            _append(evidence, rec)
+            _keep_attempt(out, task, ident, result, ws_dir)
+            print(f"[{task.task_id}] {disposition.value}: {result.stop_reason}, "
+                  f"{result.turns} turns, {result.tool_calls} calls, {result.wall_s:.0f}s; "
+                  f"verifier {outcome.passed_count}/{outcome.expected}"
+                  f"{' tamper' if outcome.tamper else ''}", flush=True)
+        finally:
+            _drop(task, ws_dir)
+    print(f"{ran} attempt(s) recorded in {evidence}", flush=True)
+    return 0
+
+
+def _keep_attempt(out: Path, task: RepairTask, ident: Identity, result: Any, ws_dir: Path) -> None:
+    """Transcript and final diff of one attempt, beside its task: the local
+    model's own words and edits, which the evidence record summarizes."""
+    d = out / "attempts" / task.task_id
+    d.mkdir(parents=True, exist_ok=True)
+    stem = f"{_now().replace(':', '')}-{ident.model_sha256[-12:].replace(':', '_')}"
+    with (d / f"{stem}.transcript.jsonl").open("w", encoding="utf-8") as f:
+        for m in result.transcript:
+            f.write(json.dumps(m, sort_keys=True) + "\n")
+    diff = subprocess.run(["git", "-C", str(ws_dir), "diff"], capture_output=True, text=True)
+    (d / f"{stem}.diff").write_text(diff.stdout, encoding="utf-8")
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    records = _read_records(Path(args.out) / "evidence.jsonl")
+    print(render(summarize(records)))
+    if args.by_reason:
+        reasons: dict[str, int] = {}
+        for r in records:
+            key = f"{r.disposition.value}: {r.reasons[0] if r.reasons else ''}"
+            reasons[key] = reasons.get(key, 0) + 1
+        for key, n in sorted(reasons.items(), key=lambda kv: -kv[1]):
+            print(f"  {n:5d}  {key}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="python -m xyntetik_runner.shadow", description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    p = sub.add_parser("import", help="scan traces, admit verifiable tasks, record the rest")
+    p.add_argument("--out", default=str(DEFAULT_OUT))
+    p.add_argument("--home", default="")
+    p.add_argument("--source", choices=["codex", "claude_code"], default="")
+    p.add_argument("--python", default=sys.executable, help="interpreter that runs the tests")
+    p.add_argument("--timeout", type=float, default=600.0)
+    p.set_defaults(fn=cmd_import)
+    p = sub.add_parser("replay", help="attempt each admitted task and verify it")
+    p.add_argument("--out", default=str(DEFAULT_OUT))
+    p.add_argument("--endpoint", default="http://127.0.0.1:8080")
+    p.add_argument("--model", default="")
+    p.add_argument("--model-sha256", default="")
+    p.add_argument("--quant", default="")
+    p.add_argument("--task", default="")
+    p.add_argument("--limit", type=int, default=0)
+    p.add_argument("--python", default=sys.executable)
+    p.add_argument("--timeout", type=float, default=600.0)
+    p.add_argument("--request-timeout", type=float, default=900.0)
+    p.add_argument("--max-turns", type=int, default=12)
+    p.add_argument("--max-tokens", type=int, default=1500)
+    p.add_argument("--test-runs", type=int, default=4)
+    p.add_argument("--wall", type=float, default=900.0)
+    p.set_defaults(fn=cmd_replay)
+    p = sub.add_parser("report", help="counts and both denominators")
+    p.add_argument("--out", default=str(DEFAULT_OUT))
+    p.add_argument("--by-reason", action="store_true")
+    p.set_defaults(fn=cmd_report)
+    args = ap.parse_args(argv)
+    fn: Any = args.fn
+    return int(fn(args))

--- a/python/src/xyntetik_runner/shadow/cli.py
+++ b/python/src/xyntetik_runner/shadow/cli.py
@@ -34,8 +34,8 @@ from xyntetik_runner.shadow.evidence import (
     summarize,
 )
 from xyntetik_runner.shadow.importer import Episode, read_episodes, scan_all, write_episodes
-from xyntetik_runner.shadow.tasks import RepairTask, Rejection, admit
-from xyntetik_runner.shadow.verifier import ProtectedTests, verify
+from xyntetik_runner.shadow.tasks import Candidate, RepairTask, Rejection, build_task, choose, pair
+from xyntetik_runner.shadow.verifier import ProtectedTests, fixed_ids, verify
 
 HARNESS_VERSION = "shadow-0.1"
 DEFAULT_OUT = Path.home() / ".xyntetik" / "shadow"
@@ -84,13 +84,44 @@ def cmd_import(args: argparse.Namespace) -> int:
           f"{n} episodes", flush=True)
     evidence = out / "evidence.jsonl"
     known = {r.episode_id for r in _read_records(evidence)}
-    seen: set[tuple[str, str]] = set()
     counts: dict[str, int] = {}
     admitted = 0
+
+    def record(e: Episode, rej: Rejection) -> None:
+        _append(evidence, EpisodeEvidence(
+            episode_id=e.episode_id, source=e.source, observed_at=e.started_at,
+            disposition=rej.disposition, identity=_instrument_identity("none"),
+            baseline_sha256="", patch_sha256=None, changed_paths=(), verifier=None, wall_s=0.0,
+            reasons=(rej.reason,)))
+        counts[rej.disposition.value] = counts.get(rej.disposition.value, 0) + 1
+
+    # Pass 1: pair every episode; pass 2: one episode per fix commit.
+    candidates: list[Candidate] = []
     for e in episodes:
         if e.episode_id in known:
             continue
-        result = admit(e, out_dir=tasks_dir, python=args.python, timeout_s=args.timeout, seen=seen)
+        paired = pair(e)
+        if isinstance(paired, Rejection):
+            record(e, paired)
+        else:
+            candidates.extend(paired)
+    chosen = choose(candidates)
+    chosen_ids = {(c.episode.episode_id, c.solution) for c in chosen.values()}
+    attributed: set[str] = set()
+    for c in candidates:
+        if (c.episode.episode_id, c.solution) in chosen_ids or c.episode.episode_id in attributed:
+            continue
+        if not any(x.episode.episode_id == c.episode.episode_id for x in chosen.values()):
+            attributed.add(c.episode.episode_id)
+            record(c.episode, Rejection(Disposition.INELIGIBLE,
+                                        "fix commit attributed to a closer prompt"))
+    built: set[str] = set()
+    for c in chosen.values():
+        if c.episode.episode_id in built:
+            continue
+        built.add(c.episode.episode_id)
+        result = build_task(c.episode, c.repo, list(c.shas), out_dir=tasks_dir,
+                            python=args.python, timeout_s=args.timeout)
         if isinstance(result, RepairTask):
             admitted += 1
             counts["admitted"] = counts.get("admitted", 0) + 1
@@ -98,13 +129,7 @@ def cmd_import(args: argparse.Namespace) -> int:
                   f"{result.baseline_failing} fail at base, {result.src_files} source file(s)",
                   flush=True)
             continue
-        rec = EpisodeEvidence(
-            episode_id=e.episode_id, source=e.source, observed_at=e.started_at,
-            disposition=result.disposition, identity=_instrument_identity("none"),
-            baseline_sha256="", patch_sha256=None, changed_paths=(), verifier=None, wall_s=0.0,
-            reasons=(result.reason,))
-        _append(evidence, rec)
-        counts[result.disposition.value] = counts.get(result.disposition.value, 0) + 1
+        record(c.episode, result)
     print("dispositions at import:", json.dumps(counts, sort_keys=True), flush=True)
     print(f"{admitted} task(s) admitted under {tasks_dir}", flush=True)
     return 0
@@ -174,6 +199,10 @@ def cmd_replay(args: argparse.Namespace) -> int:
             outcome = verify(ws_dir, protected, baseline, timeout_s=args.timeout,
                              python=args.python, pythonpath=task.pythonpath)
             changes = baseline.changes(ws_dir)
+            fixed: tuple[str, ...] = ()
+            if changes and task.failing_at_base and outcome.passed is not None:
+                fixed = fixed_ids(protected, task.failing_at_base, ws_dir, timeout_s=args.timeout,
+                                  python=args.python, pythonpath=task.pythonpath)
             if outcome.passed is True:
                 disposition = Disposition.VERIFIED_LOCAL_ATTEMPT
             elif outcome.passed is False:
@@ -189,13 +218,18 @@ def cmd_replay(args: argparse.Namespace) -> int:
                 resources={"prompt_tokens": float(result.prompt_tokens),
                            "completion_tokens": float(result.completion_tokens),
                            "turns": float(result.turns), "tool_calls": float(result.tool_calls),
-                           "test_runs": float(result.test_runs)},
-                reasons=(f"attempt: {result.stop_reason}", *outcome.reasons))
+                           "test_runs": float(result.test_runs),
+                           "failing_at_base": float(len(task.failing_at_base)),
+                           "fixed": float(len(fixed))},
+                reasons=(f"attempt: {result.stop_reason}",
+                         f"fixed {len(fixed)} of {len(task.failing_at_base)} failing at base",
+                         *outcome.reasons))
             _append(evidence, rec)
             _keep_attempt(out, task, ident, result, ws_dir)
             print(f"[{task.task_id}] {disposition.value}: {result.stop_reason}, "
                   f"{result.turns} turns, {result.tool_calls} calls, {result.wall_s:.0f}s; "
-                  f"verifier {outcome.passed_count}/{outcome.expected}"
+                  f"fixed {len(fixed)}/{len(task.failing_at_base)}, verifier "
+                  f"{outcome.passed_count}/{outcome.expected}"
                   f"{' tamper' if outcome.tamper else ''}", flush=True)
         finally:
             _drop(task, ws_dir)
@@ -217,8 +251,30 @@ def _keep_attempt(out: Path, task: RepairTask, ident: Identity, result: Any, ws_
 
 
 def cmd_report(args: argparse.Namespace) -> int:
-    records = _read_records(Path(args.out) / "evidence.jsonl")
+    out = Path(args.out)
+    records = _read_records(out / "evidence.jsonl")
     print(render(summarize(records)))
+    if args.tasks:
+        by_episode: dict[str, list[EpisodeEvidence]] = {}
+        for r in records:
+            if r.verifier is not None:
+                by_episode.setdefault(r.episode_id, []).append(r)
+        print()
+        for task in _tasks(out, None):
+            head = " ".join(task.request.split())[:72]
+            print(f"{task.task_id}  ({task.expected_tests} frozen tests, "
+                  f"{task.baseline_failing} fail at base, {task.src_files} src file(s))")
+            print(f"    request: {head}")
+            for r in by_episode.get(task.episode_id, []):
+                v = r.verifier
+                assert v is not None
+                model = r.identity.model_sha256.split(":", 1)[-1]
+                fixed = int(r.resources.get("fixed", 0))
+                print(f"    {r.disposition.value:24s} {model[:40]:40s} fixed "
+                      f"{fixed}/{task.baseline_failing}, verifier {v.passed_count}/{v.expected}"
+                      f"{' tamper' if v.tamper else ''}  {r.reasons[0][:40]}")
+            if not by_episode.get(task.episode_id):
+                print("    (not attempted yet)")
     if args.by_reason:
         reasons: dict[str, int] = {}
         for r in records:
@@ -259,6 +315,7 @@ def main(argv: list[str] | None = None) -> int:
     p = sub.add_parser("report", help="counts and both denominators")
     p.add_argument("--out", default=str(DEFAULT_OUT))
     p.add_argument("--by-reason", action="store_true")
+    p.add_argument("--tasks", action="store_true", help="one block per admitted task")
     p.set_defaults(fn=cmd_report)
     args = ap.parse_args(argv)
     fn: Any = args.fn

--- a/python/src/xyntetik_runner/shadow/evidence.py
+++ b/python/src/xyntetik_runner/shadow/evidence.py
@@ -74,7 +74,17 @@ class Identity:
     adapter_scale: float | None = None
 
     def cohort_key(self) -> str:
+        """The full partition: a new task class, verifier or context band is
+        a new cohort for evidence purposes."""
         return json.dumps(asdict(self), sort_keys=True, separators=(",", ":"))
+
+    def stack_key(self) -> str:
+        """The model stack alone (model, quant, adapter, runner build, backend,
+        harness): the unit a report row is about, across tasks."""
+        keep = ("model_sha256", "quant", "adapter_sha256", "adapter_scale", "runner_build",
+                "backend", "harness_version", "environment_id")
+        return json.dumps({k: getattr(self, k) for k in keep}, sort_keys=True,
+                          separators=(",", ":"))
 
 
 @dataclass(frozen=True)
@@ -217,7 +227,7 @@ def summarize(records: Iterable[EpisodeEvidence]) -> Summary:
         for r in recs:
             if r.verifier is None:
                 continue
-            key = r.identity.cohort_key()
+            key = r.identity.stack_key()
             row = per_cohort.setdefault(key, {"model": r.identity.model_sha256, "attempted": 0,
                                               "verified": 0, "failed": 0, "inconclusive": 0})
             row["attempted"] += 1

--- a/python/src/xyntetik_runner/shadow/evidence.py
+++ b/python/src/xyntetik_runner/shadow/evidence.py
@@ -159,17 +159,29 @@ class EpisodeEvidence:
 
 
 @dataclass(frozen=True)
-class Summary:
-    observed: int
-    eligible: int
+class CohortSummary:
+    """One model stack's results over the eligible episodes."""
+
+    cohort: str
+    model: str
     attempted: int
-    checked: int
     verified: int
     failed: int
     inconclusive: int
+
+
+@dataclass(frozen=True)
+class Summary:
+    """Per episode, never per record: an episode attempted by two stacks is
+    one episode with two cohort rows. ``eligible`` is the instrument's
+    count of episodes that could be replayed at all."""
+
+    observed: int
+    eligible: int
+    unattempted: int
     agreement_only: int
-    cohorts: int
     by_disposition: Mapping[str, int]
+    cohorts: tuple[CohortSummary, ...]
 
     @property
     def headline_allowed(self) -> bool:
@@ -177,48 +189,75 @@ class Summary:
 
 
 def summarize(records: Iterable[EpisodeEvidence]) -> Summary:
-    by: dict[str, int] = {d.value: 0 for d in Disposition}
-    cohorts: set[str] = set()
-    n = 0
+    by_episode: dict[str, list[EpisodeEvidence]] = {}
     for r in records:
-        n += 1
-        by[r.disposition.value] += 1
-        cohorts.add(r.identity.cohort_key())
-    count = {d: by[d.value] for d in Disposition}
-    return Summary(
-        observed=n,
-        eligible=sum(count[d] for d in ELIGIBLE),
-        attempted=sum(count[d] for d in ATTEMPTED),
-        checked=sum(count[d] for d in CHECKED),
-        verified=count[Disposition.VERIFIED_LOCAL_ATTEMPT],
-        failed=count[Disposition.LOCAL_FAILED],
-        inconclusive=count[Disposition.VERIFIER_INCONCLUSIVE],
-        agreement_only=count[Disposition.AGREEMENT_ONLY],
-        cohorts=len(cohorts),
-        by_disposition=by,
-    )
+        by_episode.setdefault(r.episode_id, []).append(r)
+    by: dict[str, int] = {d.value: 0 for d in Disposition}
+    eligible = unattempted = agreement = 0
+    per_cohort: dict[str, dict[str, Any]] = {}
+    for recs in by_episode.values():
+        # The instrument's disposition for the episode: verified beats
+        # failed beats inconclusive beats not-attempted, across cohorts.
+        dispositions = {r.disposition for r in recs}
+        if Disposition.VERIFIED_LOCAL_ATTEMPT in dispositions:
+            top = Disposition.VERIFIED_LOCAL_ATTEMPT
+        elif Disposition.LOCAL_FAILED in dispositions:
+            top = Disposition.LOCAL_FAILED
+        elif Disposition.VERIFIER_INCONCLUSIVE in dispositions:
+            top = Disposition.VERIFIER_INCONCLUSIVE
+        else:
+            top = recs[0].disposition
+        by[top.value] += 1
+        if top in ELIGIBLE:
+            eligible += 1
+        if top is Disposition.NOT_ATTEMPTED_RESOURCE:
+            unattempted += 1
+        if top is Disposition.AGREEMENT_ONLY:
+            agreement += 1
+        for r in recs:
+            if r.verifier is None:
+                continue
+            key = r.identity.cohort_key()
+            row = per_cohort.setdefault(key, {"model": r.identity.model_sha256, "attempted": 0,
+                                              "verified": 0, "failed": 0, "inconclusive": 0})
+            row["attempted"] += 1
+            if r.disposition is Disposition.VERIFIED_LOCAL_ATTEMPT:
+                row["verified"] += 1
+            elif r.disposition is Disposition.LOCAL_FAILED:
+                row["failed"] += 1
+            else:
+                row["inconclusive"] += 1
+    cohorts = tuple(sorted(
+        (CohortSummary(cohort=k, model=str(v["model"]), attempted=int(v["attempted"]),
+                       verified=int(v["verified"]), failed=int(v["failed"]),
+                       inconclusive=int(v["inconclusive"])) for k, v in per_cohort.items()),
+        key=lambda c: c.model))
+    return Summary(observed=len(by_episode), eligible=eligible, unattempted=unattempted,
+                   agreement_only=agreement, by_disposition=by, cohorts=cohorts)
 
 
 def render(s: Summary) -> str:
-    """Counts first, both denominators, no percentage before the floor."""
+    """Counts first, both denominators, no percentage before the floor, one
+    row per model stack."""
     lines = [
         f"{s.observed} episodes observed",
         f"{s.eligible} eligible for replay",
-        f"{s.attempted} attempted",
-        f"{s.verified} passed independent checks",
-        f"{s.failed} failed checks",
-        f"{s.inconclusive} could not be evaluated",
-        f"{s.agreement_only} agreement only (not evidence)",
         f"{s.observed - s.eligible} outside this evaluation's scope",
-        f"{s.cohorts} identity cohorts",
+        f"{s.unattempted} eligible and not attempted yet",
+        f"{s.agreement_only} agreement only (not evidence)",
     ]
-    if s.eligible:
-        ratio = f"verified over eligible: {s.verified} of {s.eligible}"
-        if s.headline_allowed:
-            ratio += f" ({100 * s.verified / s.eligible:.0f}%)"
-        lines.append(ratio)
-    if s.observed:
-        lines.append(f"verified over observed: {s.verified} of {s.observed}")
+    for c in s.cohorts:
+        model = c.model.split(":", 1)[-1]
+        row = (f"{model}: attempted {c.attempted}, verified {c.verified}, failed {c.failed}, "
+               f"inconclusive {c.inconclusive}")
+        if s.eligible:
+            row += f"; verified over eligible {c.verified} of {s.eligible}"
+            if s.headline_allowed:
+                row += f" ({100 * c.verified / s.eligible:.0f}%)"
+        row += f"; verified over observed {c.verified} of {s.observed}"
+        lines.append(row)
+    if not s.cohorts:
+        lines.append("no attempts recorded")
     if not s.headline_allowed:
         lines.append(f"(no percentage before {HEADLINE_MIN_EPISODES} independent eligible episodes)")
     return "\n".join(lines)

--- a/python/src/xyntetik_runner/shadow/importer.py
+++ b/python/src/xyntetik_runner/shadow/importer.py
@@ -1,0 +1,197 @@
+"""Import episodes from the frontier tools' own traces, without their answers.
+
+Codex and Claude Code both write session logs to the user's home directory.
+An episode is one task boundary in those logs: for Codex the
+``task_started`` / ``task_complete`` events of a session; for Claude Code
+one user prompt up to the next. The importer reads the working directory,
+the timestamps and the user's own request text, and for Codex the NAMES of
+the tools the session called. It never reads an assistant message, a
+reasoning item, a tool argument or a tool result: those carry the
+frontier's answer, and the whole point of the instrument is that the local
+attempt does not get it.
+
+Formats are undocumented and will move. A file the parser cannot read is
+skipped and counted, never guessed at.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+CLAUDE_TURN_CAP = timedelta(hours=1)
+
+
+@dataclass(frozen=True)
+class Episode:
+    source: str
+    session_id: str
+    turn: int
+    cwd: str
+    started_at: str
+    ended_at: str
+    request: str
+    request_sha256: str
+    tool_names: tuple[str, ...] = ()
+    trace_path: str = ""
+
+    @property
+    def episode_id(self) -> str:
+        return f"{self.source}:{self.session_id[:12]}:{self.turn}"
+
+    @property
+    def is_command(self) -> bool:
+        """A harness-injected turn (a slash command, a system block), not a
+        request a person typed."""
+        return self.request.lstrip().startswith("<")
+
+
+@dataclass(frozen=True)
+class ScanReport:
+    episodes: tuple[Episode, ...]
+    files_read: int
+    files_skipped: tuple[str, ...]
+
+
+def _iso(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _fmt(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _records(path: Path) -> Iterator[dict[str, object]]:
+    with path.open(encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(rec, dict):
+                yield rec
+
+
+def scan_codex(root: Path) -> ScanReport:
+    """``~/.codex/sessions/**/*.jsonl``: one session per file."""
+    episodes: list[Episode] = []
+    skipped: list[str] = []
+    files = sorted(root.rglob("*.jsonl")) if root.is_dir() else []
+    for path in files:
+        try:
+            episodes.extend(_codex_file(path))
+        except (OSError, ValueError, KeyError, TypeError):
+            skipped.append(str(path))
+    return ScanReport(tuple(episodes), len(files) - len(skipped), tuple(skipped))
+
+
+def _codex_file(path: Path) -> list[Episode]:
+    out: list[Episode] = []
+    cwd = session_id = None
+    started: str | None = None
+    request = ""
+    tools: list[str] = []
+    turn = 0
+    for rec in _records(path):
+        kind = rec.get("type")
+        payload = rec.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        if kind == "session_meta":
+            cwd = str(payload.get("cwd") or "")
+            session_id = str(payload.get("id") or payload.get("session_id") or path.stem)
+        elif kind == "event_msg":
+            ev = payload.get("type")
+            if ev == "task_started":
+                started = str(rec.get("timestamp") or "")
+                request, tools = "", []
+            elif ev == "user_message":
+                # The user's own words, the one message body the importer reads.
+                msg = payload.get("message")
+                if isinstance(msg, str):
+                    request = msg
+            elif ev == "task_complete" and started and cwd and session_id:
+                turn += 1
+                out.append(Episode(
+                    source="codex", session_id=session_id, turn=turn, cwd=cwd,
+                    started_at=_fmt(_iso(started)), ended_at=_fmt(_iso(str(rec["timestamp"]))),
+                    request=request, request_sha256=_sha(request),
+                    tool_names=tuple(sorted(set(tools))), trace_path=str(path)))
+                started = None
+        elif kind == "response_item" and payload.get("type") == "function_call":
+            name = payload.get("name")
+            if isinstance(name, str):
+                tools.append(name)
+    return out
+
+
+def scan_claude_code(root: Path) -> ScanReport:
+    """``~/.claude/projects/*/*.jsonl``: one session per file, a turn per
+    user prompt; the turn ends at the next prompt or after an hour."""
+    episodes: list[Episode] = []
+    skipped: list[str] = []
+    files = sorted(root.glob("*/*.jsonl")) if root.is_dir() else []
+    for path in files:
+        try:
+            episodes.extend(_claude_file(path))
+        except (OSError, ValueError, KeyError, TypeError):
+            skipped.append(str(path))
+    return ScanReport(tuple(episodes), len(files) - len(skipped), tuple(skipped))
+
+
+def _claude_file(path: Path) -> list[Episode]:
+    turns: list[tuple[str, str, datetime, str]] = []
+    for rec in _records(path):
+        if rec.get("type") != "user":
+            continue
+        msg = rec.get("message")
+        content = msg.get("content") if isinstance(msg, dict) else None
+        stamp = rec.get("timestamp")
+        cwd = rec.get("cwd")
+        if not (isinstance(content, str) and isinstance(stamp, str) and isinstance(cwd, str)):
+            continue  # tool results and structured turns are not requests
+        turns.append((str(rec.get("sessionId") or path.stem), cwd, _iso(stamp), content))
+    out: list[Episode] = []
+    for i, (sid, cwd, start, text) in enumerate(turns):
+        end = turns[i + 1][2] if i + 1 < len(turns) else start + CLAUDE_TURN_CAP
+        out.append(Episode(
+            source="claude_code", session_id=sid, turn=i + 1, cwd=cwd,
+            started_at=_fmt(start), ended_at=_fmt(end), request=text,
+            request_sha256=_sha(text), trace_path=str(path)))
+    return out
+
+
+def scan_all(home: Path | None = None) -> ScanReport:
+    home = home or Path.home()
+    a = scan_codex(home / ".codex" / "sessions")
+    b = scan_claude_code(home / ".claude" / "projects")
+    return ScanReport(a.episodes + b.episodes, a.files_read + b.files_read,
+                      a.files_skipped + b.files_skipped)
+
+
+def write_episodes(episodes: Iterable[Episode], path: Path) -> int:
+    n = 0
+    with path.open("w", encoding="utf-8") as f:
+        for e in episodes:
+            f.write(json.dumps(e.__dict__, sort_keys=True) + "\n")
+            n += 1
+    return n
+
+
+def read_episodes(path: Path) -> list[Episode]:
+    out: list[Episode] = []
+    for rec in _records(path):
+        rec["tool_names"] = tuple(rec.get("tool_names") or ())  # type: ignore[arg-type]
+        out.append(Episode(**rec))  # type: ignore[arg-type]
+    return out

--- a/python/src/xyntetik_runner/shadow/importer.py
+++ b/python/src/xyntetik_runner/shadow/importer.py
@@ -38,6 +38,11 @@ class Episode:
     request_sha256: str
     tool_names: tuple[str, ...] = ()
     trace_path: str = ""
+    head_start: str = ""
+    head_end: str = ""
+    """Repository HEAD when the request was made and when the turn ended,
+    known only for prospectively captured episodes (``source == "capture"``);
+    with both, the task's commit range is exact instead of a time window."""
 
     @property
     def episode_id(self) -> str:
@@ -172,12 +177,61 @@ def _claude_file(path: Path) -> list[Episode]:
     return out
 
 
+CAPTURE_FILE = Path(".xyntetik") / "shadow" / "capture.jsonl"
+
+
+def scan_capture(path: Path) -> ScanReport:
+    """The prospective path: lines written by ``shadow capture`` from a
+    prompt hook and a stop hook. A ``prompt`` line carries the request and
+    the repository HEAD at that moment; the next ``stop`` line for the same
+    session carries HEAD at the end. Only the user's request is recorded."""
+    if not path.is_file():
+        return ScanReport((), 0, ())
+    open_turns: dict[str, dict[str, object]] = {}
+    turns: dict[str, int] = {}
+    episodes: list[Episode] = []
+    try:
+        for rec in _records(path):
+            sid = str(rec.get("session_id") or "")
+            event = rec.get("event")
+            if not sid:
+                continue
+            if event == "prompt":
+                # A prompt while one is open closes the earlier one at this time.
+                if sid in open_turns:
+                    episodes.append(_close(open_turns.pop(sid), rec, path))
+                open_turns[sid] = rec
+            elif event == "stop" and sid in open_turns:
+                episodes.append(_close(open_turns.pop(sid), rec, path))
+    except (OSError, ValueError, KeyError, TypeError):
+        return ScanReport(tuple(episodes), 0, (str(path),))
+    for sid, rec in open_turns.items():
+        started = _iso(str(rec["timestamp"]))
+        episodes.append(_close(rec, {"timestamp": _fmt(started + CLAUDE_TURN_CAP), "head": ""}, path))
+    for i, e in enumerate(episodes):
+        turns[e.session_id] = turns.get(e.session_id, 0) + 1
+        episodes[i] = Episode(**{**e.__dict__, "turn": turns[e.session_id]})
+    return ScanReport(tuple(episodes), 1, ())
+
+
+def _close(start: dict[str, object], end: dict[str, object], path: Path) -> Episode:
+    request = str(start.get("prompt") or "")
+    return Episode(
+        source="capture", session_id=str(start["session_id"]), turn=0,
+        cwd=str(start.get("cwd") or ""), started_at=_fmt(_iso(str(start["timestamp"]))),
+        ended_at=_fmt(_iso(str(end["timestamp"]))), request=request,
+        request_sha256=_sha(request), trace_path=str(path),
+        head_start=str(start.get("head") or ""), head_end=str(end.get("head") or ""))
+
+
 def scan_all(home: Path | None = None) -> ScanReport:
     home = home or Path.home()
     a = scan_codex(home / ".codex" / "sessions")
     b = scan_claude_code(home / ".claude" / "projects")
-    return ScanReport(a.episodes + b.episodes, a.files_read + b.files_read,
-                      a.files_skipped + b.files_skipped)
+    c = scan_capture(home / CAPTURE_FILE)
+    return ScanReport(a.episodes + b.episodes + c.episodes,
+                      a.files_read + b.files_read + c.files_read,
+                      a.files_skipped + b.files_skipped + c.files_skipped)
 
 
 def write_episodes(episodes: Iterable[Episode], path: Path) -> int:

--- a/python/src/xyntetik_runner/shadow/tasks.py
+++ b/python/src/xyntetik_runner/shadow/tasks.py
@@ -269,6 +269,18 @@ def pair(episode: Episode) -> list[Candidate] | Rejection:
     repos = repos_under(Path(episode.cwd))
     if not repos:
         return Rejection(Disposition.INELIGIBLE, "no git repository at or under the working directory")
+    if episode.head_start and episode.head_end:
+        # Prospective capture: the exact commits between the two HEADs, in the
+        # repository whose history contains both; no time window at all.
+        if episode.head_start == episode.head_end:
+            return Rejection(Disposition.UNREPLAYABLE, "HEAD did not move during the turn")
+        for repo in repos:
+            shas = _git(str(repo), "rev-list", "--no-merges",
+                        f"{episode.head_start}..{episode.head_end}").split()
+            if shas:
+                return [Candidate(episode, repo, tuple(shas))]
+        return Rejection(Disposition.UNREPLAYABLE,
+                         "captured HEADs are not an ancestry range in any repository here")
     start = datetime.fromisoformat(episode.started_at.replace("Z", "+00:00"))
     end = datetime.fromisoformat(episode.ended_at.replace("Z", "+00:00"))
     found = [Candidate(episode, repo, tuple(commits_in_window(repo, start, end))) for repo in repos]

--- a/python/src/xyntetik_runner/shadow/tasks.py
+++ b/python/src/xyntetik_runner/shadow/tasks.py
@@ -1,0 +1,279 @@
+"""Repair tasks reconstructed from the repository, not from the trace.
+
+An episode says when and where work happened. The repository says what
+changed: the commits in the episode's window (in any git repository at or
+under the working directory) give a pre-state, a post-state and the files
+touched. A task is admitted when the range touched pytest test files and
+Python source and nothing that needs a build, the post-state's versions of
+those test files can be collected and pass on the post-state tree, and the
+same frozen files fail on the pre-state tree. The frozen tests are the
+verifier; the source diff is the frontier's answer and is never given to
+the attempt.
+
+Everything the attempt receives is: the pre-state tree, the user's request,
+and the names of the visible test files as they were at the pre-state.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterable, Sequence
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from xyntetik_runner.shadow.evidence import Disposition
+from xyntetik_runner.shadow.importer import Episode
+from xyntetik_runner.shadow.verifier import InstrumentError, ProtectedTests, calibrate, check
+
+BUILD_SUFFIXES = (".c", ".h", ".cu", ".m", ".metal", ".cpp", ".rs", ".go")
+SKIP_DIRS = frozenset({"node_modules", "models", ".venv", "venv", "__pycache__", "dist", "build"})
+COMMIT_SLACK = timedelta(minutes=30)
+
+
+@dataclass(frozen=True)
+class Rejection:
+    disposition: Disposition
+    reason: str
+
+
+@dataclass(frozen=True)
+class RepairTask:
+    task_id: str
+    episode_id: str
+    repo: str
+    base_sha: str
+    solution_sha: str
+    request: str
+    request_sha256: str
+    test_files: tuple[str, ...]
+    visible_test_files: tuple[str, ...]
+    src_files: int
+    pythonpath: tuple[str, ...]
+    protected_dir: str
+    expected_tests: int
+    baseline_failing: int
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True, indent=2)
+
+    @classmethod
+    def load(cls, path: Path) -> RepairTask:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        for key in ("test_files", "visible_test_files", "pythonpath"):
+            data[key] = tuple(data[key])
+        return cls(**data)
+
+
+def _git(repo: str, *args: str) -> str:
+    proc = subprocess.run(["git", "-C", repo, *args], capture_output=True, text=True)
+    return proc.stdout
+
+
+def repos_under(cwd: Path, *, depth: int = 2) -> list[Path]:
+    """Git repositories at or under ``cwd``, at most ``depth`` levels down,
+    so a session run from a parent directory still finds its repositories."""
+    out: list[Path] = []
+    if not cwd.is_dir():
+        return out
+    stack: list[tuple[Path, int]] = [(cwd, 0)]
+    while stack:
+        here, d = stack.pop()
+        if (here / ".git").exists():
+            out.append(here)
+            continue
+        if d >= depth:
+            continue
+        try:
+            children = sorted(p for p in here.iterdir() if p.is_dir() and not p.is_symlink())
+        except OSError:
+            continue
+        for child in children:
+            if child.name.startswith(".") or child.name in SKIP_DIRS:
+                continue
+            stack.append((child, d + 1))
+    return sorted(out)
+
+
+def commits_in_window(repo: Path, start: datetime, end: datetime,
+                      *, slack: timedelta = COMMIT_SLACK) -> list[str]:
+    """Non-merge commits on any ref authored inside the window (newest first)."""
+    text = _git(str(repo), "log", "--all", "--no-merges", "--format=%H",
+                "--since", start.isoformat(), "--until", (end + slack).isoformat())
+    return text.split()
+
+
+def touched_files(repo: Path, shas: Iterable[str]) -> set[str]:
+    files: set[str] = set()
+    for sha in shas:
+        text = _git(str(repo), "show", "--name-only", "--format=", "--no-renames", sha)
+        files.update(x for x in text.split("\n") if x)
+    return files
+
+
+def classify(files: Iterable[str]) -> tuple[list[str], list[str], list[str]]:
+    tests, src, build = [], [], []
+    for f in sorted(files):
+        name = Path(f).name
+        if name.startswith("test_") and name.endswith(".py"):
+            tests.append(f)
+        elif f.endswith(".py"):
+            src.append(f)
+        elif f.endswith(BUILD_SUFFIXES):
+            build.append(f)
+    return tests, src, build
+
+
+def import_roots(tree: Path) -> tuple[str, ...]:
+    """Workspace-relative import roots for a src layout, a python/ client, or
+    a packages/* monorepo; the repository's own tests need them."""
+    roots: list[str] = []
+    for cand in ("python/src", "src"):
+        if (tree / cand).is_dir():
+            roots.append(cand)
+    packages = tree / "packages"
+    if packages.is_dir():
+        for p in sorted(packages.iterdir()):
+            if p.is_dir():
+                roots.append(f"packages/{p.name}/src" if (p / "src").is_dir() else f"packages/{p.name}")
+    return tuple(roots)
+
+
+def _worktree(repo: Path, sha: str) -> Path:
+    d = Path(tempfile.mkdtemp(prefix="xyntetik-shadow-wt-"))
+    proc = subprocess.run(["git", "-C", str(repo), "worktree", "add", "--detach", "-q", str(d), sha],
+                          capture_output=True, text=True)
+    if proc.returncode != 0:
+        shutil.rmtree(d, ignore_errors=True)
+        raise RuntimeError(f"git worktree add failed: {proc.stderr.strip()[:200]}")
+    return d
+
+
+def _drop_worktree(repo: Path, d: Path) -> None:
+    subprocess.run(["git", "-C", str(repo), "worktree", "remove", "--force", str(d)],
+                   capture_output=True)
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def collect_tests(tree: Path, files: Sequence[str], roots: Sequence[str], *, python: str,
+                  timeout_s: float) -> dict[str, list[str]]:
+    """Expected test ids per file, from pytest's own collection at the
+    post-state; a file that does not collect contributes nothing."""
+    import os
+    env = {k: os.environ[k] for k in ("PATH", "SYSTEMROOT", "SystemRoot") if k in os.environ}
+    env.update({"HOME": str(tree), "PYTHONDONTWRITEBYTECODE": "1",
+                "PYTHONPATH": os.pathsep.join([str(tree)] + [str(tree / r) for r in roots])})
+    try:
+        proc = subprocess.run([python, "-m", "pytest", "-p", "no:cacheprovider", "--collect-only",
+                               "-q", *files], cwd=tree, env=env, capture_output=True, text=True,
+                              timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        return {}
+    expected: dict[str, list[str]] = {}
+    for line in proc.stdout.split("\n"):
+        line = line.strip()
+        if "::" not in line or line.startswith(("ERROR", "FAILED")):
+            continue
+        f, name = line.split("::", 1)
+        if f in files:
+            expected.setdefault(f, []).append(name)
+    return expected
+
+
+def build_task(episode: Episode, repo: Path, shas: Sequence[str], *, out_dir: Path,
+               python: str = sys.executable, timeout_s: float = 600.0) -> RepairTask | Rejection:
+    """Admit or reject one (episode, repository, commit range)."""
+    files = touched_files(repo, shas)
+    tests, src, build = classify(files)
+    if not tests or not src:
+        return Rejection(Disposition.INELIGIBLE, "range touches no pytest test file with Python source")
+    if build:
+        return Rejection(Disposition.INELIGIBLE, f"range touches {len(build)} file(s) that need a build")
+    solution = shas[0]
+    base = _git(str(repo), "rev-parse", f"{shas[-1]}^").strip()
+    if not base:
+        return Rejection(Disposition.UNREPLAYABLE, "first commit in the range has no parent")
+    task_id = f"{repo.name}-{base[:8]}-{solution[:8]}"
+    task_dir = out_dir / task_id
+    protected = task_dir / "protected"
+    post = pre = None
+    admitted = False
+    try:
+        post = _worktree(repo, solution)
+        pre = _worktree(repo, base)
+        roots = import_roots(post)
+        present = [t for t in tests if (post / t).is_file()]
+        if not present:
+            return Rejection(Disposition.UNREPLAYABLE, "test files were deleted in the range")
+        expected = collect_tests(post, present, roots, python=python, timeout_s=timeout_s)
+        if not expected:
+            return Rejection(Disposition.UNREPLAYABLE, "post-state test files do not collect")
+        if protected.exists():
+            shutil.rmtree(protected)
+        for rel in expected:
+            (protected / rel).parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(post / rel, protected / rel)
+        frozen = ProtectedTests.freeze(protected, expected, verifier_id=f"commit-tests:{task_id}")
+        outcome = check(post, frozen, timeout_s=timeout_s, python=python, pythonpath=roots)
+        if outcome.passed is not True:
+            return Rejection(Disposition.UNREPLAYABLE,
+                             f"frozen tests do not pass on the post-state: {'; '.join(outcome.reasons)}")
+        try:
+            cal = calibrate(frozen, pre, timeout_s=timeout_s, python=python, pythonpath=roots)
+        except InstrumentError as e:
+            return Rejection(Disposition.UNREPLAYABLE, f"instrument: {e}")
+        visible = tuple(t for t in present if (pre / t).is_file())
+        task = RepairTask(
+            task_id=task_id, episode_id=episode.episode_id, repo=str(repo), base_sha=base,
+            solution_sha=solution, request=episode.request, request_sha256=episode.request_sha256,
+            test_files=tuple(present), visible_test_files=visible, src_files=len(src),
+            pythonpath=roots, protected_dir=str(protected), expected_tests=len(frozen.expected),
+            baseline_failing=cal.failing + cal.missing)
+        (task_dir / "task.json").write_text(task.to_json() + "\n", encoding="utf-8")
+        admitted = True
+        return task
+    except RuntimeError as e:
+        return Rejection(Disposition.UNREPLAYABLE, str(e))
+    finally:
+        if post is not None:
+            _drop_worktree(repo, post)
+        if pre is not None:
+            _drop_worktree(repo, pre)
+        if not admitted and task_dir.exists():
+            shutil.rmtree(task_dir, ignore_errors=True)
+
+
+def admit(episode: Episode, *, out_dir: Path, python: str = sys.executable,
+          timeout_s: float = 600.0, seen: set[tuple[str, str]] | None = None
+          ) -> RepairTask | Rejection:
+    """Pair an episode with its repository and commit range, then build."""
+    if episode.is_command:
+        return Rejection(Disposition.INELIGIBLE, "harness-injected turn, not a request")
+    if not episode.request.strip():
+        return Rejection(Disposition.INELIGIBLE, "empty request")
+    repos = repos_under(Path(episode.cwd))
+    if not repos:
+        return Rejection(Disposition.INELIGIBLE, "no git repository at or under the working directory")
+    start = datetime.fromisoformat(episode.started_at.replace("Z", "+00:00"))
+    end = datetime.fromisoformat(episode.ended_at.replace("Z", "+00:00"))
+    candidates = [(repo, commits_in_window(repo, start, end)) for repo in repos]
+    candidates = [(r, s) for r, s in candidates if s]
+    if not candidates:
+        return Rejection(Disposition.UNREPLAYABLE, "no commit in the task window")
+    last: RepairTask | Rejection = Rejection(Disposition.INELIGIBLE, "no candidate")
+    for repo, shas in candidates:
+        # One fix commit is one task, whichever clone it is reachable from and
+        # however many turns' windows overlap it: the key is the solution sha.
+        key = ("solution", shas[0])
+        if seen is not None and key in seen:
+            return Rejection(Disposition.INELIGIBLE, "same fix commit as an earlier episode")
+        last = build_task(episode, repo, shas, out_dir=out_dir, python=python, timeout_s=timeout_s)
+        if isinstance(last, RepairTask):
+            if seen is not None:
+                seen.add(key)
+            return last
+    return last

--- a/python/src/xyntetik_runner/shadow/tasks.py
+++ b/python/src/xyntetik_runner/shadow/tasks.py
@@ -57,6 +57,7 @@ class RepairTask:
     protected_dir: str
     expected_tests: int
     baseline_failing: int
+    failing_at_base: tuple[str, ...] = ()
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), sort_keys=True, indent=2)
@@ -64,8 +65,8 @@ class RepairTask:
     @classmethod
     def load(cls, path: Path) -> RepairTask:
         data = json.loads(path.read_text(encoding="utf-8"))
-        for key in ("test_files", "visible_test_files", "pythonpath"):
-            data[key] = tuple(data[key])
+        for key in ("test_files", "visible_test_files", "pythonpath", "failing_at_base"):
+            data[key] = tuple(data.get(key) or ())
         return cls(**data)
 
 
@@ -232,7 +233,7 @@ def build_task(episode: Episode, repo: Path, shas: Sequence[str], *, out_dir: Pa
             solution_sha=solution, request=episode.request, request_sha256=episode.request_sha256,
             test_files=tuple(present), visible_test_files=visible, src_files=len(src),
             pythonpath=roots, protected_dir=str(protected), expected_tests=len(frozen.expected),
-            baseline_failing=cal.failing + cal.missing)
+            baseline_failing=cal.failing + cal.missing, failing_at_base=cal.failing_ids)
         (task_dir / "task.json").write_text(task.to_json() + "\n", encoding="utf-8")
         admitted = True
         return task
@@ -247,10 +248,20 @@ def build_task(episode: Episode, repo: Path, shas: Sequence[str], *, out_dir: Pa
             shutil.rmtree(task_dir, ignore_errors=True)
 
 
-def admit(episode: Episode, *, out_dir: Path, python: str = sys.executable,
-          timeout_s: float = 600.0, seen: set[tuple[str, str]] | None = None
-          ) -> RepairTask | Rejection:
-    """Pair an episode with its repository and commit range, then build."""
+@dataclass(frozen=True)
+class Candidate:
+    episode: Episode
+    repo: Path
+    shas: tuple[str, ...]
+
+    @property
+    def solution(self) -> str:
+        return self.shas[0]
+
+
+def pair(episode: Episode) -> list[Candidate] | Rejection:
+    """The (repository, commit range) pairs an episode's window covers, or
+    why it has none."""
     if episode.is_command:
         return Rejection(Disposition.INELIGIBLE, "harness-injected turn, not a request")
     if not episode.request.strip():
@@ -260,12 +271,43 @@ def admit(episode: Episode, *, out_dir: Path, python: str = sys.executable,
         return Rejection(Disposition.INELIGIBLE, "no git repository at or under the working directory")
     start = datetime.fromisoformat(episode.started_at.replace("Z", "+00:00"))
     end = datetime.fromisoformat(episode.ended_at.replace("Z", "+00:00"))
-    candidates = [(repo, commits_in_window(repo, start, end)) for repo in repos]
-    candidates = [(r, s) for r, s in candidates if s]
-    if not candidates:
+    found = [Candidate(episode, repo, tuple(commits_in_window(repo, start, end))) for repo in repos]
+    found = [c for c in found if c.shas]
+    if not found:
         return Rejection(Disposition.UNREPLAYABLE, "no commit in the task window")
+    return found
+
+
+def choose(candidates: Iterable[Candidate]) -> dict[str, Candidate]:
+    """One episode per fix commit: the one whose working directory is the
+    repository itself over a parent, then the latest prompt before the
+    fix. A commit reachable from two clones is still one fix."""
+    best: dict[str, Candidate] = {}
+    for c in candidates:
+        depth = 0 if Path(c.episode.cwd).resolve() == c.repo.resolve() else 1
+        key = (depth, -datetime.fromisoformat(c.episode.started_at.replace("Z", "+00:00")).timestamp())
+        cur = best.get(c.solution)
+        if cur is None:
+            best[c.solution] = c
+            continue
+        cur_depth = 0 if Path(cur.episode.cwd).resolve() == cur.repo.resolve() else 1
+        cur_key = (cur_depth, -datetime.fromisoformat(cur.episode.started_at.replace("Z", "+00:00")).timestamp())
+        if key < cur_key:
+            best[c.solution] = c
+    return best
+
+
+def admit(episode: Episode, *, out_dir: Path, python: str = sys.executable,
+          timeout_s: float = 600.0, seen: set[tuple[str, str]] | None = None
+          ) -> RepairTask | Rejection:
+    """Pair one episode with its repository and commit range, then build.
+    For a whole trace use ``pair`` + ``choose`` so overlapping windows are
+    attributed once; this per-episode path keys duplicates on the fix sha."""
+    paired = pair(episode)
+    if isinstance(paired, Rejection):
+        return paired
     last: RepairTask | Rejection = Rejection(Disposition.INELIGIBLE, "no candidate")
-    for repo, shas in candidates:
+    for repo, shas in ((c.repo, list(c.shas)) for c in paired):
         # One fix commit is one task, whichever clone it is reachable from and
         # however many turns' windows overlap it: the key is the solution sha.
         key = ("solution", shas[0])

--- a/python/src/xyntetik_runner/shadow/verifier.py
+++ b/python/src/xyntetik_runner/shadow/verifier.py
@@ -144,7 +144,7 @@ def _kill(proc: subprocess.Popen[bytes]) -> None:
 
 
 def _run_protected(protected: ProtectedTests, tree: Path, *, timeout_s: float,
-                   python: str) -> _Run:
+                   python: str, pythonpath: Sequence[str] = ()) -> _Run:
     scratch = Path(tempfile.mkdtemp(prefix="xyntetik-shadow-"))
     try:
         ws = scratch / "ws"
@@ -168,8 +168,11 @@ def _run_protected(protected: ProtectedTests, tree: Path, *, timeout_s: float,
         cmd = [python, "-m", "pytest", "-q", "-p", "no:cacheprovider", "-c", VERIFIER_INI_NAME,
                "-o", "junit_family=xunit2", "--junit-xml", str(report), *protected.test_files]
         env = {k: os.environ[k] for k in _ENV_PASSTHROUGH if k in os.environ}
+        # Import roots are workspace-relative and resolved inside the scratch
+        # copy, so a test can never import the original tree by accident.
+        roots = [str(ws)] + [str(ws / rel) for rel in pythonpath]
         env.update({"HOME": str(scratch), "PYTHONDONTWRITEBYTECODE": "1",
-                    "PYTHONPATH": str(ws)})
+                    "PYTHONPATH": os.pathsep.join(roots)})
         t0 = time.monotonic()
         proc = subprocess.Popen(cmd, cwd=ws, env=env, stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT,
@@ -201,10 +204,20 @@ def _run_protected(protected: ProtectedTests, tree: Path, *, timeout_s: float,
         shutil.rmtree(scratch, ignore_errors=True)
 
 
+def _key(rel: str, name: str) -> tuple[str, str]:
+    """JUnit keys a test by (classname, name): the module dotted path, plus
+    the class chain for methods. An expected id ``Class::test`` therefore
+    joins its class onto the module classname."""
+    if "::" in name:
+        cls, _, leaf = name.rpartition("::")
+        return (_classname(rel) + "." + cls.replace("::", "."), leaf)
+    return (_classname(rel), name)
+
+
 def _judge(protected: ProtectedTests, run: _Run) -> tuple[int, int, int, int]:
     passed = failed = skipped = missing = 0
     for rel, name in protected.expected:
-        state = run.outcomes.get((_classname(rel), name))
+        state = run.outcomes.get(_key(rel, name))
         if state == "passed":
             passed += 1
         elif state == "failed":
@@ -225,10 +238,12 @@ class Calibration:
 
 
 def calibrate(protected: ProtectedTests, baseline_root: Path, *, timeout_s: float = 600.0,
-              python: str = sys.executable) -> Calibration:
+              python: str = sys.executable, pythonpath: Sequence[str] = ()) -> Calibration:
     """Prove the instrument can fail: the frozen tests must not pass on the
-    untouched baseline. Raises ``InstrumentError`` otherwise."""
-    run = _run_protected(protected, baseline_root, timeout_s=timeout_s, python=python)
+    untouched baseline. Raises ``InstrumentError`` otherwise. ``pythonpath``
+    lists workspace-relative import roots (``python/src``, ``packages/x/src``)."""
+    run = _run_protected(protected, baseline_root, timeout_s=timeout_s, python=python,
+                         pythonpath=pythonpath)
     if run.timed_out:
         raise InstrumentError(f"protected tests timed out on the baseline after {timeout_s}s")
     passed, failed, skipped, missing = _judge(protected, run)
@@ -245,9 +260,36 @@ def calibrate(protected: ProtectedTests, baseline_root: Path, *, timeout_s: floa
                        report_sha256=run.report_sha256)
 
 
+def check(tree: Path, protected: ProtectedTests, *, timeout_s: float = 600.0,
+          python: str = sys.executable, pythonpath: Sequence[str] = ()) -> VerifierOutcome:
+    """The frozen tests on a tree with no baseline: no no-op or tamper logic.
+    This is the admission check on a known solution, not a verdict on an
+    attempt; ``verify`` is the verdict."""
+    run = _run_protected(protected, tree, timeout_s=timeout_s, python=python,
+                         pythonpath=pythonpath)
+    passed, failed, skipped, missing = _judge(protected, run)
+    if run.timed_out:
+        return VerifierOutcome(verifier_id=protected.verifier_id, passed=None,
+                               expected=len(protected.expected), passed_count=passed,
+                               failed=failed, skipped=skipped, missing=missing,
+                               reasons=(f"timeout after {timeout_s:g}s",),
+                               output_sha256=run.report_sha256,
+                               duration_s=round(run.duration_s, 3))
+    ok = failed == 0 and skipped == 0 and missing == 0
+    reasons = tuple(r for r, n in ((f"{failed} expected test(s) failed", failed),
+                                   (f"{skipped} expected test(s) skipped", skipped),
+                                   (f"{missing} expected test(s) not run", missing)) if n)
+    return VerifierOutcome(verifier_id=protected.verifier_id, passed=ok,
+                           expected=len(protected.expected), passed_count=passed, failed=failed,
+                           skipped=skipped, missing=missing, reasons=reasons,
+                           output_sha256=run.report_sha256, duration_s=round(run.duration_s, 3))
+
+
 def verify(workspace: Path, protected: ProtectedTests, baseline: Baseline, *,
-           timeout_s: float = 600.0, python: str = sys.executable) -> VerifierOutcome:
-    """Verdict on the workspace as it stands, against its baseline."""
+           timeout_s: float = 600.0, python: str = sys.executable,
+           pythonpath: Sequence[str] = ()) -> VerifierOutcome:
+    """Verdict on the workspace as it stands, against its baseline.
+    ``pythonpath`` lists workspace-relative import roots for the tests."""
     changes = baseline.changes(workspace)
     n_expected = len(protected.expected)
     if not changes:
@@ -261,7 +303,8 @@ def verify(workspace: Path, protected: ProtectedTests, baseline: Baseline, *,
             tamper.append(f"protected test file changed: {rel}")
         elif Path(rel).name in CONFIG_BASENAMES:
             tamper.append(f"test configuration changed: {rel}")
-    run = _run_protected(protected, workspace, timeout_s=timeout_s, python=python)
+    run = _run_protected(protected, workspace, timeout_s=timeout_s, python=python,
+                         pythonpath=pythonpath)
     passed, failed, skipped, missing = _judge(protected, run)
     reasons: list[str] = []
     verdict: bool | None

--- a/python/src/xyntetik_runner/shadow/verifier.py
+++ b/python/src/xyntetik_runner/shadow/verifier.py
@@ -117,6 +117,18 @@ class ProtectedTests:
         return tuple(sorted({rel for rel, _ in self.expected}))
 
 
+def fixed_ids(protected: ProtectedTests, outcome_ids: Sequence[str], tree: Path, *,
+              timeout_s: float = 600.0, python: str = sys.executable,
+              pythonpath: Sequence[str] = ()) -> tuple[str, ...]:
+    """Which of ``outcome_ids`` (``file::name``) pass on ``tree`` now. A second
+    run, kept separate from ``verify`` so the verdict stays one run."""
+    run = _run_protected(protected, tree, timeout_s=timeout_s, python=python,
+                         pythonpath=pythonpath)
+    want = set(outcome_ids)
+    return tuple(f"{rel}::{name}" for rel, name in protected.expected
+                 if f"{rel}::{name}" in want and run.outcomes.get(_key(rel, name)) == "passed")
+
+
 @dataclass(frozen=True)
 class _Run:
     outcomes: Mapping[tuple[str, str], str]
@@ -235,6 +247,9 @@ class Calibration:
     passing: int
     missing: int
     report_sha256: str
+    failing_ids: tuple[str, ...] = ()
+    """``file::name`` of every expected test that failed or did not run on the
+    baseline: the tests a fix has to turn green."""
 
 
 def calibrate(protected: ProtectedTests, baseline_root: Path, *, timeout_s: float = 600.0,
@@ -256,8 +271,10 @@ def calibrate(protected: ProtectedTests, baseline_root: Path, *, timeout_s: floa
     if run.returncode == 0:
         raise InstrumentError("pytest exited 0 on the baseline while the report shows failures; "
                               "the report and the process disagree")
+    ids = tuple(f"{rel}::{name}" for rel, name in protected.expected
+                if run.outcomes.get(_key(rel, name)) != "passed")
     return Calibration(failing=failed, passing=passed, missing=missing,
-                       report_sha256=run.report_sha256)
+                       report_sha256=run.report_sha256, failing_ids=ids)
 
 
 def check(tree: Path, protected: ProtectedTests, *, timeout_s: float = 600.0,

--- a/python/tests/test_shadow_evidence.py
+++ b/python/tests/test_shadow_evidence.py
@@ -78,13 +78,16 @@ def test_json_round_trip() -> None:
 
 def test_summary_is_per_episode_and_per_cohort_and_withholds_the_percentage() -> None:
     other = Identity(**{**IDENT.__dict__, "model_sha256": "o" * 64})
-    recs = [record(Disposition.VERIFIED_LOCAL_ATTEMPT, passing(), episode_id=f"v{i}")
-            for i in range(4)]
-    recs += [record(Disposition.LOCAL_FAILED, passing(passed=False, failed=1), episode_id=f"f{i}")
-             for i in range(2)]
+    # per-task identity fields differ between episodes; the row is per stack
+    def ident_for(i: int, base: Identity) -> Identity:
+        return Identity(**{**base.__dict__, "verifier_id": f"commit-tests:t{i}", "project": f"p{i}"})
+    recs = [record(Disposition.VERIFIED_LOCAL_ATTEMPT, passing(), episode_id=f"v{i}",
+                   identity=ident_for(i, IDENT)) for i in range(4)]
+    recs += [record(Disposition.LOCAL_FAILED, passing(passed=False, failed=1), episode_id=f"f{i}",
+                    identity=ident_for(10 + i, IDENT)) for i in range(2)]
     # the same episodes attempted by a second stack: still six episodes
     recs += [record(Disposition.LOCAL_FAILED, passing(passed=False, failed=1), episode_id=f"v{i}",
-                    identity=other) for i in range(4)]
+                    identity=ident_for(i, other)) for i in range(4)]
     recs += [record(Disposition.INELIGIBLE, None, episode_id="i0"),
              record(Disposition.UNREPLAYABLE, None, episode_id="u0"),
              record(Disposition.VERIFIER_INCONCLUSIVE, None, episode_id="q0"),
@@ -95,6 +98,7 @@ def test_summary_is_per_episode_and_per_cohort_and_withholds_the_percentage() ->
     assert (s.observed, s.eligible, s.unattempted, s.agreement_only) == (11, 9, 1, 1)
     assert s.by_disposition["verified_local_attempt"] == 4 and s.by_disposition["local_failed"] == 2
     rows = {c.model: c for c in s.cohorts}
+    assert len(rows) == 2, "one row per model stack, not per task"
     assert rows["m" * 64].verified == 4 and rows["m" * 64].failed == 2
     assert rows["o" * 64].verified == 0 and rows["o" * 64].attempted == 4
     text = render(s)

--- a/python/tests/test_shadow_evidence.py
+++ b/python/tests/test_shadow_evidence.py
@@ -76,22 +76,30 @@ def test_json_round_trip() -> None:
     assert EpisodeEvidence.from_json(r.to_json()) == r
 
 
-def test_summary_counts_both_denominators_and_withholds_the_percentage() -> None:
+def test_summary_is_per_episode_and_per_cohort_and_withholds_the_percentage() -> None:
+    other = Identity(**{**IDENT.__dict__, "model_sha256": "o" * 64})
     recs = [record(Disposition.VERIFIED_LOCAL_ATTEMPT, passing(), episode_id=f"v{i}")
             for i in range(4)]
     recs += [record(Disposition.LOCAL_FAILED, passing(passed=False, failed=1), episode_id=f"f{i}")
              for i in range(2)]
+    # the same episodes attempted by a second stack: still six episodes
+    recs += [record(Disposition.LOCAL_FAILED, passing(passed=False, failed=1), episode_id=f"v{i}",
+                    identity=other) for i in range(4)]
     recs += [record(Disposition.INELIGIBLE, None, episode_id="i0"),
              record(Disposition.UNREPLAYABLE, None, episode_id="u0"),
              record(Disposition.VERIFIER_INCONCLUSIVE, None, episode_id="q0"),
              record(Disposition.AGREEMENT_ONLY, None, episode_id="a0"),
-             record(Disposition.NOT_ATTEMPTED_RESOURCE, None, episode_id="n0")]
+             record(Disposition.NOT_ATTEMPTED_RESOURCE, None, episode_id="n0"),
+             record(Disposition.NOT_ATTEMPTED_RESOURCE, None, episode_id="v0")]
     s = summarize(recs)
-    assert (s.observed, s.eligible, s.attempted, s.checked, s.verified, s.failed) == (11, 9, 8, 6, 4, 2)
-    assert s.inconclusive == 1 and s.agreement_only == 1 and s.cohorts == 1
+    assert (s.observed, s.eligible, s.unattempted, s.agreement_only) == (11, 9, 1, 1)
+    assert s.by_disposition["verified_local_attempt"] == 4 and s.by_disposition["local_failed"] == 2
+    rows = {c.model: c for c in s.cohorts}
+    assert rows["m" * 64].verified == 4 and rows["m" * 64].failed == 2
+    assert rows["o" * 64].verified == 0 and rows["o" * 64].attempted == 4
     text = render(s)
-    assert "verified over eligible: 4 of 9" in text
-    assert "verified over observed: 4 of 11" in text
+    assert "11 episodes observed" in text and "9 eligible for replay" in text
+    assert "verified over eligible 4 of 9; verified over observed 4 of 11" in text
     assert "%" not in text.split("(no percentage")[0]
     assert f"no percentage before {HEADLINE_MIN_EPISODES}" in text
 
@@ -101,6 +109,6 @@ def test_percentage_appears_only_at_the_floor_and_only_over_eligible() -> None:
             for i in range(HEADLINE_MIN_EPISODES)]
     recs += [record(Disposition.INELIGIBLE, None, episode_id=f"i{i}") for i in range(10)]
     text = render(summarize(recs))
-    assert f"verified over eligible: {HEADLINE_MIN_EPISODES} of {HEADLINE_MIN_EPISODES} (100%)" in text
-    assert f"verified over observed: {HEADLINE_MIN_EPISODES} of {HEADLINE_MIN_EPISODES + 10}\n" in text + "\n"
+    assert f"verified over eligible {HEADLINE_MIN_EPISODES} of {HEADLINE_MIN_EPISODES} (100%)" in text
+    assert f"verified over observed {HEADLINE_MIN_EPISODES} of {HEADLINE_MIN_EPISODES + 10}" in text
     assert "no percentage" not in text

--- a/python/tests/test_shadow_pipeline.py
+++ b/python/tests/test_shadow_pipeline.py
@@ -166,6 +166,20 @@ def test_admit_rejects_harness_commands_and_dedupes_commit_ranges(repo: Path, tm
     assert isinstance(again, Rejection) and "same fix commit" in again.reason
 
 
+def test_choose_attributes_a_fix_to_the_closest_prompt_in_the_repo(repo: Path) -> None:
+    from xyntetik_runner.shadow.tasks import choose, pair
+    early_parent = pair(episode(repo.parent, turn=1, started_at="2026-09-01T10:00:00Z"))
+    late_parent = pair(episode(repo.parent, turn=2, started_at="2026-09-01T11:45:00Z"))
+    in_repo = pair(episode(repo, turn=3, started_at="2026-09-01T11:20:00Z"))
+    assert not isinstance(early_parent, Rejection) and not isinstance(late_parent, Rejection)
+    assert not isinstance(in_repo, Rejection)
+    chosen = choose([*early_parent, *late_parent, *in_repo])
+    assert len(chosen) == 1
+    assert next(iter(chosen.values())).episode.turn == 3, "the repo's own prompt wins over a parent"
+    chosen = choose([*early_parent, *late_parent])
+    assert next(iter(chosen.values())).episode.turn == 2, "then the latest prompt before the fix"
+
+
 def scripted(*steps: dict[str, Any]) -> Any:
     it = iter(steps)
 
@@ -199,12 +213,16 @@ def test_attempt_confines_paths_and_verifies_a_scripted_fix(repo: Path, tmp_path
         {"content": "", "tool_calls": [call("run_tests"), call("finish", summary="done")]},
         {"content": "", "tool_calls": []},
     )
+    assert len(task.failing_at_base) == 3 and all("::" in i for i in task.failing_at_base)
     result = attempt(task.request, ws, chat)
     assert result.finished and result.stop_reason == "finish" and result.test_runs == 2
     assert result.tool_names == ("finish", "read_file", "run_tests", "write_file")
     outcome = verify(ws_dir, ProtectedTests.load(Path(task.protected_dir)), baseline,
                      python=sys.executable, pythonpath=task.pythonpath)
     assert outcome.passed is True and outcome.passed_count == 6
+    from xyntetik_runner.shadow import fixed_ids
+    assert set(fixed_ids(ProtectedTests.load(Path(task.protected_dir)), task.failing_at_base, ws_dir,
+                         python=sys.executable, pythonpath=task.pythonpath)) == set(task.failing_at_base)
     subprocess.run(["git", "-C", str(repo), "worktree", "remove", "--force", str(ws_dir)], check=True)
 
 
@@ -248,3 +266,5 @@ def test_cli_import_and_report_on_a_synthetic_home(repo: Path, tmp_path: Path, c
     assert "3 episodes observed" not in text  # the admitted one has no record until replayed
     assert "2 episodes observed" in text and "no percentage" in text
     assert "ineligible: no git repository" in text and "unreplayable: no commit" in text
+    task = RepairTask.load(tasks[0])
+    assert task.episode_id.endswith(":1"), "the prompt before the fix, not the thanks after it"

--- a/python/tests/test_shadow_pipeline.py
+++ b/python/tests/test_shadow_pipeline.py
@@ -268,3 +268,44 @@ def test_cli_import_and_report_on_a_synthetic_home(repo: Path, tmp_path: Path, c
     assert "ineligible: no git repository" in text and "unreplayable: no commit" in text
     task = RepairTask.load(tasks[0])
     assert task.episode_id.endswith(":1"), "the prompt before the fix, not the thanks after it"
+
+
+def test_capture_hook_path_gives_an_exact_range(repo: Path, tmp_path: Path, monkeypatch: Any) -> None:
+    """Prompt and stop hooks record HEAD at both ends; the task is built from
+    the exact ancestry range, no time window, and the request is the one
+    typed at the prompt."""
+    from xyntetik_runner.shadow.importer import scan_capture
+    from xyntetik_runner.shadow.tasks import choose, pair
+    base = git(repo, "rev-parse", "HEAD^")
+    fix = git(repo, "rev-parse", "HEAD")
+    cap = tmp_path / "capture.jsonl"
+    # a prompt at the buggy state ...
+    git(repo, "checkout", "-q", base)
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(json.dumps(
+        {"session_id": "cap1", "cwd": str(repo), "prompt": "fix parse_amount"})))
+    assert main(["capture", "--event", "prompt", "--file", str(cap)]) == 0
+    # ... and a stop after the fix landed
+    git(repo, "checkout", "-q", fix)
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(json.dumps(
+        {"session_id": "cap1", "cwd": str(repo)})))
+    assert main(["capture", "--event", "stop", "--file", str(cap)]) == 0
+    lines = [json.loads(l) for l in cap.read_text().splitlines()]
+    assert [l["event"] for l in lines] == ["prompt", "stop"]
+    assert lines[0]["head"] == base and lines[1]["head"] == fix and "prompt" not in lines[1]
+    eps = scan_capture(cap).episodes
+    assert len(eps) == 1 and eps[0].source == "capture" and eps[0].request == "fix parse_amount"
+    assert (eps[0].head_start, eps[0].head_end) == (base, fix)
+    paired = pair(eps[0])
+    assert not isinstance(paired, Rejection) and paired[0].shas == (fix,)
+    chosen = choose(paired)
+    task = admit(eps[0], out_dir=tmp_path / "t", python=sys.executable)
+    assert isinstance(task, RepairTask) and task.base_sha == base and task.solution_sha == fix
+    assert len(chosen) == 1
+
+
+def test_capture_with_unmoved_head_is_unreplayable(repo: Path, tmp_path: Path) -> None:
+    from xyntetik_runner.shadow.tasks import pair
+    head = git(repo, "rev-parse", "HEAD")
+    e = episode(repo, source="capture", head_start=head, head_end=head)
+    r = pair(e)
+    assert isinstance(r, Rejection) and r.disposition is Disposition.UNREPLAYABLE

--- a/python/tests/test_shadow_pipeline.py
+++ b/python/tests/test_shadow_pipeline.py
@@ -263,8 +263,8 @@ def test_cli_import_and_report_on_a_synthetic_home(repo: Path, tmp_path: Path, c
     assert len(tasks) == 1
     assert main(["report", "--out", str(out), "--by-reason"]) == 0
     text = capsys.readouterr().out
-    assert "3 episodes observed" not in text  # the admitted one has no record until replayed
-    assert "2 episodes observed" in text and "no percentage" in text
+    assert "3 episodes observed" in text and "1 eligible for replay" in text
+    assert "1 eligible and not attempted yet" in text and "no percentage" in text
     assert "ineligible: no git repository" in text and "unreplayable: no commit" in text
     task = RepairTask.load(tasks[0])
     assert task.episode_id.endswith(":1"), "the prompt before the fix, not the thanks after it"

--- a/python/tests/test_shadow_pipeline.py
+++ b/python/tests/test_shadow_pipeline.py
@@ -1,0 +1,250 @@
+"""Importer, task builder, attempt harness and CLI, end to end on synthetic
+traces and a synthetic repository. No model: the attempt is driven by a
+scripted chat function, which is enough to prove the plumbing and the
+confinement; the model's competence is what the pilot measures."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from xyntetik_runner.shadow import Baseline, Disposition, ProtectedTests, verify
+from xyntetik_runner.shadow.attempt import Budget, Workspace, attempt
+from xyntetik_runner.shadow.cli import main
+from xyntetik_runner.shadow.importer import Episode, read_episodes, scan_claude_code, scan_codex
+from xyntetik_runner.shadow.tasks import RepairTask, Rejection, admit, repos_under
+
+FIXTURE = Path(__file__).parent / "fixtures" / "repair_task_v1"
+BUGGY = (FIXTURE / "workspace" / "calc" / "money.py").read_text()
+VISIBLE = (FIXTURE / "workspace" / "tests" / "test_money.py").read_text()
+SOLUTION_TESTS = (FIXTURE / "protected" / "tests" / "test_money.py").read_text()
+CORRECT = '''"""Money parsing for the ledger importer."""
+from decimal import ROUND_HALF_UP, Decimal
+
+
+def parse_amount(text: str) -> int:
+    cleaned = "".join(ch for ch in text if ch.isdigit() or ch in "-.")
+    return int((Decimal(cleaned) * 100).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+'''
+
+
+def git(repo: Path, *args: str, date: str = "2026-09-01T12:00:00+00:00") -> str:
+    env = {**os.environ, "GIT_AUTHOR_DATE": date, "GIT_COMMITTER_DATE": date,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@x", "GIT_COMMITTER_NAME": "t",
+           "GIT_COMMITTER_EMAIL": "t@x"}
+    return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True,
+                          env=env, check=True).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repository with the buggy state committed at 11:00 and the fix,
+    with its stronger tests, committed at 12:00."""
+    r = tmp_path / "proj"
+    (r / "calc").mkdir(parents=True)
+    (r / "tests").mkdir()
+    git(tmp_path, "init", "-q", "-b", "main", str(r))
+    (r / "calc" / "__init__.py").write_text("")
+    (r / "calc" / "money.py").write_text(BUGGY)
+    (r / "tests" / "test_money.py").write_text(VISIBLE)
+    git(r, "add", "-A")
+    git(r, "commit", "-q", "-m", "buggy", date="2026-09-01T11:00:00+00:00")
+    (r / "calc" / "money.py").write_text(CORRECT)
+    (r / "tests" / "test_money.py").write_text(SOLUTION_TESTS)
+    git(r, "add", "-A")
+    git(r, "commit", "-q", "-m", "fix", date="2026-09-01T12:00:00+00:00")
+    return r
+
+
+def episode(cwd: Path, **kw: Any) -> Episode:
+    base = dict(source="claude_code", session_id="abcdef123456", turn=1, cwd=str(cwd),
+                started_at="2026-09-01T11:30:00Z", ended_at="2026-09-01T12:10:00Z",
+                request="make parse_amount handle thousands separators, currency and rounding",
+                request_sha256="x" * 64)
+    base.update(kw)
+    return Episode(**base)  # type: ignore[arg-type]
+
+
+def test_codex_scan_reads_boundaries_and_never_the_answer(tmp_path: Path) -> None:
+    sessions = tmp_path / "sessions" / "2026"
+    sessions.mkdir(parents=True)
+    recs = [
+        {"type": "session_meta", "payload": {"id": "s1", "cwd": "/w"}},
+        {"timestamp": "2026-09-01T10:00:00Z", "type": "event_msg", "payload": {"type": "task_started"}},
+        {"type": "event_msg", "payload": {"type": "user_message", "message": "fix the parser"}},
+        {"type": "response_item", "payload": {"type": "message", "role": "assistant",
+                                              "content": "THE ANSWER"}},
+        {"type": "response_item", "payload": {"type": "function_call", "name": "shell",
+                                              "arguments": "{\"cmd\": \"THE PATCH\"}"}},
+        {"timestamp": "2026-09-01T10:05:00Z", "type": "event_msg", "payload": {"type": "task_complete"}},
+    ]
+    (sessions / "a.jsonl").write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+    (sessions / "broken.jsonl").write_bytes(b"\xff\xfe not json")
+    report = scan_codex(tmp_path / "sessions")
+    assert len(report.episodes) == 1 and report.files_read == 2
+    e = report.episodes[0]
+    assert (e.cwd, e.request, e.tool_names) == ("/w", "fix the parser", ("shell",))
+    assert e.started_at == "2026-09-01T10:00:00Z" and e.ended_at == "2026-09-01T10:05:00Z"
+    dumped = json.dumps(e.__dict__)
+    assert "THE ANSWER" not in dumped and "THE PATCH" not in dumped
+
+
+def test_claude_code_scan_turns_end_at_the_next_prompt(tmp_path: Path) -> None:
+    proj = tmp_path / "projects" / "p"
+    proj.mkdir(parents=True)
+    recs = [
+        {"type": "user", "sessionId": "s", "cwd": "/w", "timestamp": "2026-09-01T10:00:00Z",
+         "message": {"content": "do A"}},
+        {"type": "assistant", "message": {"content": "THE ANSWER"}},
+        {"type": "user", "sessionId": "s", "cwd": "/w", "timestamp": "2026-09-01T10:20:00Z",
+         "message": {"content": [{"type": "tool_result", "content": "THE OUTPUT"}]}},
+        {"type": "user", "sessionId": "s", "cwd": "/w", "timestamp": "2026-09-01T11:00:00Z",
+         "message": {"content": "<command-name>/model</command-name>"}},
+    ]
+    (proj / "s.jsonl").write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+    eps = scan_claude_code(tmp_path / "projects").episodes
+    assert [e.turn for e in eps] == [1, 2]
+    assert eps[0].ended_at == "2026-09-01T11:00:00Z" and eps[1].is_command
+    assert "THE ANSWER" not in json.dumps([e.__dict__ for e in eps])
+
+
+def test_repos_under_finds_nested_repositories(repo: Path) -> None:
+    assert repos_under(repo.parent) == [repo]
+    assert repos_under(repo) == [repo]
+
+
+def test_admit_builds_a_calibrated_task(repo: Path, tmp_path: Path) -> None:
+    out = tmp_path / "tasks"
+    out.mkdir()
+    result = admit(episode(repo.parent), out_dir=out, python=sys.executable)
+    assert isinstance(result, RepairTask), result
+    assert result.expected_tests == 6 and result.baseline_failing >= 1
+    assert result.visible_test_files == ("tests/test_money.py",)
+    assert Path(result.protected_dir, "manifest.json").is_file()
+    assert RepairTask.load(out / result.task_id / "task.json") == result
+    # the solution is recorded for provenance, never given to the attempt
+    assert result.solution_sha != result.base_sha
+
+
+def test_admit_rejects_when_no_commit_in_window(repo: Path, tmp_path: Path) -> None:
+    r = admit(episode(repo, started_at="2026-09-02T00:00:00Z", ended_at="2026-09-02T01:00:00Z"),
+              out_dir=tmp_path, python=sys.executable)
+    assert isinstance(r, Rejection) and r.disposition is Disposition.UNREPLAYABLE
+
+
+def test_admit_rejects_a_commit_whose_tests_pass_before_the_fix(tmp_path: Path) -> None:
+    r = tmp_path / "proj"
+    (r / "pkg").mkdir(parents=True)
+    (r / "tests").mkdir()
+    git(tmp_path, "init", "-q", "-b", "main", str(r))
+    (r / "pkg" / "__init__.py").write_text("X = 1\n")
+    (r / "tests" / "test_x.py").write_text("from pkg import X\n\n\ndef test_x():\n    assert X == 1\n")
+    git(r, "add", "-A")
+    git(r, "commit", "-q", "-m", "a", date="2026-09-01T11:00:00+00:00")
+    (r / "pkg" / "__init__.py").write_text("X = 1\nY = 2\n")
+    (r / "tests" / "test_x.py").write_text("from pkg import X\n\n\ndef test_x():\n    assert X == 1\n\n\ndef test_y():\n    assert True\n")
+    git(r, "add", "-A")
+    git(r, "commit", "-q", "-m", "b", date="2026-09-01T12:00:00+00:00")
+    res = admit(episode(r), out_dir=tmp_path / "t", python=sys.executable)
+    assert isinstance(res, Rejection) and res.disposition is Disposition.UNREPLAYABLE
+    assert "instrument" in res.reason
+
+
+def test_admit_rejects_harness_commands_and_dedupes_commit_ranges(repo: Path, tmp_path: Path) -> None:
+    seen: set[tuple[str, str]] = set()
+    assert isinstance(admit(episode(repo, request="<command-name>/x</command-name>"),
+                             out_dir=tmp_path, python=sys.executable), Rejection)
+    first = admit(episode(repo), out_dir=tmp_path, python=sys.executable, seen=seen)
+    assert isinstance(first, RepairTask)
+    again = admit(episode(repo, turn=2, started_at="2026-09-01T10:30:00Z"), out_dir=tmp_path,
+                  python=sys.executable, seen=seen)
+    assert isinstance(again, Rejection) and "same fix commit" in again.reason
+
+
+def scripted(*steps: dict[str, Any]) -> Any:
+    it = iter(steps)
+
+    def chat(messages: list[dict[str, Any]], tools: list[dict[str, Any]]) -> dict[str, Any]:
+        assert messages[0]["role"] == "system" and any(t["function"]["name"] == "finish" for t in tools)
+        return next(it)
+    return chat
+
+
+def call(name: str, **args: Any) -> dict[str, Any]:
+    return {"id": f"c-{name}", "type": "function",
+            "function": {"name": name, "arguments": json.dumps(args)}}
+
+
+def test_attempt_confines_paths_and_verifies_a_scripted_fix(repo: Path, tmp_path: Path) -> None:
+    task = admit(episode(repo), out_dir=tmp_path / "t", python=sys.executable)
+    assert isinstance(task, RepairTask)
+    ws_dir = tmp_path / "ws"
+    subprocess.run(["git", "-C", str(repo), "worktree", "add", "--detach", "-q", str(ws_dir),
+                    task.base_sha], check=True)
+    ws = Workspace(ws_dir, visible_tests=task.visible_test_files, pythonpath=task.pythonpath,
+                   python=sys.executable, budget=Budget(test_runs=2))
+    assert ws.read_file("../outside.txt").startswith("error")
+    assert ws.write_file("/tmp/x", "y").startswith("error")
+    assert ws.list_files("../*").startswith("error")
+    baseline = Baseline.capture(ws_dir)
+    chat = scripted(
+        {"content": "", "tool_calls": [call("read_file", path="calc/money.py"), call("run_tests")]},
+        {"content": "", "tool_calls": [call("write_file", path="calc/money.py", content=CORRECT),
+                                       call("run_tests")]},
+        {"content": "", "tool_calls": [call("run_tests"), call("finish", summary="done")]},
+        {"content": "", "tool_calls": []},
+    )
+    result = attempt(task.request, ws, chat)
+    assert result.finished and result.stop_reason == "finish" and result.test_runs == 2
+    assert result.tool_names == ("finish", "read_file", "run_tests", "write_file")
+    outcome = verify(ws_dir, ProtectedTests.load(Path(task.protected_dir)), baseline,
+                     python=sys.executable, pythonpath=task.pythonpath)
+    assert outcome.passed is True and outcome.passed_count == 6
+    subprocess.run(["git", "-C", str(repo), "worktree", "remove", "--force", str(ws_dir)], check=True)
+
+
+def test_attempt_stops_on_budget_and_no_tool_calls(repo: Path, tmp_path: Path) -> None:
+    ws = Workspace(repo, visible_tests=(), pythonpath=(), python=sys.executable,
+                   budget=Budget(max_turns=2))
+    chat = scripted({"content": "I think..."}, {"content": "still thinking"})
+    r = attempt("x", ws, chat)
+    assert not r.finished and r.stop_reason == "no tool call" and r.turns == 2
+    chat = scripted(*[{"content": "", "tool_calls": [call("list_files")]}] * 3)
+    r = attempt("x", ws, chat, budget=Budget(max_turns=2))
+    assert r.stop_reason == "turn budget" and r.tool_calls == 2
+    chat = scripted({"content": "", "tool_calls": [call("write_file", path="a", content="b")]},
+                    {"content": "", "tool_calls": []})
+    r = attempt("x", Workspace(tmp_path, visible_tests=(), pythonpath=(), python=sys.executable,
+                               budget=Budget()), chat)
+    assert (tmp_path / "a").read_text() == "b"
+
+
+def test_cli_import_and_report_on_a_synthetic_home(repo: Path, tmp_path: Path, capsys: Any) -> None:
+    home = tmp_path / "home"
+    proj = home / ".claude" / "projects" / "p"
+    proj.mkdir(parents=True)
+    recs = [
+        {"type": "user", "sessionId": "s", "cwd": str(repo.parent), "timestamp": "2026-09-01T11:30:00Z",
+         "message": {"content": "fix parse_amount for thousands separators and currency"}},
+        {"type": "user", "sessionId": "s", "cwd": str(repo.parent), "timestamp": "2026-09-01T12:10:00Z",
+         "message": {"content": "thanks"}},
+        {"type": "user", "sessionId": "s", "cwd": "/nonexistent", "timestamp": "2026-09-01T13:00:00Z",
+         "message": {"content": "unrelated"}},
+    ]
+    (proj / "s.jsonl").write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+    out = tmp_path / "out"
+    assert main(["import", "--out", str(out), "--home", str(home), "--python", sys.executable]) == 0
+    eps = read_episodes(out / "episodes.jsonl")
+    assert len(eps) == 3
+    tasks = list((out / "tasks").glob("*/task.json"))
+    assert len(tasks) == 1
+    assert main(["report", "--out", str(out), "--by-reason"]) == 0
+    text = capsys.readouterr().out
+    assert "3 episodes observed" not in text  # the admitted one has no record until replayed
+    assert "2 episodes observed" in text and "no percentage" in text
+    assert "ineligible: no git repository" in text and "unreplayable: no commit" in text

--- a/python/tests/test_shadow_verifier.py
+++ b/python/tests/test_shadow_verifier.py
@@ -166,3 +166,26 @@ def test_scratch_copy_leaves_the_workspace_untouched(task: tuple[Path, Baseline,
     verify(ws, protected, base)
     assert Baseline.capture(ws) == before
     assert not (ws / "report.xml").exists() and not (ws / "verifier.ini").exists()
+
+
+def test_pythonpath_roots_resolve_inside_the_scratch_copy(tmp_path: Path) -> None:
+    """A src-layout workspace: the package lives under src/, so the tests only
+    import when the verifier adds that root, and they must import the COPY."""
+    ws = tmp_path / "ws"
+    (ws / "src" / "calc").mkdir(parents=True)
+    (ws / "tests").mkdir()
+    (ws / "src" / "calc" / "__init__.py").write_text("")
+    (ws / "src" / "calc" / "money.py").write_text(WRONG)
+    (ws / "tests" / "test_money.py").write_text("def test_plain():\n    assert True\n")
+    src = tmp_path / "protected"
+    (src / "tests").mkdir(parents=True)
+    shutil.copyfile(FIXTURE / "protected" / "tests" / "test_money.py", src / "tests" / "test_money.py")
+    protected = ProtectedTests.freeze(src, {"tests/test_money.py": [
+        "test_plain", "test_thousands_separator", "test_float_trap", "test_negative",
+        "test_currency_prefix", "test_whitespace"]})
+    base = Baseline.capture(ws)
+    (ws / "src" / "calc" / "money.py").write_text(CORRECT)
+    without = verify(ws, protected, base)
+    assert without.passed is False and without.missing == 6, "no root: the tests cannot import calc"
+    with_root = verify(ws, protected, base, pythonpath=("src",))
+    assert with_root.passed is True and with_root.passed_count == 6


### PR DESCRIPTION
Shadow mode end to end in the Python client, stdlib-only: `python -m xyntetik_runner.shadow import | replay | report | capture`.

- **import** reads the Codex and Claude Code session files on the machine and takes from each task boundary only the working directory, timestamps and the user's own request; pairs the task with the commits in its window in any repository at or under the directory; attributes each fix commit to one prompt (the repository's own directory over a parent, then the latest before the fix); freezes the post-state test files as the verifier and requires them to pass after and fail before; and records a disposition and reason for every other episode first, so the denominator is complete before any model runs.
- **replay** gives a model a scratch worktree at the pre-state, the request, the visible test file names, five tools (list, read, write, run visible tests, finish), no shell, paths confined to the copy, a budget, `tool_choice: required`; keeps the transcript and diff; the frozen tests decide, and the record says how many failing-at-base tests were turned green.
- **report** prints counts, both denominators per model stack, no percentage before thirty eligible episodes, and `--tasks` lists each task with every attempt.
- **capture** is the prospective path: prompt and stop hooks record the request with the repository HEAD at both ends, so the task's commit range is exact.

First real run on this machine's history (2,598 episodes): 4 eligible, two 7B-class arms, 0 verified, 0 failing-at-base tests fixed. Two limits found, both properties of history replay: an agentic session commits many turns after the request, so three of the four admitted tasks carry a side remark as their request; and a terse request has no failing signal the model can see. Both are what the capture path exists for. Details and the plan verdict are in the suite plan.

Gates: python/tests 83 passed (34 new), mypy strict clean on the package. Found on the way: pytest `-q -q` on collection prints counts not ids; JUnit keys methods by `module.Class`; a solution's own test edits are not tampering, so admission uses a baseline-free check.
