### PR TITLE
shadow: the scaffold artifact, a public task bank and a reflective optimizer (R15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ names that were true when they were written.
 
 ## Unreleased
 
+- **The scaffold artifact (R15.0): a learned, hashed, model-agnostic
+  layer between the model and the harness, before any weight moves.**
+  `xyntetik_runner.shadow.scaffold.Scaffold` is a versioned JSON document
+  the attempt harness consumes: system text, a numbered procedure, tool
+  descriptions, budget overrides (a scaffold may spend less than the
+  caller's budget, never more) and exemplars. The model stays untouched,
+  so one scaffold runs on every family the runner serves, including the
+  ones the LoRA backward refuses; its sha256 sits in the evidence identity
+  and the report's stack key, so a row names the model with its scaffold,
+  and `replay --scaffold` selects one. `shadow bank --repo` builds repair
+  tasks from a public repository's commit history under the same
+  admission rule as the personal ledger (post-state tests pass, frozen
+  tests fail on the parent), with the commit message as the request, so
+  scaffold learning needs none of the owner's entitled episodes. `shadow
+  optimize` is the simplest reflective loop (after GEPA, 2025): score the
+  best scaffold on a minibatch of bank tasks, hand the failure text to
+  the local model, take its JSON child through the runner's schema-
+  constrained output, score the child on the same minibatch, keep it only
+  if better; a seeded held-out slice decides against the base scaffold at
+  the end, and the kill gate is no held-out gain within the rollout
+  budget. The optimizer never writes exemplars: exemplars are content and
+  the training-data firewall applies to them. Prior art named, not
+  claimed: DSPy, GEPA, OPRO, PromptBreeder, ADAS, Ornith. Found on the
+  way: `git rev-parse` echoes an unresolvable `<sha>^` to stdout, so a
+  root commit reached `git worktree add` as an invalid reference;
+  `--verify --quiet` is the fix.
+
 - **Shadow mode, three small items after the first pilot.** The capture
   hook now records the HEAD of every repository at or under the working
   directory, not only the directory's own, so a session started from a

--- a/python/README.md
+++ b/python/README.md
@@ -76,6 +76,16 @@ The negative controls that prove the verifier can fail live in
   prints counts and both denominators. Pass `--python` the interpreter that
   can run the repositories' tests.
 
+- `scaffold`: `Scaffold` (system, procedure, tool descriptions, budget,
+  exemplars; sha256; `base()` is the harness's original prompt and the
+  control arm of every comparison). `attempt(..., scaffold=)` consumes it;
+  `Identity.scaffold_sha256` names it in every record.
+- `bank`: `build_bank(repo)` turns a public repository's history into repair
+  tasks with the commit message as the request; `shadow bank --repo`.
+- `optimize`: `optimize(tasks, base, run, reflect)` is the reflective loop;
+  `shadow optimize` runs it against a runner endpoint with the local model as
+  its own reflector and writes `scaffolds/best.json` and `optimize.json`.
+
 The pipeline is exercised without a model in `python/tests/test_shadow_pipeline.py`
 on synthetic traces and a synthetic repository; a scripted chat function
 proves the plumbing and the confinement, the pilot measures the model.

--- a/python/src/xyntetik_runner/shadow/__init__.py
+++ b/python/src/xyntetik_runner/shadow/__init__.py
@@ -27,6 +27,7 @@ from xyntetik_runner.shadow.evidence import (
     render,
     summarize,
 )
+from xyntetik_runner.shadow.scaffold import SCAFFOLD_SCHEMA, Scaffold
 from xyntetik_runner.shadow.verifier import (
     CONFIG_BASENAMES,
     Calibration,
@@ -41,6 +42,7 @@ from xyntetik_runner.shadow.verifier import (
 __all__ = [
     "CONFIG_BASENAMES",
     "HEADLINE_MIN_EPISODES",
+    "SCAFFOLD_SCHEMA",
     "SCHEMA_VERSION",
     "Baseline",
     "Calibration",
@@ -51,6 +53,7 @@ __all__ = [
     "Identity",
     "InstrumentError",
     "ProtectedTests",
+    "Scaffold",
     "Summary",
     "VerifierOutcome",
     "calibrate",

--- a/python/src/xyntetik_runner/shadow/attempt.py
+++ b/python/src/xyntetik_runner/shadow/attempt.py
@@ -22,11 +22,12 @@ import signal
 import subprocess
 import time
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
 from xyntetik_runner.shadow.baseline import IGNORED_DIRS
+from xyntetik_runner.shadow.scaffold import BASE_SYSTEM, Scaffold
 
 ChatFn = Callable[[list[dict[str, Any]], list[dict[str, Any]]], dict[str, Any]]
 """``chat(messages, tools) -> assistant message`` (``content``, optional
@@ -61,12 +62,7 @@ TOOLS: list[dict[str, Any]] = [
                        "required": []}}},
 ]
 
-SYSTEM_PROMPT = (
-    "You are a software engineer fixing a repository checked out at the workspace root. "
-    "Work only through the tools. Read before you edit, change only what the task needs, "
-    "write complete files, run the tests to check your work, and call finish when the "
-    "tests pass or you cannot make further progress. Never ask the user questions."
-)
+SYSTEM_PROMPT = BASE_SYSTEM
 
 
 @dataclass(frozen=True)
@@ -224,9 +220,23 @@ def _name(call: dict[str, Any]) -> str:
     return str(_fn(call).get("name") or "")
 
 
+def budget_with(scaffold: Scaffold, budget: Budget) -> Budget:
+    """The budget with the scaffold's overrides, bounded above by the caller's
+    so a scaffold can spend less, never more."""
+    fields = {k: v for k, v in scaffold.budget.items() if hasattr(budget, k)}
+    kw: dict[str, Any] = {}
+    for k, v in fields.items():
+        cur = getattr(budget, k)
+        kw[k] = type(cur)(min(v, cur))
+    return replace(budget, **kw)
+
+
 def attempt(request: str, workspace: Workspace, chat: ChatFn, *, budget: Budget | None = None,
-            context: Sequence[str] = ()) -> AttemptResult:
-    budget = budget or workspace.budget
+            context: Sequence[str] = (), scaffold: Scaffold | None = None) -> AttemptResult:
+    scaffold = scaffold or Scaffold.base()
+    budget = budget_with(scaffold, budget or workspace.budget)
+    workspace.budget = budget
+    tools = scaffold.apply_tools(TOOLS)
     listing = workspace.list_files("*")
     earlier = ""
     if context:
@@ -235,7 +245,7 @@ def attempt(request: str, workspace: Workspace, chat: ChatFn, *, budget: Budget 
     user = (f"{earlier}Task:\n{request.strip()}\n\nVisible test files: "
             f"{', '.join(workspace.visible_tests) or '(none at this state; look for tests/)'}\n\n"
             f"Top-level files:\n{listing}")
-    messages: list[dict[str, Any]] = [{"role": "system", "content": SYSTEM_PROMPT},
+    messages: list[dict[str, Any]] = [{"role": "system", "content": scaffold.system_text()},
                                       {"role": "user", "content": user}]
     t0 = time.monotonic()
     turns = calls = ptoks = ctoks = 0
@@ -250,7 +260,7 @@ def attempt(request: str, workspace: Workspace, chat: ChatFn, *, budget: Budget 
                          messages=messages)
         turns += 1
         try:
-            reply = chat(messages, TOOLS)
+            reply = chat(messages, tools)
         except Exception as e:  # the model side failed; the tree is still judged
             return _done(turns, calls, workspace, ptoks, ctoks, t0,
                          f"model error: {type(e).__name__}", False, names, messages=messages)

--- a/python/src/xyntetik_runner/shadow/bank.py
+++ b/python/src/xyntetik_runner/shadow/bank.py
@@ -1,0 +1,77 @@
+"""A public task bank (R15.0.3): repair tasks from an open-source history.
+
+The same admission rule as the personal ledger, applied to a repository
+anyone may clone: a commit that touched pytest test files and Python
+source and nothing that needs a build, whose post-state tests collect and
+pass and whose frozen tests fail on the parent. The request is the commit
+message, the authors' own public words. Nothing in a bank task comes from
+a frontier tool, so scaffold learning can run on it without the
+training-data firewall's entitlement questions, and a scaffold learned
+here is then measured, not trained, on the owner's captured episodes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from xyntetik_runner.shadow.importer import Episode
+from xyntetik_runner.shadow.tasks import RepairTask, Rejection, build_task, classify, touched_files
+
+
+@dataclass(frozen=True)
+class BankEntry:
+    sha: str
+    task: RepairTask | None
+    reason: str
+
+
+def _commits(repo: Path, max_commits: int) -> Iterator[tuple[str, int, str]]:
+    proc = subprocess.run(["git", "-C", str(repo), "log", "--no-merges", "--format=%H%x00%at%x00%B%x1e",
+                           f"-n{max_commits}"], capture_output=True, text=True)
+    for chunk in proc.stdout.split("\x1e"):
+        chunk = chunk.strip("\n")
+        if not chunk:
+            continue
+        sha, at, message = chunk.split("\x00", 2)
+        yield sha, int(at), message.strip()
+
+
+def build_bank(repo: Path, *, out_dir: Path, python: str = sys.executable, limit: int = 20,
+               max_commits: int = 400, max_src_files: int = 3, timeout_s: float = 600.0,
+               log: Iterator[str] | None = None) -> list[BankEntry]:
+    """Walk the history newest first and admit up to ``limit`` tasks."""
+    out: list[BankEntry] = []
+    admitted = 0
+    for i, (sha, at, message) in enumerate(_commits(repo, max_commits)):
+        if admitted >= limit:
+            break
+        files = touched_files(repo, [sha])
+        tests, src, build = classify(files)
+        if not tests or not src:
+            out.append(BankEntry(sha, None, "no test+source pair"))
+            continue
+        if build:
+            out.append(BankEntry(sha, None, "needs a build"))
+            continue
+        if len(src) > max_src_files:
+            out.append(BankEntry(sha, None, f"{len(src)} source files, above {max_src_files}"))
+            continue
+        stamp = datetime.fromtimestamp(at, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+        request = message or f"commit {sha[:8]}"
+        episode = Episode(source="bank", session_id=repo.name, turn=i + 1, cwd=str(repo),
+                          started_at=stamp, ended_at=stamp, request=request,
+                          request_sha256=hashlib.sha256(request.encode()).hexdigest())
+        result = build_task(episode, repo, [sha], out_dir=out_dir, python=python,
+                            timeout_s=timeout_s)
+        if isinstance(result, Rejection):
+            out.append(BankEntry(sha, None, f"{result.disposition.value}: {result.reason}"))
+            continue
+        admitted += 1
+        out.append(BankEntry(sha, result, "admitted"))
+    return out

--- a/python/src/xyntetik_runner/shadow/cli.py
+++ b/python/src/xyntetik_runner/shadow/cli.py
@@ -34,6 +34,14 @@ from xyntetik_runner.shadow.evidence import (
     summarize,
 )
 from xyntetik_runner.shadow.importer import CAPTURE_FILE, Episode, read_episodes, scan_all, write_episodes
+from xyntetik_runner.shadow.bank import build_bank
+from xyntetik_runner.shadow.optimize import (
+    TaskOutcome,
+    optimize,
+    result_json,
+    runner_reflect,
+)
+from xyntetik_runner.shadow.scaffold import Scaffold
 from xyntetik_runner.shadow.tasks import (
     Candidate,
     RepairTask,
@@ -44,6 +52,37 @@ from xyntetik_runner.shadow.tasks import (
     repos_under,
 )
 from xyntetik_runner.shadow.verifier import ProtectedTests, fixed_ids, verify
+
+
+def _run_attempt_factory(args: argparse.Namespace, endpoint: RunnerEndpoint, model: str,
+                         budget: Budget) -> Any:
+    """One attempt plus verification on a scratch worktree, as the optimizer's
+    reward function: fixed count, verdict and the failure text."""
+    def run(task: RepairTask, scaffold: Scaffold) -> TaskOutcome:
+        ws_dir = _worktree(task)
+        try:
+            baseline = Baseline.capture(ws_dir)
+            ws = Workspace(ws_dir, visible_tests=task.visible_test_files,
+                           pythonpath=task.pythonpath, python=args.python, budget=budget)
+            chat = runner_chat(endpoint.post_json, model, max_tokens=budget.max_tokens)
+            result = attempt(task.request, ws, chat, budget=budget, context=task.context,
+                             scaffold=scaffold)
+            protected = ProtectedTests.load(Path(task.protected_dir))
+            outcome = verify(ws_dir, protected, baseline, timeout_s=args.timeout,
+                             python=args.python, pythonpath=task.pythonpath)
+            fixed: tuple[str, ...] = ()
+            if baseline.changes(ws_dir) and task.failing_at_base and outcome.passed is not None:
+                fixed = fixed_ids(protected, task.failing_at_base, ws_dir, timeout_s=args.timeout,
+                                  python=args.python, pythonpath=task.pythonpath)
+            tail = [m for m in result.transcript if m.get("role") == "tool"][-2:]
+            feedback = (f"stop: {result.stop_reason}; verifier: {'; '.join(outcome.reasons)}\n"
+                        + "\n".join(str(m.get("content", ""))[-600:] for m in tail))
+            return TaskOutcome(task_id=task.task_id, fixed=len(fixed),
+                               failing_at_base=len(task.failing_at_base),
+                               verified=outcome.passed is True, feedback=feedback)
+        finally:
+            _drop(task, ws_dir)
+    return run
 
 HARNESS_VERSION = "shadow-0.1"
 DEFAULT_OUT = Path.home() / ".xyntetik" / "shadow"
@@ -181,6 +220,9 @@ def cmd_replay(args: argparse.Namespace) -> int:
         return 2
     budget = Budget(max_turns=args.max_turns, wall_s=args.wall, max_tokens=args.max_tokens,
                     test_runs=args.test_runs)
+    scaffold = Scaffold.load(Path(args.scaffold)) if args.scaffold else Scaffold.base()
+    scaffold_id = "base" if not args.scaffold else scaffold.sha256
+    print(f"scaffold: {scaffold.name} ({scaffold_id[:12]})", flush=True)
     # Fit first: a model that crawls has spilled the device, and an attempt
     # at that speed measures the wall clock, not the model. Refuse it.
     tps = probe_speed(endpoint.post_json, model)
@@ -195,9 +237,10 @@ def cmd_replay(args: argparse.Namespace) -> int:
         verifier_id="", environment_id=f"{platform.node()}|{args.endpoint}",
         model_sha256=args.model_sha256 or f"unknown:{model}", quant=args.quant or "unknown",
         template_sha256="unknown", runner_build=str(caps.get("version") or "unknown"),
-        backend=str(caps.get("backend") or "unknown"), harness_version=HARNESS_VERSION)
-    done = {(r.episode_id, r.identity.model_sha256) for r in _read_records(evidence)
-            if r.verifier is not None}
+        backend=str(caps.get("backend") or "unknown"), harness_version=HARNESS_VERSION,
+        scaffold_sha256=scaffold_id)
+    done = {(r.episode_id, r.identity.model_sha256, r.identity.scaffold_sha256)
+            for r in _read_records(evidence) if r.verifier is not None}
     # A resumed import must not re-import an admitted episode as a new one.
     ran = 0
     for task in _tasks(out, args.task):
@@ -207,7 +250,7 @@ def cmd_replay(args: argparse.Namespace) -> int:
                         context_band=_band(len(task.request)),
                         tool_set=("list_files", "read_file", "write_file", "run_tests"),
                         verifier_id=f"commit-tests:{task.task_id}")
-        if (task.episode_id, ident.model_sha256) in done:
+        if (task.episode_id, ident.model_sha256, ident.scaffold_sha256) in done:
             continue
         ran += 1
         print(f"[{task.task_id}] attempt with {model} ...", flush=True)
@@ -217,7 +260,8 @@ def cmd_replay(args: argparse.Namespace) -> int:
             ws = Workspace(ws_dir, visible_tests=task.visible_test_files,
                            pythonpath=task.pythonpath, python=args.python, budget=budget)
             chat = runner_chat(endpoint.post_json, model, max_tokens=budget.max_tokens)
-            result = attempt(task.request, ws, chat, budget=budget, context=task.context)
+            result = attempt(task.request, ws, chat, budget=budget, context=task.context,
+                             scaffold=scaffold)
             protected = ProtectedTests.load(Path(task.protected_dir))
             outcome = verify(ws_dir, protected, baseline, timeout_s=args.timeout,
                              python=args.python, pythonpath=task.pythonpath)
@@ -265,12 +309,71 @@ def _keep_attempt(out: Path, task: RepairTask, ident: Identity, result: Any, ws_
     model's own words and edits, which the evidence record summarizes."""
     d = out / "attempts" / task.task_id
     d.mkdir(parents=True, exist_ok=True)
-    stem = f"{_now().replace(':', '')}-{ident.model_sha256[-12:].replace(':', '_')}"
+    stem = (f"{_now().replace(':', '')}-{ident.model_sha256[-12:].replace(':', '_')}"
+            f"-{ident.scaffold_sha256[:8]}")
     with (d / f"{stem}.transcript.jsonl").open("w", encoding="utf-8") as f:
         for m in result.transcript:
             f.write(json.dumps(m, sort_keys=True) + "\n")
     diff = subprocess.run(["git", "-C", str(ws_dir), "diff"], capture_output=True, text=True)
     (d / f"{stem}.diff").write_text(diff.stdout, encoding="utf-8")
+
+
+def cmd_bank(args: argparse.Namespace) -> int:
+    out = Path(args.out)
+    (out / "tasks").mkdir(parents=True, exist_ok=True)
+    entries = build_bank(Path(args.repo), out_dir=out / "tasks", python=args.python,
+                         limit=args.limit, max_commits=args.max_commits,
+                         max_src_files=args.max_src_files, timeout_s=args.timeout)
+    admitted = [e for e in entries if e.task is not None]
+    for e in admitted:
+        assert e.task is not None
+        print(f"  admitted {e.task.task_id}: {e.task.expected_tests} frozen tests, "
+              f"{e.task.baseline_failing} fail at base", flush=True)
+    reasons: dict[str, int] = {}
+    for e in entries:
+        if e.task is None:
+            key = e.reason.split(":")[0]
+            reasons[key] = reasons.get(key, 0) + 1
+    print(f"{len(admitted)} task(s) admitted from {len(entries)} commits; rejected:",
+          json.dumps(reasons, sort_keys=True), flush=True)
+    return 0
+
+
+def cmd_optimize(args: argparse.Namespace) -> int:
+    out = Path(args.out)
+    tasks = _tasks(out, None)
+    if not tasks:
+        print("error: no tasks under", out / "tasks", file=sys.stderr)
+        return 2
+    endpoint = RunnerEndpoint(args.endpoint, timeout=args.request_timeout)
+    caps = endpoint.capabilities()
+    models = [m.get("id") for m in caps.get("models", []) if isinstance(m, dict)]
+    model = args.model or (str(models[0]) if models else "")
+    if not model:
+        print("error: the endpoint reports no model; pass --model", file=sys.stderr)
+        return 2
+    tps = probe_speed(endpoint.post_json, model)
+    print(f"probe: {model} decodes at {tps:.1f} tok/s (floor {args.min_tps:g})", flush=True)
+    if tps < args.min_tps:
+        print("error: fit-first: below the floor; serve a model and context that fit",
+              file=sys.stderr)
+        return 2
+    budget = Budget(max_turns=args.max_turns, wall_s=args.wall, max_tokens=args.max_tokens,
+                    test_runs=args.test_runs)
+    base = Scaffold.load(Path(args.scaffold)) if args.scaffold else Scaffold.base()
+    save_dir = out / "scaffolds"
+    run = _run_attempt_factory(args, endpoint, model, budget)
+    reflect = runner_reflect(endpoint.post_json, model)
+    result = optimize(tasks, base, run, reflect, generations=args.generations, batch=args.batch,
+                      holdout_fraction=args.holdout, seed=args.seed,
+                      rollout_budget=args.rollout_budget, save_dir=save_dir,
+                      log=lambda s: print(s, flush=True))
+    (out / "optimize.json").write_text(result_json(result) + "\n", encoding="utf-8")
+    best_path = save_dir / "best.json"
+    result.best.save(best_path)
+    print(f"best scaffold {result.best.sha256[:12]} ({result.best.name}) -> {best_path}; "
+          f"rollouts {result.rollouts}; held-out gain: {result.held_out_gain}", flush=True)
+    return 0
 
 
 def cmd_capture(args: argparse.Namespace) -> int:
@@ -327,6 +430,7 @@ def cmd_report(args: argparse.Namespace) -> int:
                 assert v is not None
                 model = r.identity.model_sha256.split(":", 1)[-1]
                 fixed = int(r.resources.get("fixed", 0))
+                model = f"{model[:28]} +{r.identity.scaffold_sha256[:8]}"
                 print(f"    {r.disposition.value:24s} {model[:40]:40s} fixed "
                       f"{fixed}/{task.baseline_failing}, verifier {v.passed_count}/{v.expected}"
                       f"{' tamper' if v.tamper else ''}  {r.reasons[0][:40]}")
@@ -370,7 +474,36 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--wall", type=float, default=900.0)
     p.add_argument("--min-tps", type=float, default=15.0,
                    help="refuse a model that decodes slower than this (fit-first)")
+    p.add_argument("--scaffold", default="", help="scaffold JSON; default is the base scaffold")
     p.set_defaults(fn=cmd_replay)
+    p = sub.add_parser("bank", help="build repair tasks from a public repository's history")
+    p.add_argument("--repo", required=True)
+    p.add_argument("--out", default=str(DEFAULT_OUT.parent / "shadow-bank"))
+    p.add_argument("--python", default=sys.executable)
+    p.add_argument("--limit", type=int, default=20)
+    p.add_argument("--max-commits", type=int, default=400)
+    p.add_argument("--max-src-files", type=int, default=3)
+    p.add_argument("--timeout", type=float, default=600.0)
+    p.set_defaults(fn=cmd_bank)
+    p = sub.add_parser("optimize", help="evolve a scaffold against the tasks under --out")
+    p.add_argument("--out", default=str(DEFAULT_OUT.parent / "shadow-bank"))
+    p.add_argument("--endpoint", default="http://127.0.0.1:8080")
+    p.add_argument("--model", default="")
+    p.add_argument("--scaffold", default="", help="starting scaffold; default base")
+    p.add_argument("--generations", type=int, default=4)
+    p.add_argument("--batch", type=int, default=4)
+    p.add_argument("--holdout", type=float, default=0.3)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--rollout-budget", type=int, default=200)
+    p.add_argument("--python", default=sys.executable)
+    p.add_argument("--timeout", type=float, default=600.0)
+    p.add_argument("--request-timeout", type=float, default=900.0)
+    p.add_argument("--max-turns", type=int, default=10)
+    p.add_argument("--max-tokens", type=int, default=1500)
+    p.add_argument("--test-runs", type=int, default=3)
+    p.add_argument("--wall", type=float, default=600.0)
+    p.add_argument("--min-tps", type=float, default=15.0)
+    p.set_defaults(fn=cmd_optimize)
     p = sub.add_parser("capture", help="append a prompt or stop event from an agent hook")
     p.add_argument("--event", choices=["prompt", "stop"], required=True)
     p.add_argument("--tool", default="claude_code")

--- a/python/src/xyntetik_runner/shadow/evidence.py
+++ b/python/src/xyntetik_runner/shadow/evidence.py
@@ -72,6 +72,7 @@ class Identity:
     harness_version: str
     adapter_sha256: str | None = None
     adapter_scale: float | None = None
+    scaffold_sha256: str = "base"
 
     def cohort_key(self) -> str:
         """The full partition: a new task class, verifier or context band is
@@ -82,7 +83,7 @@ class Identity:
         """The model stack alone (model, quant, adapter, runner build, backend,
         harness): the unit a report row is about, across tasks."""
         keep = ("model_sha256", "quant", "adapter_sha256", "adapter_scale", "runner_build",
-                "backend", "harness_version", "environment_id")
+                "backend", "harness_version", "environment_id", "scaffold_sha256")
         return json.dumps({k: getattr(self, k) for k in keep}, sort_keys=True,
                           separators=(",", ":"))
 
@@ -154,6 +155,7 @@ class EpisodeEvidence:
         data: dict[str, Any] = json.loads(text)
         ident = data.pop("identity")
         ident["tool_set"] = tuple(ident["tool_set"])
+        ident.setdefault("scaffold_sha256", "base")
         ver = data.pop("verifier")
         if ver is not None:
             ver["tamper"] = tuple(ver["tamper"])
@@ -174,6 +176,7 @@ class CohortSummary:
 
     cohort: str
     model: str
+    scaffold: str
     attempted: int
     verified: int
     failed: int
@@ -228,7 +231,8 @@ def summarize(records: Iterable[EpisodeEvidence]) -> Summary:
             if r.verifier is None:
                 continue
             key = r.identity.stack_key()
-            row = per_cohort.setdefault(key, {"model": r.identity.model_sha256, "attempted": 0,
+            row = per_cohort.setdefault(key, {"model": r.identity.model_sha256,
+                                              "scaffold": r.identity.scaffold_sha256, "attempted": 0,
                                               "verified": 0, "failed": 0, "inconclusive": 0})
             row["attempted"] += 1
             if r.disposition is Disposition.VERIFIED_LOCAL_ATTEMPT:
@@ -238,10 +242,11 @@ def summarize(records: Iterable[EpisodeEvidence]) -> Summary:
             else:
                 row["inconclusive"] += 1
     cohorts = tuple(sorted(
-        (CohortSummary(cohort=k, model=str(v["model"]), attempted=int(v["attempted"]),
+        (CohortSummary(cohort=k, model=str(v["model"]), scaffold=str(v["scaffold"]),
+                       attempted=int(v["attempted"]),
                        verified=int(v["verified"]), failed=int(v["failed"]),
                        inconclusive=int(v["inconclusive"])) for k, v in per_cohort.items()),
-        key=lambda c: c.model))
+        key=lambda c: (c.model, c.scaffold)))
     return Summary(observed=len(by_episode), eligible=eligible, unattempted=unattempted,
                    agreement_only=agreement, by_disposition=by, cohorts=cohorts)
 
@@ -258,8 +263,9 @@ def render(s: Summary) -> str:
     ]
     for c in s.cohorts:
         model = c.model.split(":", 1)[-1]
-        row = (f"{model}: attempted {c.attempted}, verified {c.verified}, failed {c.failed}, "
-               f"inconclusive {c.inconclusive}")
+        scaffold = c.scaffold if c.scaffold == "base" else c.scaffold[:12]
+        row = (f"{model} + scaffold {scaffold}: attempted {c.attempted}, verified {c.verified}, "
+               f"failed {c.failed}, inconclusive {c.inconclusive}")
         if s.eligible:
             row += f"; verified over eligible {c.verified} of {s.eligible}"
             if s.headline_allowed:

--- a/python/src/xyntetik_runner/shadow/optimize.py
+++ b/python/src/xyntetik_runner/shadow/optimize.py
@@ -1,0 +1,229 @@
+"""Scaffold optimization (R15.0.4): the local model as its own reflector.
+
+The loop is deliberately the simplest member of the reflective
+prompt-evolution family (GEPA, 2025): run the current best scaffold on a
+minibatch of tasks, collect the failure text (stop reason, verifier
+reasons, the tail of what the model saw), ask the local model for a
+revised scaffold as JSON, score the child on the same minibatch, keep it
+if it is better. The reward is the protected verifier and the count of
+tests turned green, never a judge. A held-out slice, never touched during
+the search, decides at the end against the base scaffold under the
+display rule; the kill gate is no held-out gain within the rollout budget.
+
+The optimizer writes system text, procedure and tool descriptions. It does
+not write exemplars: exemplars are content, and the firewall applies.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import re
+from collections.abc import Callable, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from xyntetik_runner.shadow.scaffold import Scaffold
+from xyntetik_runner.shadow.tasks import RepairTask
+
+
+@dataclass(frozen=True)
+class TaskOutcome:
+    task_id: str
+    fixed: int
+    failing_at_base: int
+    verified: bool
+    feedback: str
+
+
+RunAttempt = Callable[[RepairTask, Scaffold], TaskOutcome]
+Reflect = Callable[[Scaffold, Sequence[TaskOutcome]], Scaffold]
+
+
+@dataclass(frozen=True)
+class Score:
+    fixed: int
+    failing: int
+    verified: int
+    n: int
+
+    @property
+    def fraction(self) -> float:
+        return self.fixed / self.failing if self.failing else 0.0
+
+    def better_than(self, other: Score) -> bool:
+        return (self.verified, self.fixed) > (other.verified, other.fixed)
+
+
+def score(tasks: Sequence[RepairTask], scaffold: Scaffold, run: RunAttempt
+          ) -> tuple[Score, list[TaskOutcome]]:
+    outcomes = [run(t, scaffold) for t in tasks]
+    return (Score(fixed=sum(o.fixed for o in outcomes),
+                  failing=sum(o.failing_at_base for o in outcomes),
+                  verified=sum(1 for o in outcomes if o.verified), n=len(outcomes)), outcomes)
+
+
+def split(tasks: Sequence[RepairTask], *, holdout_fraction: float, seed: int
+          ) -> tuple[list[RepairTask], list[RepairTask]]:
+    """Development and held-out slices, seeded; the held-out slice is never
+    used during the search."""
+    order = list(tasks)
+    random.Random(seed).shuffle(order)
+    k = max(1, int(round(len(order) * holdout_fraction))) if len(order) > 1 else 0
+    return order[k:], order[:k]
+
+
+REFLECT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "system": {"type": "string"},
+        "procedure": {"type": "array", "items": {"type": "string"}, "maxItems": 12},
+        "tool_descriptions": {"type": "object",
+                              "additionalProperties": {"type": "string"}},
+        "notes": {"type": "string"},
+    },
+    "required": ["system", "procedure", "notes"],
+}
+
+
+def reflect_prompt(scaffold: Scaffold, outcomes: Sequence[TaskOutcome]) -> str:
+    failures = [o for o in outcomes if not o.verified]
+    shown = "\n\n".join(
+        f"### {o.task_id}: fixed {o.fixed} of {o.failing_at_base}\n{o.feedback[:1500]}"
+        for o in failures[:4]) or "(all attempts passed)"
+    current = json.dumps({"system": scaffold.system, "procedure": list(scaffold.procedure),
+                          "tool_descriptions": dict(scaffold.tool_descriptions)}, indent=2)
+    return (
+        "You are improving the instructions a coding agent follows. The agent has five tools "
+        "(list_files, read_file, write_file, run_tests, finish) and no shell. Its work is "
+        "judged by hidden tests it cannot see or change.\n\n"
+        f"Current instructions (JSON):\n{current}\n\n"
+        f"What went wrong on recent tasks with these instructions:\n{shown}\n\n"
+        "Write improved instructions as JSON with keys system (one paragraph), procedure "
+        "(a short list of concrete steps), tool_descriptions (optional, tool name to "
+        "description) and notes (one sentence on what you changed and why). Keep what works. "
+        "Do not add examples. Output only the JSON object."
+    )
+
+
+def parse_reflection(text: str, parent: Scaffold, name: str) -> Scaffold:
+    """The model's JSON, tolerant of a code fence, into a child scaffold that
+    keeps the parent's exemplars and budget untouched."""
+    body = text.strip()
+    m = re.search(r"\{.*\}", body, re.S)
+    if not m:
+        raise ValueError("reflection carried no JSON object")
+    data = json.loads(m.group(0))
+    if not isinstance(data, dict):
+        raise ValueError("reflection JSON is not an object")
+    tools = data.get("tool_descriptions") or {}
+    return Scaffold(
+        name=name, system=str(data.get("system") or parent.system),
+        procedure=tuple(str(p) for p in (data.get("procedure") or ()))[:12],
+        tool_descriptions={str(k): str(v) for k, v in tools.items()} if isinstance(tools, dict) else {},
+        exemplars=parent.exemplars, budget=parent.budget,
+        notes=str(data.get("notes") or ""), parent_sha256=parent.sha256)
+
+
+def runner_reflect(post_json: Callable[..., dict[str, Any]], model: str, *, max_tokens: int = 1200
+                   ) -> Reflect:
+    """Reflection through the runner, schema-constrained where the server
+    accepts ``response_format``; plain JSON parsing otherwise."""
+    def reflect(scaffold: Scaffold, outcomes: Sequence[TaskOutcome]) -> Scaffold:
+        prompt = reflect_prompt(scaffold, outcomes)
+        payload: dict[str, Any] = {"model": model, "messages": [{"role": "user", "content": prompt}],
+                                   "max_tokens": max_tokens, "temperature": 0.7,
+                                   "response_format": {"type": "json_schema", "json_schema": {
+                                       "name": "scaffold", "schema": REFLECT_SCHEMA}}}
+        try:
+            data = post_json("/v1/chat/completions", payload)
+        except Exception:
+            payload.pop("response_format")
+            data = post_json("/v1/chat/completions", payload)
+        text = str(data["choices"][0]["message"].get("content") or "")
+        return parse_reflection(text, scaffold, name=f"{scaffold.name}>{scaffold.sha256[:6]}")
+    return reflect
+
+
+@dataclass(frozen=True)
+class Generation:
+    index: int
+    parent_sha256: str
+    child_sha256: str
+    parent: Score
+    child: Score
+    accepted: bool
+    batch: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class OptimizeResult:
+    best: Scaffold
+    generations: tuple[Generation, ...]
+    rollouts: int
+    holdout_base: Score | None
+    holdout_best: Score | None
+
+    @property
+    def held_out_gain(self) -> bool:
+        return (self.holdout_base is not None and self.holdout_best is not None
+                and self.holdout_best.better_than(self.holdout_base))
+
+
+def optimize(tasks: Sequence[RepairTask], base: Scaffold, run: RunAttempt, reflect: Reflect, *,
+             generations: int = 4, batch: int = 4, holdout_fraction: float = 0.3, seed: int = 0,
+             rollout_budget: int = 200, save_dir: Path | None = None,
+             log: Callable[[str], None] | None = None) -> OptimizeResult:
+    say = log or (lambda _s: None)
+    dev, holdout = split(tasks, holdout_fraction=holdout_fraction, seed=seed)
+    rng = random.Random(seed)
+    best = base
+    rollouts = 0
+    gens: list[Generation] = []
+    if save_dir is not None:
+        base.save(save_dir / f"gen0-{base.sha256[:8]}.json")
+    for g in range(1, generations + 1):
+        minibatch = rng.sample(dev, min(batch, len(dev))) if dev else []
+        if not minibatch or rollouts + 2 * len(minibatch) > rollout_budget:
+            say(f"gen {g}: stopping, rollout budget {rollout_budget} would be exceeded")
+            break
+        parent_score, outcomes = score(minibatch, best, run)
+        rollouts += len(minibatch)
+        try:
+            child = reflect(best, outcomes)
+        except (ValueError, KeyError, TypeError) as e:
+            say(f"gen {g}: reflection unusable ({e}); parent kept")
+            continue
+        child_score, _ = score(minibatch, child, run)
+        rollouts += len(minibatch)
+        accepted = child_score.better_than(parent_score)
+        gens.append(Generation(index=g, parent_sha256=best.sha256, child_sha256=child.sha256,
+                               parent=parent_score, child=child_score, accepted=accepted,
+                               batch=tuple(t.task_id for t in minibatch)))
+        say(f"gen {g}: parent fixed {parent_score.fixed}/{parent_score.failing} verified "
+            f"{parent_score.verified}; child fixed {child_score.fixed}/{child_score.failing} "
+            f"verified {child_score.verified}; {'ACCEPTED' if accepted else 'rejected'}")
+        if save_dir is not None:
+            child.save(save_dir / f"gen{g}-{child.sha256[:8]}{'-accepted' if accepted else ''}.json")
+        if accepted:
+            best = child
+    hb = hs = None
+    if holdout and best.sha256 != base.sha256:
+        hb, _ = score(holdout, base, run)
+        hs, _ = score(holdout, best, run)
+        rollouts += 2 * len(holdout)
+        say(f"holdout ({len(holdout)} tasks): base fixed {hb.fixed}/{hb.failing} verified "
+            f"{hb.verified}; best fixed {hs.fixed}/{hs.failing} verified {hs.verified}")
+    elif holdout:
+        say("holdout: no accepted child, nothing to compare")
+    return OptimizeResult(best=best, generations=tuple(gens), rollouts=rollouts,
+                          holdout_base=hb, holdout_best=hs)
+
+
+def result_json(r: OptimizeResult) -> str:
+    return json.dumps({"best_sha256": r.best.sha256, "best_name": r.best.name, "rollouts": r.rollouts,
+                       "held_out_gain": r.held_out_gain,
+                       "holdout_base": asdict(r.holdout_base) if r.holdout_base else None,
+                       "holdout_best": asdict(r.holdout_best) if r.holdout_best else None,
+                       "generations": [asdict(g) for g in r.generations]}, indent=2)

--- a/python/src/xyntetik_runner/shadow/scaffold.py
+++ b/python/src/xyntetik_runner/shadow/scaffold.py
@@ -1,0 +1,115 @@
+"""The scaffold artifact (R15.0): what sits between the model and the harness.
+
+A scaffold is a versioned document the attempt harness consumes: the
+system text, the procedure the model is told to follow, the tool
+descriptions, the budget it may override, and exemplars. The model stays
+untouched, so one scaffold runs on any family the runner serves, and its
+sha256 sits in the evidence identity beside the model hash, so a report
+row names "this model with this scaffold". It is text: a diff is readable,
+promotion is a file copy, rollback is the previous file.
+
+Exemplars are content. The optimizer never writes them (v1); a person may,
+from verified local attempts or their own words, never from frontier
+output. ``Scaffold.base()`` reproduces the harness's original prompt so
+the base scaffold is the control arm of every comparison.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+SCAFFOLD_SCHEMA = "xyntetik.shadow.scaffold.v1"
+
+BASE_SYSTEM = (
+    "You are a software engineer fixing a repository checked out at the workspace root. "
+    "Work only through the tools. Read before you edit, change only what the task needs, "
+    "write complete files, run the tests to check your work, and call finish when the "
+    "tests pass or you cannot make further progress. Never ask the user questions."
+)
+
+
+@dataclass(frozen=True)
+class Scaffold:
+    name: str
+    system: str
+    procedure: tuple[str, ...] = ()
+    tool_descriptions: Mapping[str, str] = field(default_factory=dict)
+    exemplars: tuple[str, ...] = ()
+    budget: Mapping[str, float] = field(default_factory=dict)
+    notes: str = ""
+    parent_sha256: str = ""
+    schema_version: str = SCAFFOLD_SCHEMA
+
+    def __post_init__(self) -> None:
+        if self.schema_version != SCAFFOLD_SCHEMA:
+            raise ValueError(f"unknown scaffold schema {self.schema_version!r}")
+        if not self.system.strip():
+            raise ValueError("a scaffold needs system text")
+
+    @classmethod
+    def base(cls) -> Scaffold:
+        return cls(name="base", system=BASE_SYSTEM)
+
+    def canonical(self) -> str:
+        data = asdict(self)
+        data["tool_descriptions"] = dict(sorted(self.tool_descriptions.items()))
+        data["budget"] = dict(sorted(self.budget.items()))
+        return json.dumps(data, sort_keys=True, separators=(",", ":"))
+
+    @property
+    def sha256(self) -> str:
+        return hashlib.sha256(self.canonical().encode("utf-8")).hexdigest()
+
+    def system_text(self) -> str:
+        """The system message the harness sends: system text, then the
+        numbered procedure, then exemplars, in that order."""
+        parts = [self.system.strip()]
+        if self.procedure:
+            steps = "\n".join(f"{i + 1}. {p.strip()}" for i, p in enumerate(self.procedure))
+            parts.append(f"Procedure:\n{steps}")
+        if self.exemplars:
+            parts.append("Examples of good work:\n" + "\n\n".join(e.strip() for e in self.exemplars))
+        return "\n\n".join(parts)
+
+    def apply_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """The tool list with this scaffold's descriptions where it has one."""
+        out: list[dict[str, Any]] = []
+        for tool in tools:
+            fn = dict(tool.get("function", {}))
+            name = str(fn.get("name", ""))
+            if name in self.tool_descriptions:
+                fn["description"] = self.tool_descriptions[name]
+            out.append({**tool, "function": fn})
+        return out
+
+    def to_json(self) -> str:
+        data = asdict(self)
+        data["tool_descriptions"] = dict(self.tool_descriptions)
+        data["budget"] = dict(self.budget)
+        return json.dumps(data, sort_keys=True, indent=2) + "\n"
+
+    def save(self, path: Path) -> str:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(self.to_json(), encoding="utf-8")
+        return self.sha256
+
+    @classmethod
+    def from_json(cls, text: str) -> Scaffold:
+        data: dict[str, Any] = json.loads(text)
+        return cls(
+            name=str(data["name"]), system=str(data["system"]),
+            procedure=tuple(str(p) for p in data.get("procedure") or ()),
+            tool_descriptions={str(k): str(v) for k, v in (data.get("tool_descriptions") or {}).items()},
+            exemplars=tuple(str(e) for e in data.get("exemplars") or ()),
+            budget={str(k): float(v) for k, v in (data.get("budget") or {}).items()},
+            notes=str(data.get("notes") or ""), parent_sha256=str(data.get("parent_sha256") or ""),
+            schema_version=str(data.get("schema_version") or SCAFFOLD_SCHEMA))
+
+    @classmethod
+    def load(cls, path: Path) -> Scaffold:
+        return cls.from_json(path.read_text(encoding="utf-8"))

--- a/python/src/xyntetik_runner/shadow/tasks.py
+++ b/python/src/xyntetik_runner/shadow/tasks.py
@@ -199,7 +199,9 @@ def build_task(episode: Episode, repo: Path, shas: Sequence[str], *, out_dir: Pa
     if build:
         return Rejection(Disposition.INELIGIBLE, f"range touches {len(build)} file(s) that need a build")
     solution = shas[0]
-    base = _git(str(repo), "rev-parse", f"{shas[-1]}^").strip()
+    # --verify: without it git echoes an unresolvable "<sha>^" back on stdout
+    # and a root commit would reach git worktree as an invalid reference.
+    base = _git(str(repo), "rev-parse", "--verify", "--quiet", f"{shas[-1]}^").strip()
     if not base:
         return Rejection(Disposition.UNREPLAYABLE, "first commit in the range has no parent")
     task_id = f"{repo.name}-{base[:8]}-{solution[:8]}"

--- a/python/tests/test_shadow_scaffold.py
+++ b/python/tests/test_shadow_scaffold.py
@@ -1,0 +1,178 @@
+"""The scaffold artifact, the bank and the optimizer, without a model."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from xyntetik_runner.shadow import Identity, Scaffold
+from xyntetik_runner.shadow.attempt import TOOLS, Budget, Workspace, attempt, budget_with
+from xyntetik_runner.shadow.bank import build_bank
+from xyntetik_runner.shadow.optimize import (
+    Score,
+    TaskOutcome,
+    optimize,
+    parse_reflection,
+    reflect_prompt,
+    split,
+)
+from xyntetik_runner.shadow.scaffold import BASE_SYSTEM
+from xyntetik_runner.shadow.tasks import RepairTask
+
+FIXTURE = Path(__file__).parent / "fixtures" / "repair_task_v1"
+
+
+def test_scaffold_hash_is_canonical_and_base_matches_the_harness(tmp_path: Path) -> None:
+    a = Scaffold(name="x", system="s", tool_descriptions={"b": "2", "a": "1"}, budget={"z": 1, "y": 2})
+    b = Scaffold(name="x", system="s", tool_descriptions={"a": "1", "b": "2"}, budget={"y": 2, "z": 1})
+    assert a.sha256 == b.sha256
+    assert Scaffold.base().system == BASE_SYSTEM and Scaffold.base().system_text() == BASE_SYSTEM
+    p = tmp_path / "s.json"
+    sha = a.save(p)
+    assert Scaffold.load(p) == a and sha == a.sha256
+    with pytest.raises(ValueError):
+        Scaffold(name="x", system="   ")
+
+
+def test_scaffold_shapes_system_text_tools_and_budget() -> None:
+    s = Scaffold(name="t", system="Fix it.", procedure=("read the test", "run tests"),
+                 exemplars=("good: ...",), tool_descriptions={"run_tests": "Run them."},
+                 budget={"max_turns": 3, "wall_s": 99999, "nonsense": 1})
+    text = s.system_text()
+    assert text.startswith("Fix it.") and "1. read the test" in text and "Examples of good work" in text
+    tools = s.apply_tools(TOOLS)
+    assert [t["function"]["description"] for t in tools if t["function"]["name"] == "run_tests"] == ["Run them."]
+    assert all(t["function"]["name"] for t in tools)
+    b = budget_with(s, Budget(max_turns=12, wall_s=900.0))
+    assert b.max_turns == 3 and b.wall_s == 900.0, "a scaffold can spend less, never more"
+
+
+def test_identity_carries_the_scaffold_and_the_stack_key_splits_on_it() -> None:
+    base = Identity(project="p", task_class="repair", context_band="<2k", tool_set=(), verifier_id="v",
+                    environment_id="e", model_sha256="m", quant="q", template_sha256="t",
+                    runner_build="b", backend="cpu", harness_version="h")
+    other = Identity(**{**base.__dict__, "scaffold_sha256": "abc"})
+    assert base.scaffold_sha256 == "base" and base.stack_key() != other.stack_key()
+
+
+def test_attempt_uses_the_scaffold_system_text(tmp_path: Path) -> None:
+    seen: list[list[dict[str, Any]]] = []
+
+    def chat(messages: list[dict[str, Any]], tools: list[dict[str, Any]]) -> dict[str, Any]:
+        seen.append(messages)
+        assert tools[0]["function"]["description"] == "custom listing"
+        return {"content": "", "tool_calls": [{"id": "1", "function": {"name": "finish", "arguments": "{}"}}]}
+    s = Scaffold(name="t", system="Be brief.", procedure=("finish at once",),
+                 tool_descriptions={"list_files": "custom listing"}, budget={"max_turns": 1})
+    ws = Workspace(tmp_path, visible_tests=(), pythonpath=(), python=sys.executable, budget=Budget())
+    r = attempt("x", ws, chat, scaffold=s)
+    assert r.finished and seen[0][0]["content"].startswith("Be brief.") and "1. finish at once" in seen[0][0]["content"]
+
+
+def git(repo: Path, *args: str, date: str) -> str:
+    env = {**os.environ, "GIT_AUTHOR_DATE": date, "GIT_COMMITTER_DATE": date, "GIT_AUTHOR_NAME": "t",
+           "GIT_AUTHOR_EMAIL": "t@x", "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@x"}
+    return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True, env=env,
+                          check=True).stdout.strip()
+
+
+def test_bank_builds_tasks_from_a_public_history(tmp_path: Path) -> None:
+    r = tmp_path / "lib"
+    (r / "calc").mkdir(parents=True)
+    (r / "tests").mkdir()
+    git(tmp_path, "init", "-q", "-b", "main", str(r), date="2026-09-01T10:00:00+00:00")
+    (r / "calc" / "__init__.py").write_text("")
+    (r / "calc" / "money.py").write_text((FIXTURE / "workspace" / "calc" / "money.py").read_text())
+    (r / "tests" / "test_money.py").write_text((FIXTURE / "workspace" / "tests" / "test_money.py").read_text())
+    git(r, "add", "-A", date="2026-09-01T10:00:00+00:00")
+    git(r, "commit", "-q", "-m", "initial", date="2026-09-01T10:00:00+00:00")
+    (r / "README.md").write_text("docs only\n")
+    git(r, "add", "-A", date="2026-09-01T11:00:00+00:00")
+    git(r, "commit", "-q", "-m", "docs", date="2026-09-01T11:00:00+00:00")
+    (r / "calc" / "money.py").write_text('''from decimal import ROUND_HALF_UP, Decimal
+
+
+def parse_amount(text: str) -> int:
+    cleaned = "".join(ch for ch in text if ch.isdigit() or ch in "-.")
+    return int((Decimal(cleaned) * 100).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+''')
+    (r / "tests" / "test_money.py").write_text((FIXTURE / "protected" / "tests" / "test_money.py").read_text())
+    git(r, "add", "-A", date="2026-09-01T12:00:00+00:00")
+    git(r, "commit", "-q", "-m", "Handle thousands separators, currency prefixes and rounding\n\nFixes #7",
+        date="2026-09-01T12:00:00+00:00")
+    entries = build_bank(r, out_dir=tmp_path / "tasks", python=sys.executable, limit=5, max_commits=10)
+    admitted = [e for e in entries if e.task]
+    assert len(admitted) == 1 and admitted[0].task is not None
+    task = admitted[0].task
+    assert task.request.startswith("Handle thousands separators") and "Fixes #7" in task.request
+    assert task.expected_tests == 6 and task.baseline_failing == 3 and task.episode_id.startswith("bank:")
+    assert {e.reason for e in entries if not e.task} == {
+        "no test+source pair", "unreplayable: first commit in the range has no parent"}
+
+
+def fake_task(i: int) -> RepairTask:
+    return RepairTask(task_id=f"t{i}", episode_id=f"bank:x:{i}", repo="/r", base_sha="a", solution_sha="b",
+                      request="fix", request_sha256="s", context=(), test_files=("tests/t.py",),
+                      visible_test_files=(), src_files=1, pythonpath=(), protected_dir="/p",
+                      expected_tests=2, baseline_failing=2, failing_at_base=("tests/t.py::a", "tests/t.py::b"))
+
+
+def test_optimizer_keeps_a_child_only_when_it_scores_better_and_reports_holdout(tmp_path: Path) -> None:
+    tasks = [fake_task(i) for i in range(10)]
+
+    def run(task: RepairTask, scaffold: Scaffold) -> TaskOutcome:
+        good = "run the tests first" in " ".join(scaffold.procedure)
+        return TaskOutcome(task.task_id, fixed=2 if good else 0, failing_at_base=2, verified=good,
+                           feedback="stop: finish; verifier: 2 expected test(s) failed")
+    calls = {"n": 0}
+
+    def reflect(scaffold: Scaffold, outcomes: list[TaskOutcome]) -> Scaffold:
+        calls["n"] += 1
+        step = "run the tests first" if calls["n"] == 2 else "think harder"
+        return Scaffold(name="child", system=scaffold.system, procedure=(*scaffold.procedure, step),
+                        parent_sha256=scaffold.sha256)
+    log: list[str] = []
+    r = optimize(tasks, Scaffold.base(), run, reflect, generations=3, batch=3, holdout_fraction=0.3,
+                 seed=1, rollout_budget=100, save_dir=tmp_path, log=log.append)
+    assert [g.accepted for g in r.generations] == [False, True, False]
+    assert "run the tests first" in r.best.procedure and r.best.parent_sha256 == Scaffold.base().sha256
+    assert r.holdout_base is not None and r.holdout_best is not None and r.held_out_gain
+    assert r.holdout_best.fixed == 2 * len(split(tasks, holdout_fraction=0.3, seed=1)[1])
+    assert any(p.name.endswith("-accepted.json") for p in tmp_path.glob("gen*.json"))
+    assert r.rollouts == 3 * 6 + 2 * 3
+
+
+def test_optimizer_respects_the_rollout_budget_and_survives_bad_reflection() -> None:
+    tasks = [fake_task(i) for i in range(6)]
+    run = lambda t, s: TaskOutcome(t.task_id, 0, 2, False, "x")  # noqa: E731
+    reflect = lambda s, o: (_ for _ in ()).throw(ValueError("garbage"))  # noqa: E731
+    r = optimize(tasks, Scaffold.base(), run, reflect, generations=5, batch=2, holdout_fraction=0.3,
+                 seed=0, rollout_budget=3)
+    assert r.generations == () and r.rollouts == 0 and not r.held_out_gain
+    r = optimize(tasks, Scaffold.base(), run, reflect, generations=2, batch=2, holdout_fraction=0.3,
+                 seed=0, rollout_budget=100)
+    assert r.generations == () and r.best == Scaffold.base()
+
+
+def test_reflection_parsing_keeps_exemplars_and_budget_from_the_parent() -> None:
+    parent = Scaffold(name="p", system="s", exemplars=("keep me",), budget={"max_turns": 2})
+    text = "Here you go:\n```json\n" + json.dumps({"system": "new", "procedure": ["a", "b"],
+                                                    "tool_descriptions": {"finish": "done"},
+                                                    "notes": "shorter"}) + "\n```"
+    child = parse_reflection(text, parent, name="c")
+    assert child.system == "new" and child.procedure == ("a", "b") and child.exemplars == ("keep me",)
+    assert child.budget == {"max_turns": 2} and child.parent_sha256 == parent.sha256
+    with pytest.raises(ValueError):
+        parse_reflection("no json here", parent, name="c")
+    prompt = reflect_prompt(parent, [TaskOutcome("t1", 0, 2, False, "boom" * 1000)])
+    assert "Do not add examples" in prompt and len(prompt) < 5000
+
+
+def test_score_ordering() -> None:
+    assert Score(fixed=3, failing=4, verified=1, n=2).better_than(Score(fixed=4, failing=4, verified=0, n=2))
+    assert not Score(fixed=1, failing=4, verified=0, n=2).better_than(Score(fixed=1, failing=4, verified=0, n=2))


### PR DESCRIPTION
R15.0: a learned, hashed, model-agnostic scaffold between the model and the harness, before any weight moves.

- `Scaffold`: versioned JSON (system, procedure, tool descriptions, budget overrides bounded by the caller's, exemplars); sha256 in the evidence identity and the report's stack key; `replay --scaffold`; `Scaffold.base()` reproduces the harness's original prompt and is the control arm.
- `shadow bank --repo`: repair tasks from a public repository's commit history under the same admission rule as the personal ledger, request = the commit message; no frontier content anywhere.
- `shadow optimize`: the simplest reflective loop (after GEPA): score on a minibatch, hand the failure text to the local model, take its JSON child through schema-constrained output, keep it only if better on the same minibatch; seeded held-out slice decides against the base; kill gate = no held-out gain within the rollout budget. The optimizer never writes exemplars.
- Found on the way: `git rev-parse` echoes an unresolvable `<sha>^` on stdout; `--verify --quiet` fixes the root-commit case.

Gates: 97 Python tests (9 new), mypy strict clean.
