### PR TITLE
shadow: capture every repo HEAD under the directory, session context, fit-first probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ names that were true when they were written.
 
 ## Unreleased
 
+- **Shadow mode, three small items after the first pilot.** The capture
+  hook now records the HEAD of every repository at or under the working
+  directory, not only the directory's own, so a session started from a
+  parent directory still yields exact commit ranges for the repositories
+  inside it (the owner's own habit, and the reason the first captured
+  turns would have fallen back to time windows). Earlier requests of the
+  same session, the user's own words and never a harness command, travel
+  with the request as context, at most three turns and four thousand
+  characters, because the one genuinely attributed pilot task failed on a
+  request ("check why CI fails and fix") that carried no failing signal on
+  its own. And `replay` probes decode speed with one short generation
+  before any attempt and refuses a model below `--min-tps` (default 15):
+  the fit-first rule measured rather than assumed, after an 8B at a 16K
+  context spilled an 8 GB card and ran at 4.5 tokens per second into the
+  wall clock on every task. The probe speed is recorded on every record.
+
 - **Shadow mode runs end to end (R14.2 to R14.5): `python -m
   xyntetik_runner.shadow import | replay | report`.** The importer reads the
   Codex and Claude Code session files already on the machine and takes from

--- a/README.md
+++ b/README.md
@@ -1823,9 +1823,14 @@ the task's commit range is exact.
     "command": "python3 -m xyntetik_runner.shadow capture --event stop"}]}]}}
 ```
 
-Only your request, the directory, the time and the commit id are written;
-the file is `~/.xyntetik/shadow/capture.jsonl` and `import` reads it beside
-the session files. Design, gates and the negative controls that prove the
+Only your request, the directory, the time and the commit ids are written
+(the HEAD of every repository at or under the directory, so a session
+started from a parent directory still gets exact ranges); the file is
+`~/.xyntetik/shadow/capture.jsonl` and `import` reads it beside the
+session files. Earlier requests of the same session travel with a task as
+context. `replay` probes decode speed first and refuses a model below
+`--min-tps` (default 15 tokens per second): serve something that fits the
+card, at an 8K context for coding attempts. Design, gates and the negative controls that prove the
 verifier can fail: [python/README.md](python/README.md).
 
 ## Desktop tray

--- a/python/src/xyntetik_runner/shadow/attempt.py
+++ b/python/src/xyntetik_runner/shadow/attempt.py
@@ -224,11 +224,15 @@ def _name(call: dict[str, Any]) -> str:
     return str(_fn(call).get("name") or "")
 
 
-def attempt(request: str, workspace: Workspace, chat: ChatFn, *, budget: Budget | None = None
-            ) -> AttemptResult:
+def attempt(request: str, workspace: Workspace, chat: ChatFn, *, budget: Budget | None = None,
+            context: Sequence[str] = ()) -> AttemptResult:
     budget = budget or workspace.budget
     listing = workspace.list_files("*")
-    user = (f"Task:\n{request.strip()}\n\nVisible test files: "
+    earlier = ""
+    if context:
+        joined = "\n\n".join(f"- {c.strip()}" for c in context)
+        earlier = f"Earlier requests in this session, oldest first:\n{joined}\n\n"
+    user = (f"{earlier}Task:\n{request.strip()}\n\nVisible test files: "
             f"{', '.join(workspace.visible_tests) or '(none at this state; look for tests/)'}\n\n"
             f"Top-level files:\n{listing}")
     messages: list[dict[str, Any]] = [{"role": "system", "content": SYSTEM_PROMPT},
@@ -301,6 +305,23 @@ def _done(turns: int, calls: int, ws: Workspace, ptoks: int, ctoks: int, t0: flo
                          wall_s=round(time.monotonic() - t0, 3), stop_reason=reason,
                          finished=finished, summary=summary, tool_names=tuple(sorted(set(names))),
                          transcript=tuple(messages))
+
+
+def probe_speed(post_json: Callable[..., dict[str, Any]], model: str, *, tokens: int = 64
+                ) -> float:
+    """Decode speed in tokens per second from one short generation: the
+    fit-first rule measured rather than assumed. A model whose weights or
+    context spilled the device shows up here as a crawl."""
+    payload = {"model": model, "messages": [{"role": "user", "content":
+               "Write the numbers from one to two hundred as words, separated by commas."}],
+               "max_tokens": tokens, "temperature": 0}
+    t0 = time.monotonic()
+    data = post_json("/v1/chat/completions", payload)
+    wall = max(time.monotonic() - t0, 1e-6)
+    usage_raw = data.get("usage")
+    usage: dict[str, Any] = usage_raw if isinstance(usage_raw, dict) else {}
+    generated = int(usage.get("completion_tokens", 0) or 0)
+    return generated / wall if generated else 0.0
 
 
 def runner_chat(post_json: Callable[..., dict[str, Any]], model: str, *, max_tokens: int,

--- a/python/src/xyntetik_runner/shadow/cli.py
+++ b/python/src/xyntetik_runner/shadow/cli.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Any
 
 from xyntetik_runner.endpoint import RunnerEndpoint
-from xyntetik_runner.shadow.attempt import Budget, Workspace, attempt, runner_chat
+from xyntetik_runner.shadow.attempt import Budget, Workspace, attempt, probe_speed, runner_chat
 from xyntetik_runner.shadow.baseline import Baseline
 from xyntetik_runner.shadow.evidence import (
     Disposition,
@@ -34,7 +34,15 @@ from xyntetik_runner.shadow.evidence import (
     summarize,
 )
 from xyntetik_runner.shadow.importer import CAPTURE_FILE, Episode, read_episodes, scan_all, write_episodes
-from xyntetik_runner.shadow.tasks import Candidate, RepairTask, Rejection, build_task, choose, pair
+from xyntetik_runner.shadow.tasks import (
+    Candidate,
+    RepairTask,
+    Rejection,
+    build_task,
+    choose,
+    pair,
+    repos_under,
+)
 from xyntetik_runner.shadow.verifier import ProtectedTests, fixed_ids, verify
 
 HARNESS_VERSION = "shadow-0.1"
@@ -173,6 +181,15 @@ def cmd_replay(args: argparse.Namespace) -> int:
         return 2
     budget = Budget(max_turns=args.max_turns, wall_s=args.wall, max_tokens=args.max_tokens,
                     test_runs=args.test_runs)
+    # Fit first: a model that crawls has spilled the device, and an attempt
+    # at that speed measures the wall clock, not the model. Refuse it.
+    tps = probe_speed(endpoint.post_json, model)
+    print(f"probe: {model} decodes at {tps:.1f} tok/s (floor {args.min_tps:g})", flush=True)
+    if tps < args.min_tps:
+        print(f"error: fit-first: {tps:.1f} tok/s is below the floor of {args.min_tps:g}; "
+              "serve a model and context that fit the device (see runner --fit) or lower "
+              "--min-tps", file=sys.stderr)
+        return 2
     base_identity = Identity(
         project="", task_class="repair", context_band="", tool_set=(),
         verifier_id="", environment_id=f"{platform.node()}|{args.endpoint}",
@@ -200,7 +217,7 @@ def cmd_replay(args: argparse.Namespace) -> int:
             ws = Workspace(ws_dir, visible_tests=task.visible_test_files,
                            pythonpath=task.pythonpath, python=args.python, budget=budget)
             chat = runner_chat(endpoint.post_json, model, max_tokens=budget.max_tokens)
-            result = attempt(task.request, ws, chat, budget=budget)
+            result = attempt(task.request, ws, chat, budget=budget, context=task.context)
             protected = ProtectedTests.load(Path(task.protected_dir))
             outcome = verify(ws_dir, protected, baseline, timeout_s=args.timeout,
                              python=args.python, pythonpath=task.pythonpath)
@@ -226,7 +243,7 @@ def cmd_replay(args: argparse.Namespace) -> int:
                            "turns": float(result.turns), "tool_calls": float(result.tool_calls),
                            "test_runs": float(result.test_runs),
                            "failing_at_base": float(len(task.failing_at_base)),
-                           "fixed": float(len(fixed))},
+                           "fixed": float(len(fixed)), "probe_tps": round(tps, 2)},
                 reasons=(f"attempt: {result.stop_reason}",
                          f"fixed {len(fixed)} of {len(task.failing_at_base)} failing at base",
                          *outcome.reasons))
@@ -270,9 +287,17 @@ def cmd_capture(args: argparse.Namespace) -> int:
     cwd = str(args.cwd or data.get("cwd") or Path.cwd())
     head = subprocess.run(["git", "-C", cwd, "rev-parse", "HEAD"], capture_output=True,
                           text=True).stdout.strip()
+    # Every repository at or under the directory, so a session started from a
+    # parent directory still yields exact ranges for the repositories inside.
+    heads = {}
+    for repo in repos_under(Path(cwd)):
+        sha = subprocess.run(["git", "-C", str(repo), "rev-parse", "HEAD"], capture_output=True,
+                             text=True).stdout.strip()
+        if sha:
+            heads[str(repo)] = sha
     rec: dict[str, Any] = {"event": args.event, "timestamp": _now(),
                            "session_id": str(args.session or data.get("session_id") or ""),
-                           "cwd": cwd, "head": head, "tool": args.tool}
+                           "cwd": cwd, "head": head, "heads": heads, "tool": args.tool}
     if args.event == "prompt":
         rec["prompt"] = str(data.get("prompt") or args.prompt or "")
     path = Path(args.file) if args.file else Path.home() / CAPTURE_FILE
@@ -343,6 +368,8 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--max-tokens", type=int, default=1500)
     p.add_argument("--test-runs", type=int, default=4)
     p.add_argument("--wall", type=float, default=900.0)
+    p.add_argument("--min-tps", type=float, default=15.0,
+                   help="refuse a model that decodes slower than this (fit-first)")
     p.set_defaults(fn=cmd_replay)
     p = sub.add_parser("capture", help="append a prompt or stop event from an agent hook")
     p.add_argument("--event", choices=["prompt", "stop"], required=True)

--- a/python/src/xyntetik_runner/shadow/importer.py
+++ b/python/src/xyntetik_runner/shadow/importer.py
@@ -43,6 +43,14 @@ class Episode:
     """Repository HEAD when the request was made and when the turn ended,
     known only for prospectively captured episodes (``source == "capture"``);
     with both, the task's commit range is exact instead of a time window."""
+    heads_start: tuple[tuple[str, str], ...] = ()
+    heads_end: tuple[tuple[str, str], ...] = ()
+    """(repository path, HEAD) for every repository at or under the working
+    directory at the two ends, so a session started from a parent directory
+    still gets exact ranges for the repositories inside it."""
+    context: tuple[str, ...] = ()
+    """Earlier requests of the same session, the user's own words, oldest
+    first, for the attempt to read beside the request (R14.4.2)."""
 
     @property
     def episode_id(self) -> str:
@@ -101,12 +109,31 @@ def scan_codex(root: Path) -> ScanReport:
     return ScanReport(tuple(episodes), len(files) - len(skipped), tuple(skipped))
 
 
+CONTEXT_TURNS = 3
+CONTEXT_CHARS = 4000
+
+
+def _context(prior: list[str]) -> tuple[str, ...]:
+    """The last few earlier requests, newest last, within a character cap."""
+    out: list[str] = []
+    total = 0
+    for text in reversed(prior[-CONTEXT_TURNS:]):
+        if not text.strip() or text.lstrip().startswith("<"):
+            continue
+        if total + len(text) > CONTEXT_CHARS:
+            break
+        out.append(text)
+        total += len(text)
+    return tuple(reversed(out))
+
+
 def _codex_file(path: Path) -> list[Episode]:
     out: list[Episode] = []
     cwd = session_id = None
     started: str | None = None
     request = ""
     tools: list[str] = []
+    prior: list[str] = []
     turn = 0
     for rec in _records(path):
         kind = rec.get("type")
@@ -132,7 +159,9 @@ def _codex_file(path: Path) -> list[Episode]:
                     source="codex", session_id=session_id, turn=turn, cwd=cwd,
                     started_at=_fmt(_iso(started)), ended_at=_fmt(_iso(str(rec["timestamp"]))),
                     request=request, request_sha256=_sha(request),
-                    tool_names=tuple(sorted(set(tools))), trace_path=str(path)))
+                    tool_names=tuple(sorted(set(tools))), trace_path=str(path),
+                    context=_context(prior)))
+                prior.append(request)
                 started = None
         elif kind == "response_item" and payload.get("type") == "function_call":
             name = payload.get("name")
@@ -173,7 +202,8 @@ def _claude_file(path: Path) -> list[Episode]:
         out.append(Episode(
             source="claude_code", session_id=sid, turn=i + 1, cwd=cwd,
             started_at=_fmt(start), ended_at=_fmt(end), request=text,
-            request_sha256=_sha(text), trace_path=str(path)))
+            request_sha256=_sha(text), trace_path=str(path),
+            context=_context([t[3] for t in turns[:i]])))
     return out
 
 
@@ -188,6 +218,7 @@ def scan_capture(path: Path) -> ScanReport:
     if not path.is_file():
         return ScanReport((), 0, ())
     open_turns: dict[str, dict[str, object]] = {}
+    prior: dict[str, list[str]] = {}
     turns: dict[str, int] = {}
     episodes: list[Episode] = []
     try:
@@ -199,29 +230,41 @@ def scan_capture(path: Path) -> ScanReport:
             if event == "prompt":
                 # A prompt while one is open closes the earlier one at this time.
                 if sid in open_turns:
-                    episodes.append(_close(open_turns.pop(sid), rec, path))
+                    episodes.append(_close(open_turns.pop(sid), rec, path, prior.get(sid, [])))
+                    prior.setdefault(sid, []).append(str(episodes[-1].request))
                 open_turns[sid] = rec
             elif event == "stop" and sid in open_turns:
-                episodes.append(_close(open_turns.pop(sid), rec, path))
+                episodes.append(_close(open_turns.pop(sid), rec, path, prior.get(sid, [])))
+                prior.setdefault(sid, []).append(str(episodes[-1].request))
     except (OSError, ValueError, KeyError, TypeError):
         return ScanReport(tuple(episodes), 0, (str(path),))
     for sid, rec in open_turns.items():
         started = _iso(str(rec["timestamp"]))
-        episodes.append(_close(rec, {"timestamp": _fmt(started + CLAUDE_TURN_CAP), "head": ""}, path))
+        episodes.append(_close(rec, {"timestamp": _fmt(started + CLAUDE_TURN_CAP), "head": ""},
+                               path, prior.get(sid, [])))
     for i, e in enumerate(episodes):
         turns[e.session_id] = turns.get(e.session_id, 0) + 1
         episodes[i] = Episode(**{**e.__dict__, "turn": turns[e.session_id]})
     return ScanReport(tuple(episodes), 1, ())
 
 
-def _close(start: dict[str, object], end: dict[str, object], path: Path) -> Episode:
+def _heads(rec: dict[str, object]) -> tuple[tuple[str, str], ...]:
+    raw = rec.get("heads")
+    if not isinstance(raw, dict):
+        return ()
+    return tuple(sorted((str(k), str(v)) for k, v in raw.items() if v))
+
+
+def _close(start: dict[str, object], end: dict[str, object], path: Path,
+           prior: list[str]) -> Episode:
     request = str(start.get("prompt") or "")
     return Episode(
         source="capture", session_id=str(start["session_id"]), turn=0,
         cwd=str(start.get("cwd") or ""), started_at=_fmt(_iso(str(start["timestamp"]))),
         ended_at=_fmt(_iso(str(end["timestamp"]))), request=request,
         request_sha256=_sha(request), trace_path=str(path),
-        head_start=str(start.get("head") or ""), head_end=str(end.get("head") or ""))
+        head_start=str(start.get("head") or ""), head_end=str(end.get("head") or ""),
+        heads_start=_heads(start), heads_end=_heads(end), context=_context(prior))
 
 
 def scan_all(home: Path | None = None) -> ScanReport:
@@ -247,5 +290,10 @@ def read_episodes(path: Path) -> list[Episode]:
     out: list[Episode] = []
     for rec in _records(path):
         rec["tool_names"] = tuple(rec.get("tool_names") or ())  # type: ignore[arg-type]
+        rec["context"] = tuple(rec.get("context") or ())  # type: ignore[arg-type]
+        for key in ("heads_start", "heads_end"):
+            raw = rec.get(key)
+            pairs = raw if isinstance(raw, list) else []
+            rec[key] = tuple((str(a), str(b)) for a, b in pairs)
         out.append(Episode(**rec))  # type: ignore[arg-type]
     return out

--- a/python/src/xyntetik_runner/shadow/tasks.py
+++ b/python/src/xyntetik_runner/shadow/tasks.py
@@ -50,6 +50,7 @@ class RepairTask:
     solution_sha: str
     request: str
     request_sha256: str
+    context: tuple[str, ...]
     test_files: tuple[str, ...]
     visible_test_files: tuple[str, ...]
     src_files: int
@@ -65,7 +66,8 @@ class RepairTask:
     @classmethod
     def load(cls, path: Path) -> RepairTask:
         data = json.loads(path.read_text(encoding="utf-8"))
-        for key in ("test_files", "visible_test_files", "pythonpath", "failing_at_base"):
+        for key in ("test_files", "visible_test_files", "pythonpath", "failing_at_base",
+                    "context"):
             data[key] = tuple(data.get(key) or ())
         return cls(**data)
 
@@ -231,7 +233,7 @@ def build_task(episode: Episode, repo: Path, shas: Sequence[str], *, out_dir: Pa
         task = RepairTask(
             task_id=task_id, episode_id=episode.episode_id, repo=str(repo), base_sha=base,
             solution_sha=solution, request=episode.request, request_sha256=episode.request_sha256,
-            test_files=tuple(present), visible_test_files=visible, src_files=len(src),
+            context=episode.context, test_files=tuple(present), visible_test_files=visible, src_files=len(src),
             pythonpath=roots, protected_dir=str(protected), expected_tests=len(frozen.expected),
             baseline_failing=cal.failing + cal.missing, failing_at_base=cal.failing_ids)
         (task_dir / "task.json").write_text(task.to_json() + "\n", encoding="utf-8")
@@ -269,16 +271,33 @@ def pair(episode: Episode) -> list[Candidate] | Rejection:
     repos = repos_under(Path(episode.cwd))
     if not repos:
         return Rejection(Disposition.INELIGIBLE, "no git repository at or under the working directory")
-    if episode.head_start and episode.head_end:
-        # Prospective capture: the exact commits between the two HEADs, in the
-        # repository whose history contains both; no time window at all.
-        if episode.head_start == episode.head_end:
-            return Rejection(Disposition.UNREPLAYABLE, "HEAD did not move during the turn")
-        for repo in repos:
-            shas = _git(str(repo), "rev-list", "--no-merges",
-                        f"{episode.head_start}..{episode.head_end}").split()
+    if episode.source == "capture":
+        # Prospective capture: the exact commits between the two HEADs of
+        # every repository the hook saw at both ends; no time window at all.
+        before = dict(episode.heads_start)
+        after = dict(episode.heads_end)
+        if episode.head_start and episode.head_end:
+            before.setdefault(episode.cwd, episode.head_start)
+            after.setdefault(episode.cwd, episode.head_end)
+        found: list[Candidate] = []
+        moved = False
+        for repo_path, start_sha in before.items():
+            end_sha = after.get(repo_path)
+            if not end_sha or end_sha == start_sha:
+                continue
+            moved = True
+            repo = Path(repo_path)
+            if not (repo / ".git").exists():
+                continue
+            shas = _git(str(repo), "rev-list", "--no-merges", f"{start_sha}..{end_sha}").split()
             if shas:
-                return [Candidate(episode, repo, tuple(shas))]
+                found.append(Candidate(episode, repo, tuple(shas)))
+        if found:
+            return found
+        if not before:
+            return Rejection(Disposition.UNREPLAYABLE, "capture recorded no repository HEAD")
+        if not moved:
+            return Rejection(Disposition.UNREPLAYABLE, "HEAD did not move during the turn")
         return Rejection(Disposition.UNREPLAYABLE,
                          "captured HEADs are not an ancestry range in any repository here")
     start = datetime.fromisoformat(episode.started_at.replace("Z", "+00:00"))

--- a/python/tests/test_shadow_pipeline.py
+++ b/python/tests/test_shadow_pipeline.py
@@ -309,3 +309,89 @@ def test_capture_with_unmoved_head_is_unreplayable(repo: Path, tmp_path: Path) -
     e = episode(repo, source="capture", head_start=head, head_end=head)
     r = pair(e)
     assert isinstance(r, Rejection) and r.disposition is Disposition.UNREPLAYABLE
+
+
+def test_capture_from_a_parent_directory_records_every_repo_head(repo: Path, tmp_path: Path, monkeypatch: Any) -> None:
+    """The owner starts sessions from a parent directory whose own HEAD never
+    moves; the hook records the HEADs of the repositories inside it and the
+    task range is still exact."""
+    from xyntetik_runner.shadow.importer import scan_capture
+    from xyntetik_runner.shadow.tasks import pair
+    base = git(repo, "rev-parse", "HEAD^")
+    fix = git(repo, "rev-parse", "HEAD")
+    cap = tmp_path / "capture.jsonl"
+    parent = repo.parent  # tmp_path itself, not a repository
+    git(repo, "checkout", "-q", base)
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(json.dumps(
+        {"session_id": "cap2", "cwd": str(parent), "prompt": "first ask"})))
+    assert main(["capture", "--event", "prompt", "--file", str(cap)]) == 0
+    git(repo, "checkout", "-q", fix)
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(json.dumps(
+        {"session_id": "cap2", "cwd": str(parent), "prompt": "fix parse_amount now"})))
+    assert main(["capture", "--event", "prompt", "--file", str(cap)]) == 0
+    lines = [json.loads(l) for l in cap.read_text().splitlines()]
+    assert lines[0]["head"] == "" and lines[0]["heads"] == {str(repo): base}
+    assert lines[1]["heads"] == {str(repo): fix}
+    eps = scan_capture(cap).episodes
+    assert len(eps) == 2
+    first = eps[0]
+    assert first.request == "first ask" and dict(first.heads_start) == {str(repo): base}
+    paired = pair(first)
+    assert not isinstance(paired, Rejection) and paired[0].shas == (fix,) and paired[0].repo == repo
+    # the second prompt carries the first as context
+    assert eps[1].context == ("first ask",)
+
+
+def test_context_reaches_the_attempt_and_the_task(repo: Path, tmp_path: Path) -> None:
+    from xyntetik_runner.shadow.tasks import RepairTask
+    e = episode(repo, context=("we saw CI fail on parse_amount", "thousands separators break"))
+    task = admit(e, out_dir=tmp_path / "t", python=sys.executable)
+    assert isinstance(task, RepairTask) and task.context == e.context
+    assert RepairTask.load(tmp_path / "t" / task.task_id / "task.json").context == e.context
+    seen: list[str] = []
+
+    def chat(messages: list[dict[str, Any]], tools: list[dict[str, Any]]) -> dict[str, Any]:
+        seen.append(messages[1]["content"])
+        return {"content": "", "tool_calls": [call("finish")]}
+    ws = Workspace(repo, visible_tests=(), pythonpath=(), python=sys.executable, budget=Budget())
+    attempt(task.request, ws, chat, context=task.context)
+    assert "Earlier requests in this session" in seen[0]
+    assert "- we saw CI fail on parse_amount" in seen[0] and "Task:\n" in seen[0]
+
+
+def test_claude_code_context_skips_commands_and_caps_turns(tmp_path: Path) -> None:
+    proj = tmp_path / "projects" / "p"
+    proj.mkdir(parents=True)
+    recs = []
+    for i, text in enumerate(["one", "<command-name>/x</command-name>", "two", "three", "four", "five"]):
+        recs.append({"type": "user", "sessionId": "s", "cwd": "/w",
+                     "timestamp": f"2026-09-01T10:{i:02d}:00Z", "message": {"content": text}})
+    (proj / "s.jsonl").write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+    eps = scan_claude_code(tmp_path / "projects").episodes
+    assert eps[-1].request == "five" and eps[-1].context == ("two", "three", "four")
+    assert eps[2].context == ("one",), "the command turn is not context"
+
+
+def test_probe_speed_and_the_fit_floor(tmp_path: Path, monkeypatch: Any, capsys: Any) -> None:
+    from xyntetik_runner.shadow import cli
+    from xyntetik_runner.shadow.attempt import probe_speed
+
+    class Slow:
+        def __init__(self, *a: Any, **k: Any) -> None:
+            pass
+
+        def capabilities(self) -> dict[str, Any]:
+            return {"models": [{"id": "crawler.gguf"}], "version": "t"}
+
+        def post_json(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+            import time
+            time.sleep(0.2)
+            return {"choices": [{"message": {"content": "x"}}],
+                    "usage": {"completion_tokens": 2}}
+    tps = probe_speed(Slow().post_json, "crawler.gguf")
+    assert 0 < tps < 15
+    monkeypatch.setattr(cli, "RunnerEndpoint", Slow)
+    (tmp_path / "tasks").mkdir()
+    rc = main(["replay", "--out", str(tmp_path), "--endpoint", "http://x", "--min-tps", "15"])
+    assert rc == 2
+    assert "fit-first" in capsys.readouterr().err


### PR DESCRIPTION
Three small items from the first pilot: the capture hook records the HEAD of every repository at or under the working directory (exact ranges for sessions started from a parent directory); earlier requests of the same session travel with a task as context (user words only, three turns, 4k chars); replay probes decode speed and refuses a model below --min-tps (default 15) before any attempt, with the probe speed on every record. 87 Python tests, mypy strict clean.