### PR TITLE
shadow: an exact-string edit tool, and a difficulty band for the optimizer

### DIFF
--- a/python/src/xyntetik_runner/shadow/attempt.py
+++ b/python/src/xyntetik_runner/shadow/attempt.py
@@ -52,6 +52,13 @@ TOOLS: list[dict[str, Any]] = [
             "path": {"type": "string"}, "content": {"type": "string"}},
             "required": ["path", "content"]}}},
     {"type": "function", "function": {
+        "name": "edit_file", "description": "Replace one exact, unique occurrence of old_text in "
+        "a workspace file with new_text. Use this for large files instead of rewriting them; "
+        "old_text must match exactly once.",
+        "parameters": {"type": "object", "properties": {
+            "path": {"type": "string"}, "old_text": {"type": "string"},
+            "new_text": {"type": "string"}}, "required": ["path", "old_text", "new_text"]}}},
+    {"type": "function", "function": {
         "name": "run_tests", "description": "Run the visible test files with pytest and return "
         "the tail of the output.",
         "parameters": {"type": "object", "properties": {}, "required": []}}},
@@ -62,7 +69,7 @@ TOOLS: list[dict[str, Any]] = [
                        "required": []}}},
 ]
 
-SYSTEM_PROMPT = BASE_SYSTEM
+SYSTEM_PROMPT = BASE_SYSTEM  # the base scaffold; tools are listed in TOOLS
 
 
 @dataclass(frozen=True)
@@ -166,6 +173,32 @@ class Workspace:
         except OSError as e:
             return f"error: {e}"
         return f"wrote {len(content)} chars to {path}"
+
+    def edit_file(self, path: str, old_text: str, new_text: str) -> str:
+        try:
+            target = self.resolve(path)
+        except ValueError as e:
+            return f"error: {e}"
+        if not target.is_file():
+            return "error: no such file"
+        if not isinstance(old_text, str) or not old_text:
+            return "error: old_text must be a non-empty string"
+        if not isinstance(new_text, str):
+            return "error: new_text must be a string"
+        try:
+            text = target.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as e:
+            return f"error: {e}"
+        n = text.count(old_text)
+        if n == 0:
+            return "error: old_text not found; read the file and copy the exact text"
+        if n > 1:
+            return f"error: old_text occurs {n} times; include more surrounding lines"
+        try:
+            target.write_text(text.replace(old_text, new_text, 1), encoding="utf-8")
+        except OSError as e:
+            return f"error: {e}"
+        return f"edited {path}: replaced {len(old_text)} chars with {len(new_text)}"
 
     def run_tests(self) -> str:
         if self.test_runs >= self.budget.test_runs:
@@ -299,6 +332,9 @@ def attempt(request: str, workspace: Workspace, chat: ChatFn, *, budget: Budget 
                 result = workspace.read_file(str(args.get("path") or ""), int(args.get("offset") or 0))
             elif name == "write_file":
                 result = workspace.write_file(str(args.get("path") or ""), args.get("content"))  # type: ignore[arg-type]
+            elif name == "edit_file":
+                result = workspace.edit_file(str(args.get("path") or ""), args.get("old_text"),  # type: ignore[arg-type]
+                                             args.get("new_text"))  # type: ignore[arg-type]
             elif name == "run_tests":
                 result = workspace.run_tests()
             else:

--- a/python/src/xyntetik_runner/shadow/cli.py
+++ b/python/src/xyntetik_runner/shadow/cli.py
@@ -341,10 +341,14 @@ def cmd_bank(args: argparse.Namespace) -> int:
 
 def cmd_optimize(args: argparse.Namespace) -> int:
     out = Path(args.out)
-    tasks = _tasks(out, None)
+    tasks = [t for t in _tasks(out, None)
+             if t.baseline_failing <= args.max_failing and t.baseline_failing < t.expected_tests]
+    # A task where everything fails at base (a test-suite move, a refactor)
+    # carries no gradient for any scaffold; the band keeps the signal.
     if not tasks:
-        print("error: no tasks under", out / "tasks", file=sys.stderr)
+        print("error: no tasks under", out / "tasks", "within --max-failing", file=sys.stderr)
         return 2
+    print(f"{len(tasks)} task(s) in the difficulty band", flush=True)
     endpoint = RunnerEndpoint(args.endpoint, timeout=args.request_timeout)
     caps = endpoint.capabilities()
     models = [m.get("id") for m in caps.get("models", []) if isinstance(m, dict)]
@@ -503,6 +507,8 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--test-runs", type=int, default=3)
     p.add_argument("--wall", type=float, default=600.0)
     p.add_argument("--min-tps", type=float, default=15.0)
+    p.add_argument("--max-failing", type=int, default=30,
+                   help="skip tasks with more failing-at-base tests than this")
     p.set_defaults(fn=cmd_optimize)
     p = sub.add_parser("capture", help="append a prompt or stop event from an agent hook")
     p.add_argument("--event", choices=["prompt", "stop"], required=True)

--- a/python/tests/test_shadow_pipeline.py
+++ b/python/tests/test_shadow_pipeline.py
@@ -403,3 +403,16 @@ def test_probe_speed_and_the_fit_floor(tmp_path: Path, monkeypatch: Any, capsys:
     rc = main(["replay", "--out", str(tmp_path), "--endpoint", "http://x", "--min-tps", "15"])
     assert rc == 2
     assert "fit-first" in capsys.readouterr().err
+
+
+def test_edit_file_replaces_one_exact_occurrence(tmp_path: Path) -> None:
+    ws = Workspace(tmp_path, visible_tests=(), pythonpath=(), python=sys.executable, budget=Budget())
+    (tmp_path / "a.py").write_text("x = 1\ny = 2\nx = 1\n")
+    assert ws.edit_file("a.py", "x = 1", "x = 9").startswith("error: old_text occurs 2")
+    assert ws.edit_file("a.py", "nope", "x").startswith("error: old_text not found")
+    assert ws.edit_file("../a.py", "y", "z").startswith("error")
+    assert ws.edit_file("a.py", "y = 2", "y = 3").startswith("edited a.py")
+    assert (tmp_path / "a.py").read_text() == "x = 1\ny = 3\nx = 1\n"
+    chat = scripted({"content": "", "tool_calls": [call("edit_file", path="a.py", old_text="x = 1\ny = 3", new_text="x = 0\ny = 0"), call("finish")]})
+    r = attempt("t", ws, chat)
+    assert r.finished and (tmp_path / "a.py").read_text() == "x = 0\ny = 0\nx = 1\n"


### PR DESCRIPTION
The public bank showed the gap: more-itertools keeps its library in one 42k-token file, which no model can rewrite whole through write_file, so the harness gains edit_file (one exact, unique occurrence replaced, confined like the other tools). The optimizer skips tasks above --max-failing or where every test fails at base, because such a task carries no gradient for any scaffold. 98 Python tests, mypy strict clean.