### PR TITLE
shadow: the Windows suite, made durable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,10 @@ scripts/tool-choice-boundary-bank.jsonl -text
 # a translated one is a different input and stops reproducing what it was
 # saved for.
 tests/fuzz/corpus/** -text
+
+# Shadow mode's frozen repair task: the protected manifest records the sha256
+# of each test file and refuses a file that differs. The hash folds CRLF to LF
+# (python/src/xyntetik_runner/shadow/baseline.py), so a translated checkout
+# still loads; this rule keeps the bytes stable on top of that, the way the
+# rest of this file treats anything a test hashes.
+python/tests/fixtures/** -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,6 +653,10 @@ jobs:
             src/json.c src/compat.c src/quants.c -o test-tools.exe -lm
           ./test-tools.exe
       - name: python client tests
+        # UTF-8 regardless of the runner's locale: the shadow fixtures carry
+        # non-ASCII text and a cp1252 default turns them into a SyntaxError
+        env:
+          PYTHONUTF8: "1"
         run: PYTHONPATH=python/src python3 -m pytest python/tests/
       - name: smoke test (completion)
         run: ./runner.exe -m test.gguf -p "hello" -n 8 --temp 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,6 +597,7 @@ jobs:
           update: false
           install: >-
             make
+            git
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-python
             mingw-w64-ucrt-x86_64-python-pytest
@@ -922,6 +923,7 @@ jobs:
           update: false
           install: >-
             make
+            git
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-python
             mingw-w64-ucrt-x86_64-python-pytest

--- a/python/src/xyntetik_runner/shadow/baseline.py
+++ b/python/src/xyntetik_runner/shadow/baseline.py
@@ -22,10 +22,23 @@ IGNORED_DIRS = frozenset({".git", "__pycache__", ".pytest_cache", ".mypy_cache",
 
 
 def file_sha256(path: Path) -> str:
+    """Content identity with CRLF folded to LF.
+
+    A git checkout on Windows translates line endings, so the same file has
+    different bytes on two machines. A protected manifest frozen on one and
+    loaded on the other must still agree, and a patch that changes nothing
+    but line endings is not a change. Hashing the newline-normalized bytes
+    makes both true; nothing here ever compares raw bytes.
+    """
     h = hashlib.sha256()
     with path.open("rb") as f:
+        pending = b""
         for chunk in iter(lambda: f.read(1 << 16), b""):
-            h.update(chunk)
+            data = pending + chunk
+            # a chunk boundary may split a CRLF pair; hold a trailing CR back
+            pending = data[-1:] if data.endswith(b"\r") else b""
+            h.update(data[: len(data) - len(pending)].replace(b"\r\n", b"\n"))
+        h.update(pending)
     return h.hexdigest()
 
 

--- a/python/src/xyntetik_runner/shadow/cli.py
+++ b/python/src/xyntetik_runner/shadow/cli.py
@@ -48,6 +48,7 @@ from xyntetik_runner.shadow.tasks import (
     Rejection,
     build_task,
     choose,
+    canonical,
     pair,
     repos_under,
 )
@@ -401,7 +402,7 @@ def cmd_capture(args: argparse.Namespace) -> int:
         sha = subprocess.run(["git", "-C", str(repo), "rev-parse", "HEAD"], capture_output=True,
                              text=True).stdout.strip()
         if sha:
-            heads[str(repo)] = sha
+            heads[str(canonical(repo))] = sha
     rec: dict[str, Any] = {"event": args.event, "timestamp": _now(),
                            "session_id": str(args.session or data.get("session_id") or ""),
                            "cwd": cwd, "head": head, "heads": heads, "tool": args.tool}

--- a/python/src/xyntetik_runner/shadow/tasks.py
+++ b/python/src/xyntetik_runner/shadow/tasks.py
@@ -17,6 +17,7 @@ and the names of the visible test files as they were at the pre-state.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -72,6 +73,14 @@ class RepairTask:
         return cls(**data)
 
 
+def canonical(path: Path | str) -> Path:
+    """One spelling per directory. ``Path.resolve`` is not enough on every
+    Python: a Windows build can keep the separator a path was created with,
+    so ``C:/x/proj`` and ``C:/x\\proj`` compare unequal while naming one
+    directory. normpath fixes the separators and dots, normcase the case."""
+    return Path(os.path.normcase(os.path.normpath(os.path.realpath(str(path)))))
+
+
 def _git(repo: str, *args: str) -> str:
     proc = subprocess.run(["git", "-C", repo, *args], capture_output=True, text=True)
     return proc.stdout
@@ -90,11 +99,11 @@ def repos_under(cwd: Path, *, depth: int = 2) -> list[Path]:
     # separator while a caller's may not (pytest's temp paths on Windows
     # keep forward slashes), and two spellings of one directory must be one
     # repository in every set and dict keyed on it.
-    stack: list[tuple[Path, int]] = [(cwd.resolve(), 0)]
+    stack: list[tuple[Path, int]] = [(canonical(cwd), 0)]
     while stack:
         here, d = stack.pop()
         if (here / ".git").exists():
-            out.append(here)
+            out.append(canonical(here))
         if d >= depth:
             continue
         try:
@@ -323,13 +332,13 @@ def choose(candidates: Iterable[Candidate]) -> dict[str, Candidate]:
     fix. A commit reachable from two clones is still one fix."""
     best: dict[str, Candidate] = {}
     for c in candidates:
-        depth = 0 if Path(c.episode.cwd).resolve() == c.repo.resolve() else 1
+        depth = 0 if canonical(c.episode.cwd) == canonical(c.repo) else 1
         key = (depth, -datetime.fromisoformat(c.episode.started_at.replace("Z", "+00:00")).timestamp())
         cur = best.get(c.solution)
         if cur is None:
             best[c.solution] = c
             continue
-        cur_depth = 0 if Path(cur.episode.cwd).resolve() == cur.repo.resolve() else 1
+        cur_depth = 0 if canonical(cur.episode.cwd) == canonical(cur.repo) else 1
         cur_key = (cur_depth, -datetime.fromisoformat(cur.episode.started_at.replace("Z", "+00:00")).timestamp())
         if key < cur_key:
             best[c.solution] = c

--- a/python/src/xyntetik_runner/shadow/tasks.py
+++ b/python/src/xyntetik_runner/shadow/tasks.py
@@ -86,7 +86,11 @@ def repos_under(cwd: Path, *, depth: int = 2) -> list[Path]:
     out: list[Path] = []
     if not cwd.is_dir():
         return out
-    stack: list[tuple[Path, int]] = [(cwd, 0)]
+    # Resolved paths throughout: a walked path carries the platform's
+    # separator while a caller's may not (pytest's temp paths on Windows
+    # keep forward slashes), and two spellings of one directory must be one
+    # repository in every set and dict keyed on it.
+    stack: list[tuple[Path, int]] = [(cwd.resolve(), 0)]
     while stack:
         here, d = stack.pop()
         if (here / ".git").exists():

--- a/python/tests/test_shadow_pipeline.py
+++ b/python/tests/test_shadow_pipeline.py
@@ -114,16 +114,18 @@ def test_claude_code_scan_turns_end_at_the_next_prompt(tmp_path: Path) -> None:
 
 
 def test_repos_under_finds_nested_repositories(repo: Path) -> None:
-    assert repos_under(repo.parent) == [repo.resolve()]
-    assert repos_under(repo) == [repo.resolve()]
+    from xyntetik_runner.shadow.tasks import canonical
+    assert repos_under(repo.parent) == [canonical(repo)]
+    assert repos_under(repo) == [canonical(repo)]
 
 
 def test_repos_under_descends_through_an_umbrella_repository(repo: Path) -> None:
     """The owner's layout: a parent directory that is itself a repository,
     with the real projects untracked inside it. Both are found."""
     git(repo.parent, "init", "-q", "-b", "main", str(repo.parent))
+    from xyntetik_runner.shadow.tasks import canonical
     found = repos_under(repo.parent)
-    assert found == sorted([repo.parent.resolve(), repo.resolve()])
+    assert found == sorted([canonical(repo.parent), canonical(repo)])
 
 
 def test_admit_builds_a_calibrated_task(repo: Path, tmp_path: Path) -> None:
@@ -337,8 +339,9 @@ def test_capture_from_a_parent_directory_records_every_repo_head(repo: Path, tmp
     monkeypatch.setattr("sys.stdin", __import__("io").StringIO(json.dumps(
         {"session_id": "cap2", "cwd": str(parent), "prompt": "fix parse_amount now"})))
     assert main(["capture", "--event", "prompt", "--file", str(cap)]) == 0
+    from xyntetik_runner.shadow.tasks import canonical
     lines = [json.loads(l) for l in cap.read_text().splitlines()]
-    key = str(repo.resolve())
+    key = str(canonical(repo))
     assert lines[0]["head"] == "" and lines[0]["heads"] == {key: base}
     assert lines[1]["heads"] == {key: fix}
     eps = scan_capture(cap).episodes
@@ -347,7 +350,7 @@ def test_capture_from_a_parent_directory_records_every_repo_head(repo: Path, tmp
     assert first.request == "first ask" and dict(first.heads_start) == {key: base}
     paired = pair(first)
     assert not isinstance(paired, Rejection) and paired[0].shas == (fix,)
-    assert paired[0].repo.resolve() == repo.resolve()
+    assert canonical(paired[0].repo) == canonical(repo)
     # the second prompt carries the first as context
     assert eps[1].context == ("first ask",)
 

--- a/python/tests/test_shadow_pipeline.py
+++ b/python/tests/test_shadow_pipeline.py
@@ -114,8 +114,8 @@ def test_claude_code_scan_turns_end_at_the_next_prompt(tmp_path: Path) -> None:
 
 
 def test_repos_under_finds_nested_repositories(repo: Path) -> None:
-    assert repos_under(repo.parent) == [repo]
-    assert repos_under(repo) == [repo]
+    assert repos_under(repo.parent) == [repo.resolve()]
+    assert repos_under(repo) == [repo.resolve()]
 
 
 def test_repos_under_descends_through_an_umbrella_repository(repo: Path) -> None:
@@ -123,7 +123,7 @@ def test_repos_under_descends_through_an_umbrella_repository(repo: Path) -> None
     with the real projects untracked inside it. Both are found."""
     git(repo.parent, "init", "-q", "-b", "main", str(repo.parent))
     found = repos_under(repo.parent)
-    assert found == sorted([repo.parent, repo])
+    assert found == sorted([repo.parent.resolve(), repo.resolve()])
 
 
 def test_admit_builds_a_calibrated_task(repo: Path, tmp_path: Path) -> None:
@@ -338,14 +338,16 @@ def test_capture_from_a_parent_directory_records_every_repo_head(repo: Path, tmp
         {"session_id": "cap2", "cwd": str(parent), "prompt": "fix parse_amount now"})))
     assert main(["capture", "--event", "prompt", "--file", str(cap)]) == 0
     lines = [json.loads(l) for l in cap.read_text().splitlines()]
-    assert lines[0]["head"] == "" and lines[0]["heads"] == {str(repo): base}
-    assert lines[1]["heads"] == {str(repo): fix}
+    key = str(repo.resolve())
+    assert lines[0]["head"] == "" and lines[0]["heads"] == {key: base}
+    assert lines[1]["heads"] == {key: fix}
     eps = scan_capture(cap).episodes
     assert len(eps) == 2
     first = eps[0]
-    assert first.request == "first ask" and dict(first.heads_start) == {str(repo): base}
+    assert first.request == "first ask" and dict(first.heads_start) == {key: base}
     paired = pair(first)
-    assert not isinstance(paired, Rejection) and paired[0].shas == (fix,) and paired[0].repo == repo
+    assert not isinstance(paired, Rejection) and paired[0].shas == (fix,)
+    assert paired[0].repo.resolve() == repo.resolve()
     # the second prompt carries the first as context
     assert eps[1].context == ("first ask",)
 

--- a/python/tests/test_shadow_pipeline.py
+++ b/python/tests/test_shadow_pipeline.py
@@ -20,9 +20,9 @@ from xyntetik_runner.shadow.importer import Episode, read_episodes, scan_claude_
 from xyntetik_runner.shadow.tasks import RepairTask, Rejection, admit, repos_under
 
 FIXTURE = Path(__file__).parent / "fixtures" / "repair_task_v1"
-BUGGY = (FIXTURE / "workspace" / "calc" / "money.py").read_text()
-VISIBLE = (FIXTURE / "workspace" / "tests" / "test_money.py").read_text()
-SOLUTION_TESTS = (FIXTURE / "protected" / "tests" / "test_money.py").read_text()
+BUGGY = (FIXTURE / "workspace" / "calc" / "money.py").read_text(encoding="utf-8")
+VISIBLE = (FIXTURE / "workspace" / "tests" / "test_money.py").read_text(encoding="utf-8")
+SOLUTION_TESTS = (FIXTURE / "protected" / "tests" / "test_money.py").read_text(encoding="utf-8")
 CORRECT = '''"""Money parsing for the ledger importer."""
 from decimal import ROUND_HALF_UP, Decimal
 
@@ -49,13 +49,13 @@ def repo(tmp_path: Path) -> Path:
     (r / "calc").mkdir(parents=True)
     (r / "tests").mkdir()
     git(tmp_path, "init", "-q", "-b", "main", str(r))
-    (r / "calc" / "__init__.py").write_text("")
-    (r / "calc" / "money.py").write_text(BUGGY)
-    (r / "tests" / "test_money.py").write_text(VISIBLE)
+    (r / "calc" / "__init__.py").write_text("", encoding="utf-8")
+    (r / "calc" / "money.py").write_text(BUGGY, encoding="utf-8")
+    (r / "tests" / "test_money.py").write_text(VISIBLE, encoding="utf-8")
     git(r, "add", "-A")
     git(r, "commit", "-q", "-m", "buggy", date="2026-09-01T11:00:00+00:00")
-    (r / "calc" / "money.py").write_text(CORRECT)
-    (r / "tests" / "test_money.py").write_text(SOLUTION_TESTS)
+    (r / "calc" / "money.py").write_text(CORRECT, encoding="utf-8")
+    (r / "tests" / "test_money.py").write_text(SOLUTION_TESTS, encoding="utf-8")
     git(r, "add", "-A")
     git(r, "commit", "-q", "-m", "fix", date="2026-09-01T12:00:00+00:00")
     return r
@@ -83,7 +83,7 @@ def test_codex_scan_reads_boundaries_and_never_the_answer(tmp_path: Path) -> Non
                                               "arguments": "{\"cmd\": \"THE PATCH\"}"}},
         {"timestamp": "2026-09-01T10:05:00Z", "type": "event_msg", "payload": {"type": "task_complete"}},
     ]
-    (sessions / "a.jsonl").write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+    (sessions / "a.jsonl").write_text("\n".join(json.dumps(r) for r in recs) + "\n", encoding="utf-8")
     (sessions / "broken.jsonl").write_bytes(b"\xff\xfe not json")
     report = scan_codex(tmp_path / "sessions")
     assert len(report.episodes) == 1 and report.files_read == 2
@@ -106,7 +106,7 @@ def test_claude_code_scan_turns_end_at_the_next_prompt(tmp_path: Path) -> None:
         {"type": "user", "sessionId": "s", "cwd": "/w", "timestamp": "2026-09-01T11:00:00Z",
          "message": {"content": "<command-name>/model</command-name>"}},
     ]
-    (proj / "s.jsonl").write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+    (proj / "s.jsonl").write_text("\n".join(json.dumps(r) for r in recs) + "\n", encoding="utf-8")
     eps = scan_claude_code(tmp_path / "projects").episodes
     assert [e.turn for e in eps] == [1, 2]
     assert eps[0].ended_at == "2026-09-01T11:00:00Z" and eps[1].is_command
@@ -152,12 +152,12 @@ def test_admit_rejects_a_commit_whose_tests_pass_before_the_fix(tmp_path: Path) 
     (r / "pkg").mkdir(parents=True)
     (r / "tests").mkdir()
     git(tmp_path, "init", "-q", "-b", "main", str(r))
-    (r / "pkg" / "__init__.py").write_text("X = 1\n")
-    (r / "tests" / "test_x.py").write_text("from pkg import X\n\n\ndef test_x():\n    assert X == 1\n")
+    (r / "pkg" / "__init__.py").write_text("X = 1\n", encoding="utf-8")
+    (r / "tests" / "test_x.py").write_text("from pkg import X\n\n\ndef test_x():\n    assert X == 1\n", encoding="utf-8")
     git(r, "add", "-A")
     git(r, "commit", "-q", "-m", "a", date="2026-09-01T11:00:00+00:00")
-    (r / "pkg" / "__init__.py").write_text("X = 1\nY = 2\n")
-    (r / "tests" / "test_x.py").write_text("from pkg import X\n\n\ndef test_x():\n    assert X == 1\n\n\ndef test_y():\n    assert True\n")
+    (r / "pkg" / "__init__.py").write_text("X = 1\nY = 2\n", encoding="utf-8")
+    (r / "tests" / "test_x.py").write_text("from pkg import X\n\n\ndef test_x():\n    assert X == 1\n\n\ndef test_y():\n    assert True\n", encoding="utf-8")
     git(r, "add", "-A")
     git(r, "commit", "-q", "-m", "b", date="2026-09-01T12:00:00+00:00")
     res = admit(episode(r), out_dir=tmp_path / "t", python=sys.executable)
@@ -249,7 +249,7 @@ def test_attempt_stops_on_budget_and_no_tool_calls(repo: Path, tmp_path: Path) -
                     {"content": "", "tool_calls": []})
     r = attempt("x", Workspace(tmp_path, visible_tests=(), pythonpath=(), python=sys.executable,
                                budget=Budget()), chat)
-    assert (tmp_path / "a").read_text() == "b"
+    assert (tmp_path / "a").read_text(encoding="utf-8") == "b"
 
 
 def test_cli_import_and_report_on_a_synthetic_home(repo: Path, tmp_path: Path, capsys: Any) -> None:
@@ -264,7 +264,7 @@ def test_cli_import_and_report_on_a_synthetic_home(repo: Path, tmp_path: Path, c
         {"type": "user", "sessionId": "s", "cwd": "/nonexistent", "timestamp": "2026-09-01T13:00:00Z",
          "message": {"content": "unrelated"}},
     ]
-    (proj / "s.jsonl").write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+    (proj / "s.jsonl").write_text("\n".join(json.dumps(r) for r in recs) + "\n", encoding="utf-8")
     out = tmp_path / "out"
     assert main(["import", "--out", str(out), "--home", str(home), "--python", sys.executable]) == 0
     eps = read_episodes(out / "episodes.jsonl")
@@ -299,7 +299,7 @@ def test_capture_hook_path_gives_an_exact_range(repo: Path, tmp_path: Path, monk
     monkeypatch.setattr("sys.stdin", __import__("io").StringIO(json.dumps(
         {"session_id": "cap1", "cwd": str(repo)})))
     assert main(["capture", "--event", "stop", "--file", str(cap)]) == 0
-    lines = [json.loads(l) for l in cap.read_text().splitlines()]
+    lines = [json.loads(l) for l in cap.read_text(encoding="utf-8").splitlines()]
     assert [l["event"] for l in lines] == ["prompt", "stop"]
     assert lines[0]["head"] == base and lines[1]["head"] == fix and "prompt" not in lines[1]
     eps = scan_capture(cap).episodes
@@ -340,7 +340,7 @@ def test_capture_from_a_parent_directory_records_every_repo_head(repo: Path, tmp
         {"session_id": "cap2", "cwd": str(parent), "prompt": "fix parse_amount now"})))
     assert main(["capture", "--event", "prompt", "--file", str(cap)]) == 0
     from xyntetik_runner.shadow.tasks import canonical
-    lines = [json.loads(l) for l in cap.read_text().splitlines()]
+    lines = [json.loads(l) for l in cap.read_text(encoding="utf-8").splitlines()]
     key = str(canonical(repo))
     assert lines[0]["head"] == "" and lines[0]["heads"] == {key: base}
     assert lines[1]["heads"] == {key: fix}
@@ -379,7 +379,7 @@ def test_claude_code_context_skips_commands_and_caps_turns(tmp_path: Path) -> No
     for i, text in enumerate(["one", "<command-name>/x</command-name>", "two", "three", "four", "five"]):
         recs.append({"type": "user", "sessionId": "s", "cwd": "/w",
                      "timestamp": f"2026-09-01T10:{i:02d}:00Z", "message": {"content": text}})
-    (proj / "s.jsonl").write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+    (proj / "s.jsonl").write_text("\n".join(json.dumps(r) for r in recs) + "\n", encoding="utf-8")
     eps = scan_claude_code(tmp_path / "projects").episodes
     assert eps[-1].request == "five" and eps[-1].context == ("two", "three", "four")
     assert eps[2].context == ("one",), "the command turn is not context"
@@ -412,12 +412,12 @@ def test_probe_speed_and_the_fit_floor(tmp_path: Path, monkeypatch: Any, capsys:
 
 def test_edit_file_replaces_one_exact_occurrence(tmp_path: Path) -> None:
     ws = Workspace(tmp_path, visible_tests=(), pythonpath=(), python=sys.executable, budget=Budget())
-    (tmp_path / "a.py").write_text("x = 1\ny = 2\nx = 1\n")
+    (tmp_path / "a.py").write_text("x = 1\ny = 2\nx = 1\n", encoding="utf-8")
     assert ws.edit_file("a.py", "x = 1", "x = 9").startswith("error: old_text occurs 2")
     assert ws.edit_file("a.py", "nope", "x").startswith("error: old_text not found")
     assert ws.edit_file("../a.py", "y", "z").startswith("error")
     assert ws.edit_file("a.py", "y = 2", "y = 3").startswith("edited a.py")
-    assert (tmp_path / "a.py").read_text() == "x = 1\ny = 3\nx = 1\n"
+    assert (tmp_path / "a.py").read_text(encoding="utf-8") == "x = 1\ny = 3\nx = 1\n"
     chat = scripted({"content": "", "tool_calls": [call("edit_file", path="a.py", old_text="x = 1\ny = 3", new_text="x = 0\ny = 0"), call("finish")]})
     r = attempt("t", ws, chat)
-    assert r.finished and (tmp_path / "a.py").read_text() == "x = 0\ny = 0\nx = 1\n"
+    assert r.finished and (tmp_path / "a.py").read_text(encoding="utf-8") == "x = 0\ny = 0\nx = 1\n"

--- a/python/tests/test_shadow_scaffold.py
+++ b/python/tests/test_shadow_scaffold.py
@@ -86,12 +86,12 @@ def test_bank_builds_tasks_from_a_public_history(tmp_path: Path) -> None:
     (r / "calc").mkdir(parents=True)
     (r / "tests").mkdir()
     git(tmp_path, "init", "-q", "-b", "main", str(r), date="2026-09-01T10:00:00+00:00")
-    (r / "calc" / "__init__.py").write_text("")
-    (r / "calc" / "money.py").write_text((FIXTURE / "workspace" / "calc" / "money.py").read_text())
-    (r / "tests" / "test_money.py").write_text((FIXTURE / "workspace" / "tests" / "test_money.py").read_text())
+    (r / "calc" / "__init__.py").write_text("", encoding="utf-8")
+    (r / "calc" / "money.py").write_text((FIXTURE / "workspace" / "calc" / "money.py").read_text(), encoding="utf-8")
+    (r / "tests" / "test_money.py").write_text((FIXTURE / "workspace" / "tests" / "test_money.py").read_text(), encoding="utf-8")
     git(r, "add", "-A", date="2026-09-01T10:00:00+00:00")
     git(r, "commit", "-q", "-m", "initial", date="2026-09-01T10:00:00+00:00")
-    (r / "README.md").write_text("docs only\n")
+    (r / "README.md").write_text("docs only\n", encoding="utf-8")
     git(r, "add", "-A", date="2026-09-01T11:00:00+00:00")
     git(r, "commit", "-q", "-m", "docs", date="2026-09-01T11:00:00+00:00")
     (r / "calc" / "money.py").write_text('''from decimal import ROUND_HALF_UP, Decimal
@@ -100,8 +100,8 @@ def test_bank_builds_tasks_from_a_public_history(tmp_path: Path) -> None:
 def parse_amount(text: str) -> int:
     cleaned = "".join(ch for ch in text if ch.isdigit() or ch in "-.")
     return int((Decimal(cleaned) * 100).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
-''')
-    (r / "tests" / "test_money.py").write_text((FIXTURE / "protected" / "tests" / "test_money.py").read_text())
+''', encoding="utf-8")
+    (r / "tests" / "test_money.py").write_text((FIXTURE / "protected" / "tests" / "test_money.py").read_text(), encoding="utf-8")
     git(r, "add", "-A", date="2026-09-01T12:00:00+00:00")
     git(r, "commit", "-q", "-m", "Handle thousands separators, currency prefixes and rounding\n\nFixes #7",
         date="2026-09-01T12:00:00+00:00")

--- a/python/tests/test_shadow_verifier.py
+++ b/python/tests/test_shadow_verifier.py
@@ -70,7 +70,7 @@ def test_manifest_is_frozen_and_checked(tmp_path: Path) -> None:
     src = tmp_path / "protected"
     shutil.copytree(FIXTURE / "protected", src)
     ProtectedTests.load(src)
-    (src / "tests" / "test_money.py").write_text("def test_plain():\n    assert True\n")
+    (src / "tests" / "test_money.py").write_text("def test_plain():\n    assert True\n", encoding="utf-8")
     with pytest.raises(InstrumentError, match="differs from its manifest"):
         ProtectedTests.load(src)
 
@@ -87,7 +87,7 @@ def test_calibration_refuses_a_protected_set_that_cannot_fail(tmp_path: Path) ->
     src = tmp_path / "protected"
     (src / "tests").mkdir(parents=True)
     (src / "tests" / "test_money.py").write_text(
-        "from calc.money import parse_amount\n\n\ndef test_plain():\n    assert parse_amount('12.34') == 1234\n")
+        "from calc.money import parse_amount\n\n\ndef test_plain():\n    assert parse_amount('12.34') == 1234\n", encoding="utf-8")
     protected = ProtectedTests.freeze(src, {"tests/test_money.py": ["test_plain"]})
     with pytest.raises(InstrumentError, match="cannot reject a no-op"):
         calibrate(protected, ws)
@@ -95,7 +95,7 @@ def test_calibration_refuses_a_protected_set_that_cannot_fail(tmp_path: Path) ->
 
 def test_correct_patch_is_verified(task: tuple[Path, Baseline, ProtectedTests]) -> None:
     ws, base, protected = task
-    (ws / "calc" / "money.py").write_text(CORRECT)
+    (ws / "calc" / "money.py").write_text(CORRECT, encoding="utf-8")
     out = verify(ws, protected, base)
     assert out.passed is True and out.passed_count == 6 and not out.tamper and not out.reasons
     assert out.output_sha256 and out.duration_s > 0
@@ -104,7 +104,7 @@ def test_correct_patch_is_verified(task: tuple[Path, Baseline, ProtectedTests]) 
 
 def test_wrong_patch_passes_visible_tests_and_fails_protected(task: tuple[Path, Baseline, ProtectedTests]) -> None:
     ws, base, protected = task
-    (ws / "calc" / "money.py").write_text(WRONG)
+    (ws / "calc" / "money.py").write_text(WRONG, encoding="utf-8")
     assert visible_tests_pass(ws), "the control must fool the attempt's own tests"
     out = verify(ws, protected, base)
     assert out.passed is False and out.failed >= 2 and not out.tamper
@@ -119,7 +119,7 @@ def test_no_op_is_rejected_without_running(task: tuple[Path, Baseline, Protected
 
 def test_tampered_test_file_is_flagged_and_frozen_copy_runs(task: tuple[Path, Baseline, ProtectedTests]) -> None:
     ws, base, protected = task
-    (ws / "tests" / "test_money.py").write_text("def test_plain():\n    assert True\n")
+    (ws / "tests" / "test_money.py").write_text("def test_plain():\n    assert True\n", encoding="utf-8")
     assert visible_tests_pass(ws)
     out = verify(ws, protected, base)
     assert out.passed is False
@@ -129,7 +129,7 @@ def test_tampered_test_file_is_flagged_and_frozen_copy_runs(task: tuple[Path, Ba
 
 def test_conftest_injection_is_flagged_even_though_it_would_pass(task: tuple[Path, Baseline, ProtectedTests]) -> None:
     ws, base, protected = task
-    (ws / "tests" / "conftest.py").write_text(MONKEYPATCH_CONFTEST)
+    (ws / "tests" / "conftest.py").write_text(MONKEYPATCH_CONFTEST, encoding="utf-8")
     assert visible_tests_pass(ws), "the control must fool a naive verifier"
     out = verify(ws, protected, base)
     assert out.passed is False
@@ -139,8 +139,8 @@ def test_conftest_injection_is_flagged_even_though_it_would_pass(task: tuple[Pat
 
 def test_config_injection_is_flagged(task: tuple[Path, Baseline, ProtectedTests]) -> None:
     ws, base, protected = task
-    (ws / "calc" / "money.py").write_text(CORRECT)
-    (ws / "pytest.ini").write_text("[pytest]\naddopts = -k nothing_matches_this\n")
+    (ws / "calc" / "money.py").write_text(CORRECT, encoding="utf-8")
+    (ws / "pytest.ini").write_text("[pytest]\naddopts = -k nothing_matches_this\n", encoding="utf-8")
     out = verify(ws, protected, base)
     assert out.passed is False and "test configuration changed: pytest.ini" in out.tamper
     assert out.passed_count == 6, "the verifier's own ini was used, the injected one ignored"
@@ -149,14 +149,14 @@ def test_config_injection_is_flagged(task: tuple[Path, Baseline, ProtectedTests]
 def test_skip_cannot_count_as_success(task: tuple[Path, Baseline, ProtectedTests]) -> None:
     ws, base, protected = task
     (ws / "calc" / "money.py").write_text(
-        'import pytest\npytest.skip("skipping the module under test", allow_module_level=True)\n')
+        'import pytest\npytest.skip("skipping the module under test", allow_module_level=True)\n', encoding="utf-8")
     out = verify(ws, protected, base)
     assert out.passed is False and (out.skipped + out.missing) == out.expected
 
 
 def test_timeout_is_inconclusive_never_a_pass(task: tuple[Path, Baseline, ProtectedTests]) -> None:
     ws, base, protected = task
-    (ws / "calc" / "money.py").write_text("import time\ntime.sleep(60)\n")
+    (ws / "calc" / "money.py").write_text("import time\ntime.sleep(60)\n", encoding="utf-8")
     out = verify(ws, protected, base, timeout_s=3)
     assert out.passed is None and out.reasons == ("timeout after 3s",)
     assert out.duration_s < 30
@@ -164,7 +164,7 @@ def test_timeout_is_inconclusive_never_a_pass(task: tuple[Path, Baseline, Protec
 
 def test_scratch_copy_leaves_the_workspace_untouched(task: tuple[Path, Baseline, ProtectedTests]) -> None:
     ws, base, protected = task
-    (ws / "calc" / "money.py").write_text(CORRECT)
+    (ws / "calc" / "money.py").write_text(CORRECT, encoding="utf-8")
     before = Baseline.capture(ws)
     verify(ws, protected, base)
     assert Baseline.capture(ws) == before
@@ -177,9 +177,9 @@ def test_pythonpath_roots_resolve_inside_the_scratch_copy(tmp_path: Path) -> Non
     ws = tmp_path / "ws"
     (ws / "src" / "calc").mkdir(parents=True)
     (ws / "tests").mkdir()
-    (ws / "src" / "calc" / "__init__.py").write_text("")
-    (ws / "src" / "calc" / "money.py").write_text(WRONG)
-    (ws / "tests" / "test_money.py").write_text("def test_plain():\n    assert True\n")
+    (ws / "src" / "calc" / "__init__.py").write_text("", encoding="utf-8")
+    (ws / "src" / "calc" / "money.py").write_text(WRONG, encoding="utf-8")
+    (ws / "tests" / "test_money.py").write_text("def test_plain():\n    assert True\n", encoding="utf-8")
     src = tmp_path / "protected"
     (src / "tests").mkdir(parents=True)
     shutil.copyfile(FIXTURE / "protected" / "tests" / "test_money.py", src / "tests" / "test_money.py")
@@ -187,7 +187,7 @@ def test_pythonpath_roots_resolve_inside_the_scratch_copy(tmp_path: Path) -> Non
         "test_plain", "test_thousands_separator", "test_float_trap", "test_negative",
         "test_currency_prefix", "test_whitespace"]})
     base = Baseline.capture(ws)
-    (ws / "src" / "calc" / "money.py").write_text(CORRECT)
+    (ws / "src" / "calc" / "money.py").write_text(CORRECT, encoding="utf-8")
     without = verify(ws, protected, base)
     assert without.passed is False and without.missing == 6, "no root: the tests cannot import calc"
     with_root = verify(ws, protected, base, pythonpath=("src",))

--- a/python/tests/test_shadow_verifier.py
+++ b/python/tests/test_shadow_verifier.py
@@ -59,7 +59,10 @@ def visible_tests_pass(ws: Path) -> bool:
     env = {k: v for k, v in os.environ.items() if k in ("PATH", "SYSTEMROOT", "SystemRoot")}
     env["PYTHONPATH"] = str(ws)
     r = subprocess.run([sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", "tests"],
-                       cwd=ws, capture_output=True, env=env)
+                       cwd=ws, capture_output=True, env=env, text=True)
+    if r.returncode != 0:
+        # printed so a failing control explains itself in the CI log
+        print(f"visible tests exit {r.returncode}:\n{r.stdout[-2500:]}\n{r.stderr[-800:]}")
     return r.returncode == 0
 
 

--- a/python/tests/test_shadow_verifier.py
+++ b/python/tests/test_shadow_verifier.py
@@ -189,3 +189,32 @@ def test_pythonpath_roots_resolve_inside_the_scratch_copy(tmp_path: Path) -> Non
     assert without.passed is False and without.missing == 6, "no root: the tests cannot import calc"
     with_root = verify(ws, protected, base, pythonpath=("src",))
     assert with_root.passed is True and with_root.passed_count == 6
+
+
+def test_hashes_fold_crlf_so_a_windows_checkout_still_loads(tmp_path: Path) -> None:
+    """The fixture was frozen on a machine that writes LF; a git checkout on
+    Windows rewrites it with CRLF. The manifest must still load, the tree
+    must still count as unchanged, and a CR split across a read chunk must
+    not change the answer."""
+    from xyntetik_runner.shadow import file_sha256
+    lf = tmp_path / "lf.py"
+    crlf = tmp_path / "crlf.py"
+    text = "x = 1\n" * 20000  # well past one 64 KiB read chunk
+    lf.write_bytes(text.encode())
+    crlf.write_bytes(text.replace("\n", "\r\n").encode())
+    assert file_sha256(lf) == file_sha256(crlf)
+    lone_cr = tmp_path / "cr.py"
+    lone_cr.write_bytes(b"a\rb\n")
+    assert file_sha256(lone_cr) != file_sha256(lf), "a lone CR is content, not a line ending"
+    src = tmp_path / "protected"
+    shutil.copytree(FIXTURE / "protected", src)
+    f = src / "tests" / "test_money.py"
+    f.write_bytes(f.read_bytes().replace(b"\n", b"\r\n"))
+    protected = ProtectedTests.load(src)  # would raise InstrumentError on a byte comparison
+    assert protected.expected
+    ws = tmp_path / "ws"
+    shutil.copytree(FIXTURE / "workspace", ws)
+    base = Baseline.capture(ws)
+    money = ws / "calc" / "money.py"
+    money.write_bytes(money.read_bytes().replace(b"\n", b"\r\n"))
+    assert not base.changes(ws), "line endings alone are not a change"


### PR DESCRIPTION
Both Windows jobs went red at the first shadow-mode PR. Two causes in the log: a CRLF checkout of the frozen fixture breaks the protected manifest's byte hash (the content hash now folds CRLF to LF, with a test loading the manifest from a CRLF copy), and git is absent from the MSYS2 shell (both jobs now install it). The fixture joins .gitattributes under the existing rule for files a test hashes. Proven on the branch by workflow dispatch, which is the only way windows-suite runs before a merge.