### PR TITLE
shadow: install and uninstall, the harness wiring as one explicit opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ names that were true when they were written.
 
 ## Unreleased
 
+- **`shadow install`: the harness wiring as one explicit opt-in.** Merges
+  the prompt and stop capture hooks into the Claude Code user settings
+  beside whatever is there (backup beside the file, idempotent), writes a
+  `/shadow` skill that shows the ledger and the capture summary from
+  inside a session, and a `/shadow` prompt for Codex, which has no
+  prompt-time hook. `uninstall` removes exactly that and nothing else;
+  `capture --summary` prints the counts the commands show. Nothing runs
+  until a prompt is submitted, and the hooks can never block one.
+
 - **The scaffold artifact (R15.0): a learned, hashed, model-agnostic
   layer between the model and the harness, before any weight moves.**
   `xyntetik_runner.shadow.scaffold.Scaffold` is a versioned JSON document

--- a/README.md
+++ b/README.md
@@ -1823,7 +1823,14 @@ the task's commit range is exact.
     "command": "python3 -m xyntetik_runner.shadow capture --event stop"}]}]}}
 ```
 
-Only your request, the directory, the time and the commit ids are written
+`python -m xyntetik_runner.shadow install` writes exactly this for you:
+the two hooks merged into your Claude Code settings beside whatever is
+there (a backup sits next to the file), a `/shadow` skill that shows the
+ledger from inside a Claude Code session, and a `/shadow` prompt for
+Codex, which has no prompt-time hook and stays on its session files. It
+is an explicit opt-in, nothing runs until you submit a prompt, and
+`uninstall` removes exactly what it wrote. Only your request, the
+directory, the time and the commit ids are written
 (the HEAD of every repository at or under the directory, so a session
 started from a parent directory still gets exact ranges); the file is
 `~/.xyntetik/shadow/capture.jsonl` and `import` reads it beside the

--- a/python/README.md
+++ b/python/README.md
@@ -86,6 +86,11 @@ The negative controls that prove the verifier can fail live in
   `shadow optimize` runs it against a runner endpoint with the local model as
   its own reflector and writes `scaffolds/best.json` and `optimize.json`.
 
+- `install`: `shadow install [--pythonpath P] [--out DIR]` merges the two capture
+  hooks into `~/.claude/settings.json`, writes the `/shadow` skill and the Codex
+  `/shadow` prompt; `uninstall` reverses exactly that; `capture --summary` counts
+  the capture file.
+
 The pipeline is exercised without a model in `python/tests/test_shadow_pipeline.py`
 on synthetic traces and a synthetic repository; a scripted chat function
 proves the plumbing and the confinement, the pilot measures the model.

--- a/python/src/xyntetik_runner/shadow/cli.py
+++ b/python/src/xyntetik_runner/shadow/cli.py
@@ -34,6 +34,7 @@ from xyntetik_runner.shadow.evidence import (
     summarize,
 )
 from xyntetik_runner.shadow.importer import CAPTURE_FILE, Episode, read_episodes, scan_all, write_episodes
+from xyntetik_runner.shadow.install import install, uninstall
 from xyntetik_runner.shadow.bank import build_bank
 from xyntetik_runner.shadow.optimize import (
     TaskOutcome,
@@ -385,13 +386,31 @@ def cmd_capture(args: argparse.Namespace) -> int:
     """Append one prompt or stop line from a hook. Reads the hook's JSON on
     stdin (Claude Code passes ``session_id``, ``cwd`` and, on prompt
     submission, ``prompt``); records the request, the directory, the time
-    and the repository HEAD, and nothing the assistant produced."""
+    and the repository HEAD, and nothing the assistant produced.
+    ``--summary`` prints counts over the capture file instead."""
+    if args.summary:
+        path = Path(args.file) if args.file else Path.home() / CAPTURE_FILE
+        rows: list[dict[str, Any]] = []
+        if path.is_file():
+            for line in path.read_text(encoding="utf-8").splitlines():
+                try:
+                    rows.append(json.loads(line))
+                except ValueError:
+                    continue
+        prompts = [r for r in rows if r.get("event") == "prompt"]
+        with_heads = sum(1 for r in prompts if r.get("heads"))
+        print(f"captured: {len(rows)} lines, {len(prompts)} prompts, {with_heads} with repository "
+              f"heads, {len({r.get('session_id') for r in rows})} sessions ({path})")
+        return 0
     try:
         data = json.loads(sys.stdin.read() or "{}")
     except ValueError:
         data = {}
     if not isinstance(data, dict):
         data = {}
+    if args.event not in ("prompt", "stop"):
+        print("error: --event prompt|stop is required (or --summary)", file=sys.stderr)
+        return 2
     cwd = str(args.cwd or data.get("cwd") or Path.cwd())
     head = subprocess.run(["git", "-C", cwd, "rev-parse", "HEAD"], capture_output=True,
                           text=True).stdout.strip()
@@ -412,6 +431,27 @@ def cmd_capture(args: argparse.Namespace) -> int:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(rec, sort_keys=True) + "\n")
+    return 0
+
+
+def cmd_install(args: argparse.Namespace) -> int:
+    home = Path(args.home) if args.home else Path.home()
+    done = install(home, python=args.python, pythonpath=args.pythonpath or None, out=args.out,
+                   claude=not args.no_claude, codex=not args.no_codex)
+    if done.settings:
+        print(f"claude code: {done.hooks_added} hook(s) added to {done.settings} "
+              f"(backup beside it); skill {done.claude_skill}")
+    if done.codex_prompt:
+        print(f"codex: prompt {done.codex_prompt}")
+    print("nothing runs until a prompt is submitted; the hooks never block one; "
+          "'shadow uninstall' removes exactly this")
+    return 0
+
+
+def cmd_uninstall(args: argparse.Namespace) -> int:
+    home = Path(args.home) if args.home else Path.home()
+    done = uninstall(home)
+    print(f"removed {-done.hooks_added} hook(s), the /shadow skill and the codex prompt")
     return 0
 
 
@@ -512,13 +552,26 @@ def main(argv: list[str] | None = None) -> int:
                    help="skip tasks with more failing-at-base tests than this")
     p.set_defaults(fn=cmd_optimize)
     p = sub.add_parser("capture", help="append a prompt or stop event from an agent hook")
-    p.add_argument("--event", choices=["prompt", "stop"], required=True)
+    p.add_argument("--event", choices=["prompt", "stop"], default="")
+    p.add_argument("--summary", action="store_true", help="print counts over the capture file")
     p.add_argument("--tool", default="claude_code")
     p.add_argument("--cwd", default="")
     p.add_argument("--session", default="")
     p.add_argument("--prompt", default="")
     p.add_argument("--file", default="")
     p.set_defaults(fn=cmd_capture)
+    p = sub.add_parser("install", help="wire the hooks and a /shadow command into the harnesses "
+                                       "(explicit opt-in; reversible with uninstall)")
+    p.add_argument("--home", default="")
+    p.add_argument("--python", default=sys.executable)
+    p.add_argument("--pythonpath", default="", help="set when the client is not installed")
+    p.add_argument("--out", default="~/.xyntetik/shadow")
+    p.add_argument("--no-claude", action="store_true")
+    p.add_argument("--no-codex", action="store_true")
+    p.set_defaults(fn=cmd_install)
+    p = sub.add_parser("uninstall", help="remove exactly what install wrote")
+    p.add_argument("--home", default="")
+    p.set_defaults(fn=cmd_uninstall)
     p = sub.add_parser("report", help="counts and both denominators")
     p.add_argument("--out", default=str(DEFAULT_OUT))
     p.add_argument("--by-reason", action="store_true")

--- a/python/src/xyntetik_runner/shadow/install.py
+++ b/python/src/xyntetik_runner/shadow/install.py
@@ -1,0 +1,161 @@
+"""One explicit opt-in that wires shadow mode into the harnesses.
+
+Nothing here runs implicitly: ``shadow install`` is a command a person
+types, it says what it wrote, and ``shadow uninstall`` removes exactly
+that. Claude Code gets two hooks (prompt and stop) merged into the user
+settings beside whatever is already there, and a ``/shadow`` skill that
+shows the ledger. Codex gets a ``/shadow`` prompt; it has no prompt-time
+hook, so its capture stays on the session files ``import`` already reads.
+The hook commands never block a prompt: they redirect their errors away
+and end in ``|| true``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+MARK = "xyntetik_runner.shadow capture"
+SKILL_NAME = "shadow"
+
+
+@dataclass(frozen=True)
+class Installed:
+    settings: Path | None
+    claude_skill: Path | None
+    codex_prompt: Path | None
+    hooks_added: int
+
+
+def hook_command(event: str, python: str, pythonpath: str | None) -> str:
+    prefix = f"PYTHONPATH={pythonpath} " if pythonpath else ""
+    return (f"{prefix}{python} -m xyntetik_runner.shadow capture --event {event} "
+            f"2>/dev/null || true")
+
+
+def _hook_entry(command: str) -> dict[str, object]:
+    return {"hooks": [{"type": "command", "timeout": 10, "command": command}]}
+
+
+def install_claude_hooks(settings: Path, *, python: str, pythonpath: str | None) -> int:
+    """Merge the two hooks into ``settings`` (created if absent); idempotent.
+    Returns how many hooks were added. A backup sits beside the file."""
+    data: dict[str, object] = {}
+    if settings.is_file():
+        data = json.loads(settings.read_text(encoding="utf-8") or "{}")
+        shutil.copyfile(settings, settings.with_suffix(".json.bak-shadow"))
+    hooks = data.setdefault("hooks", {})
+    assert isinstance(hooks, dict)
+    added = 0
+    for event, name in (("prompt", "UserPromptSubmit"), ("stop", "Stop")):
+        entries = hooks.setdefault(name, [])
+        assert isinstance(entries, list)
+        present = any(MARK in json.dumps(e) for e in entries)
+        if not present:
+            entries.append(_hook_entry(hook_command(event, python, pythonpath)))
+            added += 1
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    settings.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return added
+
+
+def uninstall_claude_hooks(settings: Path) -> int:
+    if not settings.is_file():
+        return 0
+    data = json.loads(settings.read_text(encoding="utf-8") or "{}")
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return 0
+    removed = 0
+    for name in ("UserPromptSubmit", "Stop"):
+        entries = hooks.get(name)
+        if not isinstance(entries, list):
+            continue
+        kept = [e for e in entries if MARK not in json.dumps(e)]
+        removed += len(entries) - len(kept)
+        if kept:
+            hooks[name] = kept
+        else:
+            hooks.pop(name, None)
+    if not hooks:
+        data.pop("hooks", None)
+    settings.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return removed
+
+
+def skill_text(python: str, pythonpath: str | None, out: str) -> str:
+    prefix = f"PYTHONPATH={pythonpath} " if pythonpath else ""
+    return f"""---
+name: {SKILL_NAME}
+description: Shadow-mode status from inside the session - the ledger's counts and both denominators, per admitted task with every attempt, and the capture file's size. Read-only; never starts a replay. Use when the user asks /shadow, "shadow status", "what did my local model manage", or "how many episodes are captured".
+---
+
+# /shadow: shadow-mode status without leaving the session
+
+Run this and show the output verbatim in a fenced block, then one or two
+sentences of reading. Counts before rates; never invent a percentage the
+report withholds.
+
+```
+{prefix}{python} -m xyntetik_runner.shadow report --out {out} --tasks
+```
+
+Then the capture that accumulates from the prompt and stop hooks (only the
+user's own requests, directories, times and commit ids):
+
+```
+{prefix}{python} -m xyntetik_runner.shadow capture --summary
+```
+
+Never run `replay`, `optimize`, `bank` or `import` from this command; they
+are long-running and belong to a deliberate session. If the user wants one,
+name the command and its cost and let them start it.
+"""
+
+
+def codex_prompt_text(python: str, pythonpath: str | None, out: str) -> str:
+    prefix = f"PYTHONPATH={pythonpath} " if pythonpath else ""
+    return f"""Shadow-mode status, read-only, without leaving this session.
+
+Run and show verbatim:
+{prefix}{python} -m xyntetik_runner.shadow report --out {out} --tasks
+{prefix}{python} -m xyntetik_runner.shadow capture --summary
+
+Counts before rates; never invent a percentage the report withholds. Do not
+run replay, optimize, bank or import from here; they are long-running and
+belong to a deliberate session.
+"""
+
+
+def install(home: Path, *, python: str = sys.executable, pythonpath: str | None = None,
+            out: str = "~/.xyntetik/shadow", claude: bool = True, codex: bool = True) -> Installed:
+    settings = skill = prompt = None
+    added = 0
+    if claude:
+        settings = home / ".claude" / "settings.json"
+        added = install_claude_hooks(settings, python=python, pythonpath=pythonpath)
+        skill = home / ".claude" / "skills" / SKILL_NAME / "SKILL.md"
+        skill.parent.mkdir(parents=True, exist_ok=True)
+        skill.write_text(skill_text(python, pythonpath, out), encoding="utf-8")
+    if codex:
+        prompt = home / ".codex" / "prompts" / f"{SKILL_NAME}.md"
+        prompt.parent.mkdir(parents=True, exist_ok=True)
+        prompt.write_text(codex_prompt_text(python, pythonpath, out), encoding="utf-8")
+    return Installed(settings=settings, claude_skill=skill, codex_prompt=prompt, hooks_added=added)
+
+
+def uninstall(home: Path) -> Installed:
+    settings = home / ".claude" / "settings.json"
+    removed = uninstall_claude_hooks(settings)
+    skill = home / ".claude" / "skills" / SKILL_NAME / "SKILL.md"
+    prompt = home / ".codex" / "prompts" / f"{SKILL_NAME}.md"
+    for p in (skill, prompt):
+        if p.is_file():
+            p.unlink()
+    if skill.parent.is_dir() and not any(skill.parent.iterdir()):
+        skill.parent.rmdir()
+    return Installed(settings=settings if settings.is_file() else None, claude_skill=None,
+                     codex_prompt=None, hooks_added=-removed)

--- a/python/tests/test_shadow_pipeline.py
+++ b/python/tests/test_shadow_pipeline.py
@@ -421,3 +421,44 @@ def test_edit_file_replaces_one_exact_occurrence(tmp_path: Path) -> None:
     chat = scripted({"content": "", "tool_calls": [call("edit_file", path="a.py", old_text="x = 1\ny = 3", new_text="x = 0\ny = 0"), call("finish")]})
     r = attempt("t", ws, chat)
     assert r.finished and (tmp_path / "a.py").read_text(encoding="utf-8") == "x = 0\ny = 0\nx = 1\n"
+
+
+def test_install_is_explicit_idempotent_and_reversible(tmp_path: Path, capsys: Any) -> None:
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    settings = home / ".claude" / "settings.json"
+    settings.write_text(json.dumps({"model": "x", "hooks": {"Stop": [{"hooks": [
+        {"type": "command", "command": "echo mine"}]}]}}), encoding="utf-8")
+    assert main(["install", "--home", str(home), "--python", "py", "--pythonpath", "/src",
+                 "--out", "/o"]) == 0
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert data["model"] == "x", "existing settings survive"
+    stop = data["hooks"]["Stop"]
+    assert stop[0]["hooks"][0]["command"] == "echo mine", "existing hooks survive"
+    assert "capture --event stop 2>/dev/null || true" in stop[1]["hooks"][0]["command"]
+    assert "PYTHONPATH=/src py -m" in data["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"]
+    assert settings.with_suffix(".json.bak-shadow").is_file()
+    skill = home / ".claude" / "skills" / "shadow" / "SKILL.md"
+    prompt = home / ".codex" / "prompts" / "shadow.md"
+    assert "report --out /o --tasks" in skill.read_text(encoding="utf-8")
+    assert "Never run `replay`" in skill.read_text(encoding="utf-8")
+    assert "capture --summary" in prompt.read_text(encoding="utf-8")
+    # idempotent
+    assert main(["install", "--home", str(home), "--python", "py"]) == 0
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert len(data["hooks"]["Stop"]) == 2 and len(data["hooks"]["UserPromptSubmit"]) == 1
+    # reversible: exactly what install wrote, nothing else
+    assert main(["uninstall", "--home", str(home)]) == 0
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert data["hooks"] == {"Stop": [{"hooks": [{"type": "command", "command": "echo mine"}]}]}
+    assert not skill.exists() and not prompt.exists()
+    out = capsys.readouterr().out
+    assert "2 hook(s) added" in out and "removed 2 hook(s)" in out
+
+
+def test_capture_summary_counts_the_file(tmp_path: Path, capsys: Any) -> None:
+    cap = tmp_path / "c.jsonl"
+    cap.write_text('{"event":"prompt","session_id":"a","heads":{"/r":"x"}}\n{"event":"stop","session_id":"a"}\n'
+                   '{"event":"prompt","session_id":"b","heads":{}}\n', encoding="utf-8")
+    assert main(["capture", "--summary", "--file", str(cap)]) == 0
+    assert "3 lines, 2 prompts, 1 with repository heads, 2 sessions" in capsys.readouterr().out


### PR DESCRIPTION
One command merges the two capture hooks into the Claude Code user settings (backup, idempotent), writes a /shadow skill that shows the ledger and the capture summary from inside a session, and a /shadow prompt for Codex (no prompt-time hook there). uninstall reverses exactly that. 101 Python tests, mypy strict clean.