### PR TITLE
shadow: the repository walk descends through an umbrella repository

### DIFF
--- a/python/src/xyntetik_runner/shadow/tasks.py
+++ b/python/src/xyntetik_runner/shadow/tasks.py
@@ -79,7 +79,10 @@ def _git(repo: str, *args: str) -> str:
 
 def repos_under(cwd: Path, *, depth: int = 2) -> list[Path]:
     """Git repositories at or under ``cwd``, at most ``depth`` levels down,
-    so a session run from a parent directory still finds its repositories."""
+    so a session run from a parent directory still finds its repositories.
+    A repository that contains other repositories (an umbrella checkout
+    with the real projects untracked inside it) yields all of them: the
+    walk does not stop at the first ``.git``."""
     out: list[Path] = []
     if not cwd.is_dir():
         return out
@@ -88,7 +91,6 @@ def repos_under(cwd: Path, *, depth: int = 2) -> list[Path]:
         here, d = stack.pop()
         if (here / ".git").exists():
             out.append(here)
-            continue
         if d >= depth:
             continue
         try:

--- a/python/tests/test_shadow_pipeline.py
+++ b/python/tests/test_shadow_pipeline.py
@@ -118,6 +118,14 @@ def test_repos_under_finds_nested_repositories(repo: Path) -> None:
     assert repos_under(repo) == [repo]
 
 
+def test_repos_under_descends_through_an_umbrella_repository(repo: Path) -> None:
+    """The owner's layout: a parent directory that is itself a repository,
+    with the real projects untracked inside it. Both are found."""
+    git(repo.parent, "init", "-q", "-b", "main", str(repo.parent))
+    found = repos_under(repo.parent)
+    assert found == sorted([repo.parent, repo])
+
+
 def test_admit_builds_a_calibrated_task(repo: Path, tmp_path: Path) -> None:
     out = tmp_path / "tasks"
     out.mkdir()


### PR DESCRIPTION
The owner's working directory is itself a repository with the real projects untracked inside; the walk stopped at its .git and the capture hook recorded only the umbrella HEAD. Now it records a repository and keeps descending, bounded by depth. Test added; hand check against the real layout records all four HEADs.