### PR TITLE
shadow: adapt (overnight adaptation, held-out gate) and the model pick at --shadow-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ names that were true when they were written.
 
 ## Unreleased
 
+- **`shadow adapt`: overnight adaptation from the ledger, kept only on a
+  held-out verified rise.** The data is the repository's own commits at
+  the function unit (the prompt is the request, the visible tests and the
+  function before the fix; the completion is the function after it),
+  rendered through the model's own chat template read from the GGUF
+  header (ChatML and Llama 3; others are refused, since the prompt at
+  training must match the prompt at serving). Every unit is self-checked
+  first: the human's function spliced over the pre-state must be verified.
+  A seeded slice is held out; the run serves the base, evaluates, trains
+  through `--train`, serves the adapter with `--lora`, evaluates again, and
+  keeps the adapter only if the held-out verified count rises; a rise on
+  the training slice alone is reported as memorization. Runs are recorded
+  under `~/.xyntetik/shadow/adapters/`, a kept adapter is served by the
+  next delegation, and the `/shadow` skill and prompt offer the run as an
+  explicit, confirmed action that shows its plan first.
+- **`--shadow-mode` without `-m` proposes a model.** It looks for GGUF
+  files under the usual directories, asks `--fit` about each at the
+  offload context, prints what it looked at, and proposes the largest
+  that fits; with none fitting it installs without a model and says so.
+
 - **`runner --shadow-mode -m MODEL`: shadow mode as a runner command, with
   the harness offload it enables.** The binary finds the stdlib-only
   Python client beside itself (`python/src`, now carried in the release

--- a/README.md
+++ b/README.md
@@ -1807,6 +1807,33 @@ verdict for you to apply with `git apply`; the working tree is never
 touched and nothing is applied silently. You keep your harness and your
 frontier model; the runner takes what the evidence says it can.
 
+Without `-m`, `--shadow-mode` looks for GGUF files under the usual
+directories, asks the runner's own `--fit` about each, and proposes the
+largest that fits at the offload context; the list it looked at is
+printed, and `-m` always wins.
+
+The ledger can also improve the local model, overnight and only where it
+can be proven. `/shadow` can show the plan for an adaptation run and,
+once you say so in your own words, start it:
+
+```sh
+python -m xyntetik_runner.shadow adapt --dry-run   # the plan, nothing trained
+python -m xyntetik_runner.shadow adapt --yes       # hours; the log path is printed
+python -m xyntetik_runner.shadow adapt --status    # every run and its verdict
+```
+
+The data is the repository's own commits, never a frontier transcript:
+for every admitted task whose fix changed one function, the prompt is
+the request, the visible tests and that function before the fix, the
+completion is the function after it, and the human's own function is
+spliced back and verified before the task is used at all. A seeded slice
+is held out and never trained on. The run evaluates base and adapter on
+it with the protected tests and keeps the adapter only if the held-out
+verified count rises; a rise on the training slice alone is reported as
+memorization and discarded. A kept adapter is served by the next
+delegation by itself, through `--lora`; every run, kept or not, is
+recorded with its numbers.
+
 To measure first, the bench runs the models on your disk against your own
 repository's history:
 

--- a/python/README.md
+++ b/python/README.md
@@ -95,6 +95,10 @@ The negative controls that prove the verifier can fail live in
   --request ...`: one bounded attempt on a detached worktree at HEAD, the
   repository's tests on the copy, the diff as a patch file, the verdict; starts
   the configured runner when no `--endpoint` is given.
+- `adapt`: overnight adaptation from the ledger's own commits at the function
+  unit; base and adapter evaluated on a held-out slice with the protected
+  tests, the adapter kept only on a held-out verified rise; `--dry-run` shows
+  the plan, `--status` the recorded runs.
 - `install`: `shadow install [--pythonpath P] [--out DIR]` merges the two capture
   hooks into `~/.claude/settings.json`, writes the `/shadow` skill and the Codex
   `/shadow` prompt; `uninstall` reverses exactly that; `capture --summary` counts

--- a/python/src/xyntetik_runner/shadow/adapt.py
+++ b/python/src/xyntetik_runner/shadow/adapt.py
@@ -1,0 +1,544 @@
+"""Overnight adaptation from the ledger: the repository's own commits as
+verified-SFT data, trained through the runner's adapter path, promoted only
+when the held-out verified count rises.
+
+The ledger never holds frontier content, so the only completions it can
+offer are the human's commits. The unit is the function: for a task whose
+fix changed exactly one function or method, the prompt is the request, the
+visible tests at the pre-state and that function's source at the pre-state,
+rendered through the model's own chat template; the completion is the same
+function at the solution commit. A whole source file does not fit a
+training window (a 40k-token module is ordinary), a function does.
+
+Every unit is self-checked before it is used: the human's function, spliced
+over the pre-state span, must be verified by the protected tests, or the
+unit is dropped. Evaluation splices the model's function the same way and
+the verifier judges the whole tree, so "verified" here means the same as
+everywhere else in shadow mode: the frozen tests pass and nothing else
+broke.
+
+The gate is the held-out slice, seeded and never trained on. The adapter
+is kept when its held-out verified count is higher than the base's on the
+same tasks and samples; a rise on the development slice alone is
+memorization and is reported as such. Nothing here decides for the user:
+`adapt` prints its plan and runs only when told to.
+"""
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import os
+import random
+import re
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from .baseline import Baseline
+from .tasks import RepairTask, classify, touched_files
+from .verifier import ProtectedTests, fixed_ids, verify
+
+SYSTEM = ("You are a software engineer. You receive a change request, the tests, and the "
+          "current source of one function. Output the complete new source of that function "
+          "and nothing else: no explanation, no code fence, no other code.")
+CHARS_PER_TOKEN = 4.2  # measured 4.6 to 4.7 on code with the Qwen2.5 tokenizer; kept conservative
+MIN_UNITS = 2  # one to train on, one to hold out; anything less has no gate
+_HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+# ---------------------------------------------------------------- GGUF header
+
+_GGUF_SCALARS = {0: "B", 1: "b", 2: "H", 3: "h", 4: "I", 5: "i", 6: "f", 7: "?", 10: "Q",
+                 11: "q", 12: "d"}
+
+
+def gguf_meta(path: Path, *, keys: Sequence[str] = ("general.architecture",
+                                                     "tokenizer.chat_template")) -> dict[str, Any]:
+    """Scalar metadata from a GGUF header, without reading the tensors. Arrays
+    are stepped over, so the vocabulary costs a walk and no memory."""
+    want = set(keys)
+    out: dict[str, Any] = {}
+    with open(path, "rb") as f:
+        def take(n: int) -> bytes:
+            b = f.read(n)
+            if len(b) != n:
+                raise ValueError("truncated GGUF header")
+            return b
+
+        def string() -> str:
+            n = struct.unpack("<Q", take(8))[0]
+            return take(n).decode("utf-8", "replace")
+
+        def value(t: int) -> Any:
+            if t == 8:
+                return string()
+            if t == 9:
+                et = struct.unpack("<I", take(4))[0]
+                n = struct.unpack("<Q", take(8))[0]
+                for _ in range(n):
+                    value(et)
+                return None
+            fmt = _GGUF_SCALARS.get(t)
+            if fmt is None:
+                raise ValueError(f"unknown GGUF value type {t}")
+            return struct.unpack("<" + fmt, take(struct.calcsize(fmt)))[0]
+
+        if take(4) != b"GGUF":
+            raise ValueError("not a GGUF file")
+        version = struct.unpack("<I", take(4))[0]
+        if version < 2:
+            raise ValueError(f"GGUF version {version} is not supported")
+        _n_tensors, n_kv = struct.unpack("<QQ", take(16))
+        for _ in range(n_kv):
+            key = string()
+            t = struct.unpack("<I", take(4))[0]
+            v = value(t)
+            if key in want:
+                out[key] = v
+            if want <= set(out):
+                break
+    return out
+
+
+def template_family(chat_template: str) -> str | None:
+    """The chat-template family this module can render byte for byte as the
+    runner renders it, or None. Training prompts must match serving."""
+    if "<|im_start|>" in chat_template:
+        return "chatml"
+    if "<|start_header_id|>" in chat_template:
+        return "llama3"
+    return None
+
+
+def render_prompt(family: str, system: str, user: str) -> str:
+    if family == "chatml":
+        return (f"<|im_start|>system\n{system}<|im_end|>\n<|im_start|>user\n{user}<|im_end|>\n"
+                f"<|im_start|>assistant\n")
+    if family == "llama3":
+        return (f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{system}<|eot_id|>"
+                f"<|start_header_id|>user<|end_header_id|>\n\n{user}<|eot_id|>"
+                f"<|start_header_id|>assistant<|end_header_id|>\n\n")
+    raise ValueError(f"no renderer for template family {family!r}")
+
+
+# ---------------------------------------------------------------- the unit
+
+@dataclass(frozen=True)
+class FunctionUnit:
+    task_id: str
+    rel: str
+    name: str
+    base_span: tuple[int, int]
+    base_fn: str
+    sol_fn: str
+
+
+def _git(repo: str, *args: str) -> str:
+    return subprocess.run(["git", "-C", repo, *args], capture_output=True, text=True,
+                          encoding="utf-8", errors="replace").stdout
+
+
+def function_spans(text: str) -> dict[str, tuple[int, int]]:
+    """Qualified name to (first line including decorators, last line)."""
+    out: dict[str, tuple[int, int]] = {}
+    tree = ast.parse(text)
+
+    def walk(node: ast.AST, prefix: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                name = prefix + child.name
+                if not isinstance(child, ast.ClassDef) and child.end_lineno:
+                    first = min([d.lineno for d in child.decorator_list] + [child.lineno])
+                    out[name] = (first, child.end_lineno)
+                walk(child, name + ".")
+            else:
+                walk(child, prefix)
+    walk(tree, "")
+    return out
+
+
+def function_unit(task: RepairTask) -> FunctionUnit | str:
+    """The one changed function of a single-file fix, or why there is none."""
+    if task.src_files != 1:
+        return f"{task.src_files} source files"
+    files = touched_files(Path(task.repo), [task.solution_sha])
+    _, src, _ = classify(files)
+    if len(src) != 1:
+        return f"{len(src)} source files in the range"
+    rel = src[0]
+    base_text = _git(task.repo, "show", f"{task.base_sha}:{rel}")
+    sol_text = _git(task.repo, "show", f"{task.solution_sha}:{rel}")
+    if not base_text or not sol_text:
+        return "file absent in a state"
+    try:
+        base_spans, sol_spans = function_spans(base_text), function_spans(sol_text)
+    except SyntaxError:
+        return "syntax error in a state"
+    ranges: list[tuple[int, int]] = []
+    for line in _git(task.repo, "diff", "-U0", task.base_sha, task.solution_sha, "--", rel).split("\n"):
+        m = _HUNK.match(line)
+        if m:
+            start = int(m.group(1))
+            count = int(m.group(2)) if m.group(2) is not None else 1
+            ranges.append((start, start + max(count, 1) - 1))
+    if not ranges:
+        return "no hunks"
+    sol_lines = sol_text.split("\n")
+    owners: set[str] = set()
+    for a, b in ranges:
+        inside = [(n, s) for n, s in sol_spans.items() if s[0] <= a and b <= s[1]]
+        if not inside:
+            probe = sol_lines[a - 1] if 0 < a <= len(sol_lines) else ""
+            if probe.startswith(("import ", "from ")):
+                continue  # an import the fix needed; the self-check decides whether it mattered
+            return f"lines {a}-{b} outside any function"
+        owners.add(min(inside, key=lambda x: x[1][1] - x[1][0])[0])
+    if len(owners) != 1:
+        return f"{len(owners)} functions changed"
+    name = owners.pop()
+    if name not in base_spans:
+        return f"{name} is new at the solution"
+    b0, b1 = base_spans[name]
+    s0, s1 = sol_spans[name]
+    base_fn = "\n".join(base_text.split("\n")[b0 - 1:b1])
+    sol_fn = "\n".join(sol_lines[s0 - 1:s1])
+    if base_fn == sol_fn:
+        return "function text identical (change was elsewhere)"
+    return FunctionUnit(task.task_id, rel, name, (b0, b1), base_fn, sol_fn)
+
+
+def unit_prompt(task: RepairTask, u: FunctionUnit, *, test_chars: int = 6000) -> str:
+    visible = "".join(_git(task.repo, "show", f"{task.base_sha}:{vt}")[:test_chars]
+                      for vt in task.visible_test_files)
+    return (f"Change request:\n{task.request.strip()}\n\nCurrent tests ({', '.join(task.visible_test_files)}):\n"
+            f"{visible}\n\nCurrent source of {u.name} in {u.rel}:\n{u.base_fn}\n\n"
+            f"Output the complete new source of {u.name}.")
+
+
+def splice(text: str, span: tuple[int, int], new_fn: str) -> str:
+    lines = text.split("\n")
+    return "\n".join(lines[:span[0] - 1] + new_fn.rstrip("\n").split("\n") + lines[span[1]:])
+
+
+def strip_fence(text: str) -> str:
+    m = re.search(r"```(?:python)?\n(.*?)```", text, re.S)
+    return m.group(1) if m else text
+
+
+def _worktree(task: RepairTask) -> Path:
+    d = Path(tempfile.mkdtemp(prefix="xyntetik-shadow-adapt-"))
+    proc = subprocess.run(["git", "-C", task.repo, "worktree", "add", "--detach", "-q", str(d),
+                           task.base_sha], capture_output=True, text=True)
+    if proc.returncode != 0:
+        shutil.rmtree(d, ignore_errors=True)
+        raise RuntimeError(f"git worktree add failed: {proc.stderr.strip()[:200]}")
+    return d
+
+
+def _drop(task: RepairTask, d: Path) -> None:
+    subprocess.run(["git", "-C", task.repo, "worktree", "remove", "--force", str(d)],
+                   capture_output=True)
+    shutil.rmtree(d, ignore_errors=True)
+
+
+@dataclass(frozen=True)
+class Judgement:
+    verified: bool
+    fixed: int
+    failing: int
+    reasons: tuple[str, ...]
+
+
+def judge(task: RepairTask, u: FunctionUnit, new_fn: str, *, python: str,
+          timeout_s: float = 600.0) -> Judgement:
+    """Splice ``new_fn`` over the unit's pre-state span in a scratch worktree
+    and let the protected verifier judge the whole tree."""
+    base_text = _git(task.repo, "show", f"{task.base_sha}:{u.rel}")
+    protected = ProtectedTests.load(Path(task.protected_dir))
+    ws = _worktree(task)
+    try:
+        baseline = Baseline.capture(ws)
+        (ws / u.rel).write_text(splice(base_text, u.base_span, new_fn), encoding="utf-8")
+        outcome = verify(ws, protected, baseline, timeout_s=timeout_s, python=python,
+                         pythonpath=task.pythonpath)
+        fixed = fixed_ids(protected, task.failing_at_base, ws, timeout_s=timeout_s, python=python,
+                          pythonpath=task.pythonpath) \
+            if outcome.passed is not None and task.failing_at_base else ()
+    finally:
+        _drop(task, ws)
+    return Judgement(outcome.passed is True, len(fixed), len(task.failing_at_base),
+                     tuple(outcome.reasons))
+
+
+# ---------------------------------------------------------------- dataset
+
+def split(tasks: Sequence[RepairTask], *, holdout_fraction: float, seed: int
+          ) -> tuple[list[RepairTask], list[RepairTask]]:
+    """Development and held-out slices, seeded; the held-out slice is never
+    trained on. The same rule the scaffold optimizer uses."""
+    order = list(tasks)
+    random.Random(seed).shuffle(order)
+    k = max(1, int(round(len(order) * holdout_fraction))) if len(order) > 1 else 0
+    return order[k:], order[:k]
+
+
+@dataclass
+class Dataset:
+    family: str
+    ctx: int
+    examples: list[dict[str, object]]
+    dev: list[tuple[RepairTask, FunctionUnit]]
+    holdout: list[tuple[RepairTask, FunctionUnit]]
+    dropped: list[dict[str, str]] = field(default_factory=list)
+
+    def manifest(self) -> dict[str, Any]:
+        return {"schema": "xyntetik.shadow.adapt.v1", "unit": "function", "family": self.family,
+                "ctx": self.ctx, "chars_per_token": CHARS_PER_TOKEN,
+                "system_sha256": hashlib.sha256(SYSTEM.encode()).hexdigest(),
+                "dev": [{"task_id": t.task_id, "function": u.name, "rel": u.rel} for t, u in self.dev],
+                "holdout": [{"task_id": t.task_id, "function": u.name, "rel": u.rel}
+                            for t, u in self.holdout],
+                "dropped": self.dropped, "examples": len(self.examples)}
+
+    def write(self, out: Path) -> Path:
+        out.mkdir(parents=True, exist_ok=True)
+        data = "".join(json.dumps(e) + "\n" for e in self.examples)
+        (out / "train.jsonl").write_text(data, encoding="utf-8")
+        man = self.manifest()
+        man["train_sha256"] = hashlib.sha256(data.encode("utf-8")).hexdigest()
+        (out / "manifest.json").write_text(json.dumps(man, indent=2) + "\n", encoding="utf-8")
+        return out / "train.jsonl"
+
+
+def build_dataset(tasks: Sequence[RepairTask], *, family: str, ctx: int, python: str,
+                  seed: int = 0, holdout_fraction: float = 0.3,
+                  log: Callable[[str], None] = lambda s: None) -> Dataset:
+    """Units for every task that has one and whose human function passes the
+    self-check, split into development and held-out; the development units
+    that fit the window become training examples."""
+    units: list[tuple[RepairTask, FunctionUnit]] = []
+    dropped: list[dict[str, str]] = []
+    for task in tasks:
+        u = function_unit(task)
+        if isinstance(u, str):
+            dropped.append({"task_id": task.task_id, "why": u})
+            continue
+        j = judge(task, u, u.sol_fn, python=python)
+        if not j.verified:
+            dropped.append({"task_id": task.task_id,
+                            "why": "the human's function alone is not verified: " + "; ".join(j.reasons)})
+            continue
+        units.append((task, u))
+        log(f"  unit {task.task_id} {u.name} (self-check verified)")
+    by_id = {t.task_id: (t, u) for t, u in units}
+    dev_t, hold_t = split([t for t, _ in units], holdout_fraction=holdout_fraction, seed=seed)
+    dev = [by_id[t.task_id] for t in dev_t]
+    holdout = [by_id[t.task_id] for t in hold_t]
+    budget = int(ctx * CHARS_PER_TOKEN) - 64
+    examples: list[dict[str, object]] = []
+    kept: list[tuple[RepairTask, FunctionUnit]] = []
+    for task, u in dev:
+        prompt = render_prompt(family, SYSTEM, unit_prompt(task, u))
+        if len(prompt) + len(u.sol_fn) > budget:
+            dropped.append({"task_id": task.task_id,
+                            "why": f"{len(prompt) + len(u.sol_fn)} chars over the {budget} window budget"})
+            continue
+        examples.append({"prompt": prompt, "completion": u.sol_fn, "weight": 1.0})
+        kept.append((task, u))
+    return Dataset(family, ctx, examples, kept, holdout, dropped)
+
+
+# ---------------------------------------------------------------- evaluation
+
+@dataclass
+class Evaluation:
+    label: str
+    k: int
+    tasks: list[dict[str, Any]]
+
+    @property
+    def verified_samples(self) -> int:
+        return sum(1 for t in self.tasks for s in t["samples"] if s["verified"])
+
+    @property
+    def verified_tasks(self) -> int:
+        return sum(1 for t in self.tasks if any(s["verified"] for s in t["samples"]))
+
+    @property
+    def samples(self) -> int:
+        return sum(len(t["samples"]) for t in self.tasks)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"label": self.label, "k": self.k, "tasks": self.tasks,
+                "summary": {"tasks": len(self.tasks), "samples": self.samples,
+                            "verified_samples": self.verified_samples,
+                            "verified_tasks": self.verified_tasks}}
+
+
+def evaluate(units: Sequence[tuple[RepairTask, FunctionUnit]],
+             post_json: Callable[[str, dict[str, Any]], dict[str, Any]], model: str, *,
+             label: str, k: int, python: str, temperature: float = 0.8, max_tokens: int = 1500,
+             log: Callable[[str], None] = lambda s: None) -> Evaluation:
+    """K samples per unit through the served model, each spliced and judged."""
+    rows: list[dict[str, Any]] = []
+    for task, u in units:
+        messages = [{"role": "system", "content": SYSTEM},
+                    {"role": "user", "content": unit_prompt(task, u)}]
+        samples: list[dict[str, Any]] = []
+        for i in range(k):
+            t0 = time.monotonic()
+            resp = post_json("/v1/chat/completions", {
+                "model": model, "messages": messages, "max_tokens": max_tokens,
+                "temperature": temperature, "seed": 1000 + i})
+            text = str((resp.get("choices") or [{}])[0].get("message", {}).get("content") or "")
+            wall = time.monotonic() - t0
+            new_fn = strip_fence(text)
+            j = judge(task, u, new_fn, python=python)
+            samples.append({"i": i, "verified": j.verified, "fixed": j.fixed, "failing": j.failing,
+                            "gen_wall_s": round(wall, 2), "chars": len(new_fn),
+                            "completion_sha256": hashlib.sha256(new_fn.encode("utf-8")).hexdigest()})
+            log(f"  {label} {task.task_id} {u.name} sample {i}: verified {j.verified}, "
+                f"fixed {j.fixed}/{j.failing}, {wall:.0f}s")
+        rows.append({"task_id": task.task_id, "function": u.name, "samples": samples})
+    return Evaluation(label, k, rows)
+
+
+# ---------------------------------------------------------------- training
+
+@dataclass(frozen=True)
+class TrainResult:
+    adapter: Path
+    steps: int
+    returncode: int
+    log: Path
+    first_step_s: float | None
+    loss_first: float | None
+    loss_last: float | None
+
+
+def train(runner: str, model: str, data: Path, adapter: Path, *, ctx: int, steps: int, lr: float,
+          rank: int, threads: int, log_path: Path, gpu: bool = True,
+          log: Callable[[str], None] = lambda s: None) -> TrainResult:
+    """One `runner --train` run, its stderr kept in ``log_path``. The GPU
+    switch is safe on every build: without CUDA the runner says so and
+    trains on the CPU, and the adapter bytes do not depend on it."""
+    args = [runner, "-m", model, "--gpu", "off", "--train", str(data), "--train-ctx", str(ctx),
+            "--train-steps", str(steps), "--lr", str(lr), "--lora-rank", str(rank),
+            "--train-out", str(adapter)]
+    if threads > 0:
+        args += ["-t", str(threads)]
+    env = dict(os.environ)
+    env["RUNNER_TRAIN_GPU"] = "1" if gpu else "0"
+    env["RUNNER_TRAIN_PROF"] = "1"
+    first_step: float | None = None
+    loss_first: float | None = None
+    loss_last: float | None = None
+    with open(log_path, "w", encoding="utf-8") as lf:
+        proc = subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, env=env,
+                                text=True, encoding="utf-8", errors="replace")
+        assert proc.stderr is not None
+        for line in proc.stderr:
+            lf.write(line)
+            lf.flush()
+            if line.startswith("{") and '"step"' in line:
+                try:
+                    rec = json.loads(line)
+                except ValueError:
+                    continue
+                if first_step is None:
+                    first_step = float(rec.get("step_s") or 0)
+                    loss_first = float(rec.get("loss") or 0)
+                    log(f"  step 1: {rec.get('tokens')} tokens in {first_step:.0f}s; "
+                        f"{steps} steps is about {first_step * steps / 3600:.1f} h")
+                loss_last = float(rec.get("loss") or 0)
+                log(f"  step {rec.get('step')}/{steps}: loss {loss_last:.4f}, {rec.get('step_s')}s")
+        rc = proc.wait()
+    return TrainResult(adapter, steps, rc, log_path, first_step, loss_first, loss_last)
+
+
+# ---------------------------------------------------------------- verdict
+
+@dataclass(frozen=True)
+class Verdict:
+    promoted: bool
+    holdout_base: int
+    holdout_adapter: int
+    dev_base: int
+    dev_adapter: int
+    reason: str
+
+
+def decide(base_hold: Evaluation, ada_hold: Evaluation, base_dev: Evaluation,
+           ada_dev: Evaluation) -> Verdict:
+    hb, ha = base_hold.verified_samples, ada_hold.verified_samples
+    db, da = base_dev.verified_samples, ada_dev.verified_samples
+    if ha > hb:
+        return Verdict(True, hb, ha, db, da,
+                       f"held-out verified rose {hb} -> {ha} of {ada_hold.samples} samples")
+    if da > db:
+        return Verdict(False, hb, ha, db, da,
+                       f"held-out verified {hb} -> {ha}, development {db} -> {da}: a rise on the "
+                       "training slice alone is memorization, not kept")
+    return Verdict(False, hb, ha, db, da, f"held-out verified {hb} -> {ha}: no rise, not kept")
+
+
+def adapters_dir(home: Path) -> Path:
+    return home / ".xyntetik" / "shadow" / "adapters"
+
+
+def record_run(home: Path, stamp: str, *, dataset: Dataset, base_hold: Evaluation,
+               ada_hold: Evaluation, base_dev: Evaluation, ada_dev: Evaluation,
+               trained: TrainResult, verdict: Verdict, model: str) -> Path:
+    d = adapters_dir(home) / stamp
+    d.mkdir(parents=True, exist_ok=True)
+    if trained.adapter.is_file() and trained.adapter.parent != d:
+        shutil.copyfile(trained.adapter, d / "adapter.gguf")
+    record = {
+        "schema": "xyntetik.shadow.adapt.run.v1", "stamp": stamp, "model": model,
+        "model_sha256": _sha256(Path(model)) if Path(model).is_file() else "",
+        "dataset": dataset.manifest(),
+        "training": {"steps": trained.steps, "returncode": trained.returncode,
+                     "first_step_s": trained.first_step_s, "loss_first": trained.loss_first,
+                     "loss_last": trained.loss_last, "log": str(trained.log)},
+        "base_holdout": base_hold.to_dict(), "adapter_holdout": ada_hold.to_dict(),
+        "base_dev": base_dev.to_dict(), "adapter_dev": ada_dev.to_dict(),
+        "verdict": asdict(verdict),
+        "adapter": str(d / "adapter.gguf") if (d / "adapter.gguf").is_file() else "",
+    }
+    (d / "run.json").write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+    return d
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def render_status(home: Path) -> str:
+    runs = sorted(p for p in adapters_dir(home).glob("*/run.json")) if adapters_dir(home).is_dir() else []
+    if not runs:
+        return "no adaptation runs yet"
+    lines = ["| run | model | examples | held-out verified base -> adapter | development | kept |",
+             "|---|---|---:|---|---|---|"]
+    for p in runs:
+        try:
+            r = json.loads(p.read_text(encoding="utf-8"))
+        except ValueError:
+            continue
+        v = r.get("verdict", {})
+        lines.append(f"| {r.get('stamp')} | {Path(str(r.get('model'))).name} | "
+                     f"{r.get('dataset', {}).get('examples')} | "
+                     f"{v.get('holdout_base')} -> {v.get('holdout_adapter')} | "
+                     f"{v.get('dev_base')} -> {v.get('dev_adapter')} | "
+                     f"{'yes' if v.get('promoted') else 'no'} |")
+    return "\n".join(lines)

--- a/python/src/xyntetik_runner/shadow/cli.py
+++ b/python/src/xyntetik_runner/shadow/cli.py
@@ -37,7 +37,9 @@ from xyntetik_runner.shadow.evidence import (
     summarize,
 )
 from xyntetik_runner.shadow.importer import CAPTURE_FILE, Episode, read_episodes, scan_all, write_episodes
-from xyntetik_runner.shadow.install import harness_present, install, read_config, uninstall
+from xyntetik_runner.shadow import adapt
+from xyntetik_runner.shadow.install import (harness_present, install, read_config, render_candidates,
+                                            set_config_adapter, suggest_model, uninstall)
 from xyntetik_runner.shadow.routes import delegate, render_routes, route_table
 from xyntetik_runner.shadow.bank import build_bank
 from xyntetik_runner.shadow.optimize import (
@@ -595,18 +597,31 @@ def cmd_install(args: argparse.Namespace) -> int:
     has_claude, has_codex = harness_present(home)
     claude = not args.no_claude and (has_claude or args.claude)
     codex = not args.no_codex and (has_codex or args.codex)
+    if not (claude or codex):
+        print("nothing to install: neither ~/.claude nor ~/.codex exists here "
+              "(pass --claude or --codex to force)", file=sys.stderr)
+        return 2
     plan = []
     if claude:
         plan.append(f"Claude Code: prompt and stop capture hooks merged into {home / '.claude' / 'settings.json'} "
                     "(backup beside it) and a /shadow skill")
     if codex:
         plan.append(f"Codex: a /shadow prompt under {home / '.codex' / 'prompts'}")
+    picked = ""
     if args.model:
         plan.append(f"model for offloading: {args.model} (served by {args.runner} when asked)")
-    if not plan:
-        print("nothing to install: neither ~/.claude nor ~/.codex exists here "
-              "(pass --claude or --codex to force)", file=sys.stderr)
-        return 2
+    elif not args.no_pick:
+        best, cands = suggest_model(args.runner, home, ctx=args.ctx)
+        if best is not None:
+            picked = str(best.path)
+            plan.append(f"model for offloading: {picked} (found on disk, the largest that fits at "
+                        f"ctx {args.ctx} by 'runner --fit'; pass -m to choose another)")
+        else:
+            plan.append("no model for offloading yet: " + ("none of the GGUF files found fits at "
+                        f"ctx {args.ctx}" if cands else "no GGUF file found") +
+                        "; run 'runner --shadow-mode -m MODEL.gguf' later")
+        print("models looked at:")
+        print(render_candidates(cands))
     print("shadow mode will write:")
     for line in plan:
         print(f"  - {line}")
@@ -625,7 +640,7 @@ def cmd_install(args: argparse.Namespace) -> int:
             print("not installed")
             return 1
     done = install(home, python=args.python, pythonpath=args.pythonpath or None, out=args.out,
-                   claude=claude, codex=codex, model=args.model, runner=args.runner, ctx=args.ctx,
+                   claude=claude, codex=codex, model=args.model or picked, runner=args.runner, ctx=args.ctx,
                    gpu=args.gpu, threads=args.threads)
     if done.config:
         print(f"config: {done.config}")
@@ -665,11 +680,15 @@ def cmd_delegate(args: argparse.Namespace) -> int:
                 return 2
             ctx = int(str(cfg.get("ctx") or 8192))
             threads = int(str(cfg.get("threads") or 0))
+            adapter = str(cfg.get("adapter") or "")
+            extra = ("--lora", adapter) if adapter and Path(adapter).is_file() else ()
             launch = ServerLaunch(executable=str(cfg.get("runner") or "runner"), model=model_path,
                                   port=_free_port(), context_size=ctx,
-                                  gpu=str(cfg.get("gpu") or "auto"), threads=threads or None)
+                                  gpu=str(cfg.get("gpu") or "auto"), threads=threads or None,
+                                  extra_args=extra)
             managed = ManagedRunner(launch)
-            print(f"starting {launch.executable} with {Path(model_path).name} ...", flush=True)
+            print(f"starting {launch.executable} with {Path(model_path).name}"
+                  f"{' + adapter ' + Path(adapter).name if extra else ''} ...", flush=True)
             if not managed.start(timeout=args.start_timeout):
                 print("error: the runner did not start; check the model path and 'runner --fit'",
                       file=sys.stderr)
@@ -701,6 +720,143 @@ def cmd_delegate(args: argparse.Namespace) -> int:
     if d.changed_paths:
         print(f"apply with: git apply {d.patch_path}   (your call; the working tree is untouched)")
     return 0 if d.tests_exit == 0 else 1
+
+
+def _serve_for(cfg: dict[str, object], model_path: str, *, extra: tuple[str, ...],
+               start_timeout: float, request_timeout: float) -> tuple[ManagedRunner, RunnerEndpoint]:
+    launch = ServerLaunch(executable=str(cfg.get("runner") or "runner"), model=model_path,
+                          port=_free_port(), context_size=int(str(cfg.get("ctx") or 8192)),
+                          gpu=str(cfg.get("gpu") or "auto"),
+                          threads=int(str(cfg.get("threads") or 0)) or None, extra_args=extra)
+    managed = ManagedRunner(launch)
+    if not managed.start(timeout=start_timeout):
+        raise RuntimeError("the runner did not start; check the model path and 'runner --fit'")
+    return managed, RunnerEndpoint(managed.base_url, timeout=request_timeout)
+
+
+def cmd_adapt(args: argparse.Namespace) -> int:
+    home = Path(args.home) if args.home else Path.home()
+    if args.status:
+        print(adapt.render_status(home))
+        return 0
+    cfg = read_config(home)
+    model_path = str(args.model or cfg.get("model") or "")
+    runner = str(args.runner or cfg.get("runner") or "runner")
+    if not model_path:
+        print("error: no model in the shadow config; run 'runner --shadow-mode -m MODEL.gguf' first",
+              file=sys.stderr)
+        return 2
+    if not Path(model_path).is_file():
+        print(f"error: model not found: {model_path}", file=sys.stderr)
+        return 2
+    try:
+        meta = adapt.gguf_meta(Path(model_path))
+    except (OSError, ValueError) as e:
+        print(f"error: cannot read the model header: {e}", file=sys.stderr)
+        return 2
+    family = adapt.template_family(str(meta.get("tokenizer.chat_template") or ""))
+    if family is None:
+        print("error: this model's chat template is not one adapt can render for training "
+              "(ChatML or Llama 3); the prompt at training must match the prompt at serving",
+              file=sys.stderr)
+        return 2
+    tasks: list[RepairTask] = []
+    for d in [Path(args.out).expanduser()] + [Path(b).expanduser() for b in args.bank.split(",") if b]:
+        if (d / "tasks").is_dir():
+            tasks += _tasks(d, None)
+    tasks = [t for t in tasks if t.baseline_failing <= args.max_failing and t.baseline_failing < t.expected_tests]
+    if not tasks:
+        print("error: no admitted tasks under --out or --bank; capture work or run 'shadow bank'",
+              file=sys.stderr)
+        return 2
+    log = lambda s: print(s, flush=True)  # noqa: E731
+    print(f"{len(tasks)} task(s); model {Path(model_path).name} ({family} template); "
+          f"self-checking the function units ...", flush=True)
+    ds = adapt.build_dataset(tasks, family=family, ctx=args.ctx, python=args.python, seed=args.seed,
+                             holdout_fraction=args.holdout_fraction, log=log)
+    n_units = len(ds.dev) + len(ds.holdout)
+    print(f"units: {n_units} (development {len(ds.dev)}, held out {len(ds.holdout)}); "
+          f"examples: {len(ds.examples)}; dropped: {len(ds.dropped)}")
+    for dropped in ds.dropped:
+        print(f"  drop {dropped['task_id']}: {dropped['why']}")
+    if n_units < adapt.MIN_UNITS or not ds.examples or not ds.holdout:
+        print(f"too few units to adapt: at least {adapt.MIN_UNITS} verified function units are "
+              "needed, one to train on and one to hold out; the bench and captured work add units")
+        return 1
+    steps = args.epochs * len(ds.examples)
+    print(f"plan: train {len(ds.examples)} example(s) for {steps} step(s) (rank {args.rank}, "
+          f"lr {args.lr}, ctx {args.ctx}); evaluate base and adapter on {len(ds.holdout)} held-out "
+          f"unit(s) with K {args.k}; keep the adapter only if held-out verified rises")
+    if args.dry_run:
+        print("dry run: nothing trained")
+        return 0
+    if not args.yes:
+        if not sys.stdin.isatty():
+            print("error: not a terminal; pass --yes to confirm", file=sys.stderr)
+            return 2
+        if input("Start the adaptation run now? [y/N] ").strip().lower() not in ("y", "yes"):
+            print("not started")
+            return 1
+    stamp = _now().replace(":", "").replace("-", "")[:15]
+    run_dir = adapt.adapters_dir(home) / stamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+    data = ds.write(run_dir)
+    print(f"run: {run_dir}", flush=True)
+    managed: ManagedRunner | None = None
+    try:
+        print("serving the base for its evaluation ...", flush=True)
+        managed, endpoint = _serve_for(cfg | {"runner": runner}, model_path, extra=(),
+                                       start_timeout=args.start_timeout,
+                                       request_timeout=args.request_timeout)
+        model_id = _served_model(endpoint)
+        base_hold = adapt.evaluate(ds.holdout, endpoint.post_json, model_id, label="base held-out",
+                                   k=args.k, python=args.python, log=log)
+        base_dev = adapt.evaluate(ds.dev, endpoint.post_json, model_id, label="base development",
+                                  k=args.k, python=args.python, log=log)
+        managed.stop()
+        managed = None
+        print(f"base: held-out {base_hold.verified_samples}/{base_hold.samples} verified, "
+              f"development {base_dev.verified_samples}/{base_dev.samples}", flush=True)
+        adapter = run_dir / "adapter.gguf"
+        print(f"training {steps} step(s); log {run_dir / 'train.log'} ...", flush=True)
+        trained = adapt.train(runner, model_path, data, adapter, ctx=args.ctx, steps=steps, lr=args.lr,
+                              rank=args.rank, threads=args.threads, log_path=run_dir / "train.log",
+                              gpu=not args.cpu_train, log=log)
+        if trained.returncode != 0 or not adapter.is_file():
+            print(f"error: training failed (exit {trained.returncode}); see {trained.log}",
+                  file=sys.stderr)
+            return 2
+        print("serving the adapter for its evaluation ...", flush=True)
+        managed, endpoint = _serve_for(cfg | {"runner": runner}, model_path,
+                                       extra=("--lora", str(adapter)),
+                                       start_timeout=args.start_timeout,
+                                       request_timeout=args.request_timeout)
+        model_id = _served_model(endpoint)
+        ada_hold = adapt.evaluate(ds.holdout, endpoint.post_json, model_id, label="adapter held-out",
+                                  k=args.k, python=args.python, log=log)
+        ada_dev = adapt.evaluate(ds.dev, endpoint.post_json, model_id, label="adapter development",
+                                 k=args.k, python=args.python, log=log)
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    finally:
+        if managed is not None:
+            managed.stop()
+    verdict = adapt.decide(base_hold, ada_hold, base_dev, ada_dev)
+    adapt.record_run(home, stamp, dataset=ds, base_hold=base_hold, ada_hold=ada_hold, base_dev=base_dev,
+                     ada_dev=ada_dev, trained=trained, verdict=verdict, model=model_path)
+    if verdict.promoted:
+        set_config_adapter(home, str(adapter))
+        print(f"kept: {verdict.reason}; the next delegation serves {adapter}")
+    else:
+        print(f"not kept: {verdict.reason}; recorded under {run_dir}")
+    return 0
+
+
+def _served_model(endpoint: RunnerEndpoint) -> str:
+    caps = endpoint.capabilities()
+    models = [m.get("id") for m in caps.get("models", []) if isinstance(m, dict)]
+    return str(models[0]) if models else "model"
 
 
 def cmd_uninstall(args: argparse.Namespace) -> int:
@@ -855,6 +1011,7 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--ctx", type=int, default=8192)
     p.add_argument("--gpu", default="auto")
     p.add_argument("--threads", type=int, default=0)
+    p.add_argument("--no-pick", action="store_true", help="without -m, do not look for a model on disk")
     p.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
     p.add_argument("--dry-run", action="store_true", help="print what would be written")
     p.set_defaults(fn=cmd_install)
@@ -876,6 +1033,31 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--start-timeout", type=float, default=600.0)
     p.add_argument("--json", action="store_true")
     p.set_defaults(fn=cmd_delegate)
+    p = sub.add_parser("adapt", help="overnight: train the configured model's adapter on the ledger's "
+                                     "own commits, keep it only on a held-out verified rise")
+    p.add_argument("--out", default=str(DEFAULT_OUT))
+    p.add_argument("--bank", default=str(DEFAULT_OUT.parent / "shadow-bank"),
+                   help="comma-separated task directories to add (the bench bank)")
+    p.add_argument("--home", default="")
+    p.add_argument("--model", default="", help="default: the shadow config's model")
+    p.add_argument("--runner", default="", help="default: the shadow config's runner")
+    p.add_argument("--python", default=sys.executable)
+    p.add_argument("--ctx", type=int, default=4096, help="training window")
+    p.add_argument("--epochs", type=int, default=3)
+    p.add_argument("--lr", type=float, default=1e-4)
+    p.add_argument("--rank", type=int, default=8)
+    p.add_argument("--threads", type=int, default=0)
+    p.add_argument("--k", type=int, default=4, help="samples per unit in each evaluation")
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--holdout-fraction", type=float, default=0.3)
+    p.add_argument("--max-failing", type=int, default=30)
+    p.add_argument("--cpu-train", action="store_true", help="do not ask for the GPU training path")
+    p.add_argument("--start-timeout", type=float, default=600.0)
+    p.add_argument("--request-timeout", type=float, default=900.0)
+    p.add_argument("--dry-run", action="store_true", help="print the plan; train nothing")
+    p.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
+    p.add_argument("--status", action="store_true", help="list the recorded runs and their verdicts")
+    p.set_defaults(fn=cmd_adapt)
     p = sub.add_parser("uninstall", help="remove exactly what install wrote")
     p.add_argument("--home", default="")
     p.set_defaults(fn=cmd_uninstall)

--- a/python/src/xyntetik_runner/shadow/install.py
+++ b/python/src/xyntetik_runner/shadow/install.py
@@ -14,9 +14,11 @@ from __future__ import annotations
 
 import json
 import shutil
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Sequence
 
 MARK = "xyntetik_runner.shadow capture"
 SKILL_NAME = "shadow"
@@ -45,6 +47,86 @@ def write_config(home: Path, *, model: str, runner: str, ctx: int, gpu: str,
             "out": out}
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return path
+
+
+def set_config_adapter(home: Path, adapter: str) -> Path:
+    """Record (or clear, with "") the promoted adapter the offload serves."""
+    path = home / CONFIG_REL
+    data = read_config(home)
+    if adapter:
+        data["adapter"] = adapter
+    else:
+        data.pop("adapter", None)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+MODEL_DIRS = ("models", "Models", ".cache/lm-studio/models", ".lmstudio/models",
+              ".cache/huggingface/hub")
+
+
+@dataclass(frozen=True)
+class Candidate:
+    path: Path
+    size: int
+    verdict: str
+
+    @property
+    def fits(self) -> bool:
+        return self.verdict.startswith("FITS")
+
+
+def fit_verdict(runner: str, model: Path, ctx: int) -> str:
+    """The runner's own `--fit` verdict word(s) for ``model`` at ``ctx``, or
+    "unknown" when the runner could not be asked."""
+    try:
+        proc = subprocess.run([runner, "--fit", str(model), "-c", str(ctx)], capture_output=True,
+                              text=True, encoding="utf-8", errors="replace", timeout=60)
+    except (OSError, subprocess.TimeoutExpired):
+        return "unknown"
+    for line in (proc.stdout + proc.stderr).splitlines():
+        stripped = line.strip()
+        if stripped.startswith("verdict"):
+            rest = stripped[len("verdict"):].strip()
+            return rest.split(" \u2014 ")[0].split(" - ")[0].strip() or "unknown"
+    return "unknown"
+
+
+def find_models(home: Path, *, cwd: Path | None = None, dirs: Sequence[str] = MODEL_DIRS,
+                depth: int = 3) -> list[Path]:
+    """GGUF files under the usual places, largest first, no duplicates."""
+    roots = [home / d for d in dirs] + ([cwd] if cwd else [])
+    seen: dict[tuple[int, int], tuple[Path, int]] = {}
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*.gguf"):
+            if len(path.relative_to(root).parts) > depth or not path.is_file():
+                continue
+            # one entry per file: ~/models and ~/Models are the same directory
+            # on a case-folding filesystem, and both are looked at
+            st = path.stat()
+            key = (st.st_dev, st.st_ino)
+            if key not in seen:
+                seen[key] = (path, st.st_size)
+    return [q for q, _ in sorted(seen.values(), key=lambda v: -v[1])]
+
+
+def suggest_model(runner: str, home: Path, *, ctx: int = 8192, cwd: Path | None = None
+                  ) -> tuple[Candidate | None, list[Candidate]]:
+    """The largest GGUF on disk the runner says fits at ``ctx``, and every
+    candidate it looked at. The first thing the flow needs is a model that
+    fits; the bench decides which one is any good."""
+    cands = [Candidate(m, m.stat().st_size, fit_verdict(runner, m, ctx)) for m in find_models(home, cwd=cwd)]
+    fitting = [c for c in cands if c.fits]
+    return (fitting[0] if fitting else None), cands
+
+
+def render_candidates(cands: Sequence[Candidate]) -> str:
+    if not cands:
+        return "no GGUF files found under " + ", ".join("~/" + d for d in MODEL_DIRS)
+    return "\n".join(f"  {c.path.name}  {c.size / 2**30:.1f} GiB  {c.verdict}" for c in cands)
 
 
 def read_config(home: Path) -> dict[str, object]:
@@ -164,6 +246,30 @@ and never applied silently.
    `git apply <patch>`; the user applies it, you do not. If they failed,
    say so and continue with the frontier model as usual.
 
+## Adapt overnight (only when the user asks for it, always confirmed)
+
+The ledger's admitted tasks and the bench bank hold the repository's own
+commits; `adapt` trains the configured model's adapter on the ones whose
+fix changed one function, evaluates base and adapter on a held-out slice
+with the protected tests, and keeps the adapter only if the held-out
+verified count rises. It runs for hours. Never start it on your own.
+
+1. Show the plan and nothing else:
+   ```
+   {prefix}{python} -m xyntetik_runner.shadow adapt --out {out} --dry-run
+   ```
+   It prints the units, how many are held out, and the examples. If it
+   says there are too few units, say so; the bench (`shadow bench`) and
+   more captured work are what add units.
+2. Only after the user confirms in their own words, start it:
+   ```
+   {prefix}{python} -m xyntetik_runner.shadow adapt --out {out} --yes
+   ```
+   and tell them where the log is. When it finishes, show
+   `{prefix}{python} -m xyntetik_runner.shadow adapt --status`
+   verbatim. A kept adapter is served by the next delegation by itself; a
+   discarded one is still recorded, with its numbers.
+
 Never run `replay`, `optimize`, `bank` or `import` from this command; they
 are long-running and belong to a deliberate session.
 """
@@ -188,6 +294,17 @@ touched), runs the repository's tests there, and prints the verdict, the
 diff and a patch path. Show both; if the tests passed offer `git apply
 <patch>` and let the user apply it; if they failed, say so and continue
 with the frontier model. If no class qualifies, say so and offer the bench.
+
+Adapt overnight (only when the user asks, always confirmed): show the plan
+{prefix}{python} -m xyntetik_runner.shadow adapt --out {out} --dry-run
+(units from the repository's own commits, the held-out count, the
+examples). Only after the user confirms in their own words, start
+{prefix}{python} -m xyntetik_runner.shadow adapt --out {out} --yes
+which trains the configured model's adapter for hours, evaluates base and
+adapter on the held-out slice with the protected tests, and keeps the
+adapter only if held-out verified rises. Afterwards show
+{prefix}{python} -m xyntetik_runner.shadow adapt --status
+verbatim. A kept adapter is served by the next delegation by itself.
 
 Do not run replay, optimize, bank or import from here; they are long-running
 and belong to a deliberate session.

--- a/python/tests/test_shadow_adapt.py
+++ b/python/tests/test_shadow_adapt.py
@@ -1,0 +1,276 @@
+"""`shadow adapt`: the ledger's own commits as verified-SFT data at the
+function unit, the held-out gate, and the model pick at install. No model:
+the served endpoint is scripted, training is a stand-in that writes an
+adapter file, and the verifier is the real one on real scratch worktrees."""
+from __future__ import annotations
+
+import json
+import os
+import struct
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from xyntetik_runner.shadow import adapt
+from xyntetik_runner.shadow.cli import main
+from xyntetik_runner.shadow.importer import Episode
+from xyntetik_runner.shadow.install import (Candidate, fit_verdict, read_config, suggest_model,
+                                            write_config)
+from xyntetik_runner.shadow.tasks import RepairTask, admit
+
+FIXTURE = Path(__file__).parent / "fixtures" / "repair_task_v1"
+BUGGY = (FIXTURE / "workspace" / "calc" / "money.py").read_text(encoding="utf-8")
+VISIBLE = (FIXTURE / "workspace" / "tests" / "test_money.py").read_text(encoding="utf-8")
+SOLUTION_TESTS = (FIXTURE / "protected" / "tests" / "test_money.py").read_text(encoding="utf-8")
+# a fix that lives entirely inside the function: no import, so the unit is the whole change
+CORRECT_FN = '''def parse_amount(text: str) -> int:
+    """Return the amount in integer cents for a decimal money string."""
+    cleaned = "".join(ch for ch in text if ch.isdigit() or ch in "-.")
+    whole, _, frac = cleaned.partition(".")
+    sign = -1 if whole.startswith("-") else 1
+    whole = whole.lstrip("-") or "0"
+    return sign * (int(whole) * 100 + int((frac + "00")[:2]))'''
+CORRECT = '"""Money parsing for the ledger importer."""\n\n\n' + CORRECT_FN + "\n"
+BUGGY_FN = BUGGY.split("\n\n\n", 1)[1].rstrip("\n")
+
+
+def git(repo: Path, *args: str, date: str = "2026-09-01T12:00:00+00:00") -> str:
+    env = {**os.environ, "GIT_AUTHOR_DATE": date, "GIT_COMMITTER_DATE": date,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@x", "GIT_COMMITTER_NAME": "t",
+           "GIT_COMMITTER_EMAIL": "t@x"}
+    return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True,
+                          env=env, check=True).stdout.strip()
+
+
+def make_repo(root: Path, name: str, *, tag: str) -> Path:
+    """Buggy at 11:00, fixed inside parse_amount at 12:00; ``tag`` varies the
+    content so two repositories do not share commit ids."""
+    r = root / name
+    (r / "calc").mkdir(parents=True)
+    (r / "tests").mkdir()
+    git(root, "init", "-q", "-b", "main", str(r))
+    (r / "calc" / "__init__.py").write_text(f"# {tag}\n", encoding="utf-8")
+    (r / "calc" / "money.py").write_text(BUGGY, encoding="utf-8")
+    (r / "tests" / "test_money.py").write_text(VISIBLE, encoding="utf-8")
+    git(r, "add", "-A")
+    git(r, "commit", "-q", "-m", "buggy", date="2026-09-01T11:00:00+00:00")
+    (r / "calc" / "money.py").write_text(CORRECT, encoding="utf-8")
+    (r / "tests" / "test_money.py").write_text(SOLUTION_TESTS, encoding="utf-8")
+    git(r, "add", "-A")
+    git(r, "commit", "-q", "-m", "fix parse_amount", date="2026-09-01T12:00:00+00:00")
+    return r
+
+
+def admitted(root: Path, out: Path, names: tuple[str, ...]) -> list[RepairTask]:
+    tasks = []
+    for i, name in enumerate(names):
+        repo = make_repo(root, name, tag=name)
+        ep = Episode(source="claude_code", session_id=f"s{i}", turn=1, cwd=str(repo),
+                     started_at="2026-09-01T11:30:00Z", ended_at="2026-09-01T12:10:00Z",
+                     request="make parse_amount handle thousands separators, currency and rounding",
+                     request_sha256=str(i) * 64)
+        t = admit(ep, out_dir=out, python=sys.executable)
+        assert isinstance(t, RepairTask), t
+        tasks.append(t)
+    return tasks
+
+
+def write_gguf(path: Path, kvs: list[tuple[str, Any]]) -> None:
+    """A GGUF v3 header with no tensors: strings, a uint32 and one string array."""
+    def s(x: str) -> bytes:
+        b = x.encode("utf-8")
+        return struct.pack("<Q", len(b)) + b
+    body = b""
+    for k, v in kvs:
+        body += s(k)
+        if isinstance(v, str):
+            body += struct.pack("<I", 8) + s(v)
+        elif isinstance(v, int):
+            body += struct.pack("<I", 4) + struct.pack("<I", v)
+        else:
+            body += struct.pack("<I", 9) + struct.pack("<I", 8) + struct.pack("<Q", len(v))
+            for item in v:
+                body += s(item)
+    path.write_bytes(b"GGUF" + struct.pack("<I", 3) + struct.pack("<QQ", 0, len(kvs)) + body)
+
+
+def test_gguf_header_and_template_family(tmp_path: Path) -> None:
+    m = tmp_path / "m.gguf"
+    write_gguf(m, [("general.architecture", "qwen2"), ("qwen2.block_count", 28),
+                   ("tokenizer.ggml.tokens", ["<|im_start|>", "a", "b"]),
+                   ("tokenizer.chat_template", "{% for m in messages %}<|im_start|>{{ m.role }}\n{{ m.content }}<|im_end|>\n{% endfor %}")])
+    meta = adapt.gguf_meta(m)
+    assert meta["general.architecture"] == "qwen2"
+    assert adapt.template_family(str(meta["tokenizer.chat_template"])) == "chatml"
+    assert adapt.template_family("<|start_header_id|>system<|end_header_id|>") == "llama3"
+    assert adapt.template_family("[INST] {{ x }} [/INST]") is None
+    assert adapt.render_prompt("chatml", "S", "U") == "<|im_start|>system\nS<|im_end|>\n<|im_start|>user\nU<|im_end|>\n<|im_start|>assistant\n"
+    with pytest.raises(ValueError):
+        adapt.gguf_meta(tmp_path / "not.gguf") if (tmp_path / "not.gguf").write_bytes(b"nope") else None
+
+
+def test_function_unit_self_check_and_split(tmp_path: Path) -> None:
+    out = tmp_path / "out"
+    (out / "tasks").mkdir(parents=True)
+    tasks = admitted(tmp_path, out / "tasks", ("alpha", "beta"))
+    u = adapt.function_unit(tasks[0])
+    assert isinstance(u, adapt.FunctionUnit), u
+    assert u.name == "parse_amount" and u.rel == "calc/money.py" and u.base_fn == BUGGY_FN
+    assert u.sol_fn == CORRECT_FN
+    # the human's function alone is verified; the buggy one is not
+    assert adapt.judge(tasks[0], u, u.sol_fn, python=sys.executable).verified
+    j = adapt.judge(tasks[0], u, u.base_fn, python=sys.executable)
+    assert not j.verified and j.fixed == 0 and j.failing >= 1
+    ds = adapt.build_dataset(tasks, family="chatml", ctx=4096, python=sys.executable)
+    assert len(ds.dev) == 1 and len(ds.holdout) == 1 and len(ds.examples) == 1 and not ds.dropped
+    ex = ds.examples[0]
+    assert str(ex["prompt"]).startswith("<|im_start|>system\n") and str(ex["prompt"]).endswith("<|im_start|>assistant\n")
+    assert "Current source of parse_amount in calc/money.py" in str(ex["prompt"])
+    assert ex["completion"] == CORRECT_FN and ex["weight"] == 1.0
+    # a task whose fix is not one function is named, not silently dropped
+    two = tmp_path / "gamma"
+    make_repo(tmp_path, "gamma", tag="g")
+    (two / "calc" / "money.py").write_text(CORRECT + "\n\ndef other() -> int:\n    return 1\n", encoding="utf-8")
+    git(two, "commit", "-q", "-am", "more", date="2026-09-01T12:30:00+00:00")
+    ep = Episode(source="claude_code", session_id="s9", turn=1, cwd=str(two),
+                 started_at="2026-09-01T11:30:00Z", ended_at="2026-09-01T12:40:00Z",
+                 request="x", request_sha256="9" * 64)
+    t3 = admit(ep, out_dir=out / "tasks", python=sys.executable)
+    if isinstance(t3, RepairTask):
+        why = adapt.function_unit(t3)
+        assert isinstance(why, str) and ("functions changed" in why or "outside any function" in why or "new at the solution" in why)
+
+
+def test_adapt_end_to_end_keeps_the_adapter_only_on_a_held_out_rise(tmp_path: Path, capsys: Any, monkeypatch: Any) -> None:
+    from xyntetik_runner.shadow import cli
+    home = tmp_path / "home"
+    out = tmp_path / "out"
+    (out / "tasks").mkdir(parents=True)
+    admitted(tmp_path, out / "tasks", ("alpha", "beta"))
+    model = tmp_path / "coder.gguf"
+    write_gguf(model, [("tokenizer.chat_template", "<|im_start|>x")])
+    write_config(home, model=str(model), runner="fake-runner", ctx=4096, gpu="auto", threads=0, out=str(out))
+    served: dict[str, Any] = {"lora": False}
+
+    class FakeManaged:
+        def __init__(self, launch: Any, **k: Any) -> None:
+            served["lora"] = "--lora" in launch.extra_args
+            served["extra"] = launch.extra_args
+            self.base_url = "http://fake"
+
+        def start(self, **k: Any) -> bool:
+            return True
+
+        def stop(self, **k: Any) -> None:
+            pass
+
+    behaviour = {"adapter_answer": CORRECT_FN}
+
+    class FakeEndpoint:
+        def __init__(self, url: str, **k: Any) -> None:
+            pass
+
+        def capabilities(self, **k: Any) -> dict[str, Any]:
+            return {"models": [{"id": "coder.gguf"}]}
+
+        def post_json(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+            assert path == "/v1/chat/completions" and payload["messages"][0]["content"] == adapt.SYSTEM
+            answer = behaviour["adapter_answer"] if served["lora"] else BUGGY_FN
+            return {"choices": [{"message": {"content": "```python\n" + answer + "\n```"}}]}
+
+    def fake_train(runner: str, model_path: str, data: Path, adapter: Path, **k: Any) -> adapt.TrainResult:
+        assert runner == "fake-runner" and Path(data).is_file()
+        lines = Path(data).read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1 and json.loads(lines[0])["completion"] == CORRECT_FN
+        adapter.write_bytes(b"GGUF-adapter")
+        return adapt.TrainResult(adapter, k["steps"], 0, k["log_path"], 12.5, 0.5, 0.1)
+    monkeypatch.setattr(cli, "ManagedRunner", FakeManaged)
+    monkeypatch.setattr(cli, "RunnerEndpoint", FakeEndpoint)
+    monkeypatch.setattr(adapt, "train", fake_train)
+    common = ["adapt", "--out", str(out), "--bank", "", "--home", str(home), "--python", sys.executable, "--k", "2"]
+    # the plan first, nothing trained
+    assert main(common + ["--dry-run"]) == 0
+    text = capsys.readouterr().out
+    assert "units: 2 (development 1, held out 1)" in text and "dry run: nothing trained" in text
+    assert not list(adapt.adapters_dir(home).glob("*")) if adapt.adapters_dir(home).is_dir() else True
+    # no terminal, no --yes: refused
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(""))
+    assert main(common) == 2
+    # the run: base answers the buggy function, the adapter the human's -> held-out rises -> kept
+    assert main(common + ["--yes"]) == 0
+    text = capsys.readouterr().out
+    assert "kept: held-out verified rose 0 -> 2 of 2 samples" in text, text
+    cfg = read_config(home)
+    assert Path(str(cfg["adapter"])).is_file() and served["extra"] == ("--lora", str(cfg["adapter"]))
+    runs = sorted(adapt.adapters_dir(home).glob("*/run.json"))
+    assert len(runs) == 1
+    rec = json.loads(runs[0].read_text(encoding="utf-8"))
+    assert rec["verdict"]["promoted"] is True and rec["base_holdout"]["summary"]["verified_samples"] == 0
+    assert rec["adapter_holdout"]["summary"]["verified_samples"] == 2 and rec["dataset"]["examples"] == 1
+    assert (runs[0].parent / "train.jsonl").is_file() and (runs[0].parent / "manifest.json").is_file()
+    # a second run whose adapter is no better is recorded and not kept; the config keeps the first
+    behaviour["adapter_answer"] = BUGGY_FN
+    assert main(common + ["--yes"]) == 0
+    text = capsys.readouterr().out
+    assert "not kept: held-out verified 0 -> 0: no rise" in text, text
+    assert read_config(home)["adapter"] == cfg["adapter"]
+    assert main(["adapt", "--home", str(home), "--status"]) == 0
+    status = capsys.readouterr().out
+    assert status.count("| yes |") == 1 and status.count("| no |") == 1
+    # delegate serves the kept adapter by itself
+    assert main(["delegate", "--repo", str(tmp_path / "alpha"), "--request", "x", "--home", str(home),
+                 "--python", sys.executable, "--max-turns", "1"]) in (0, 1)
+    assert served["lora"] is True
+
+
+def test_adapt_refuses_without_a_gate_or_a_renderable_template(tmp_path: Path, capsys: Any) -> None:
+    home = tmp_path / "home"
+    out = tmp_path / "out"
+    (out / "tasks").mkdir(parents=True)
+    admitted(tmp_path, out / "tasks", ("solo",))
+    model = tmp_path / "m.gguf"
+    write_gguf(model, [("tokenizer.chat_template", "<|im_start|>")])
+    write_config(home, model=str(model), runner="r", ctx=4096, gpu="auto", threads=0, out=str(out))
+    assert main(["adapt", "--out", str(out), "--bank", "", "--home", str(home), "--python", sys.executable, "--dry-run"]) == 1
+    assert "too few units to adapt" in capsys.readouterr().out
+    write_gguf(model, [("tokenizer.chat_template", "[INST]")])
+    assert main(["adapt", "--out", str(out), "--bank", "", "--home", str(home), "--python", sys.executable, "--dry-run"]) == 2
+    assert "chat template is not one adapt can render" in capsys.readouterr().err
+    assert "no adaptation runs yet" in adapt.render_status(home)
+
+
+def test_install_picks_the_largest_gguf_that_fits(tmp_path: Path, capsys: Any, monkeypatch: Any) -> None:
+    from xyntetik_runner.shadow import cli, install as inst
+    home = tmp_path / "home"
+    (home / ".codex").mkdir(parents=True)
+    (home / "models").mkdir()
+    (home / "models" / "small.gguf").write_bytes(b"0" * 10)
+    (home / "models" / "big.gguf").write_bytes(b"0" * 20)
+    (home / "models" / "huge.gguf").write_bytes(b"0" * 30)
+    verdicts = {"huge.gguf": "PAGES", "big.gguf": "FITS WITH --kv q8", "small.gguf": "FITS"}
+    monkeypatch.setattr(inst, "fit_verdict", lambda runner, m, ctx: verdicts[m.name])
+    best, cands = suggest_model("runner", home)
+    assert best is not None and best.path.name == "big.gguf" and [c.path.name for c in cands] == ["huge.gguf", "big.gguf", "small.gguf"]
+    monkeypatch.setattr(cli, "suggest_model", lambda runner, home, ctx=8192: suggest_model(runner, home, ctx=ctx))
+    assert main(["install", "--home", str(home), "--yes"]) == 0
+    text = capsys.readouterr().out
+    assert "big.gguf (found on disk" in text and "huge.gguf" in text and "PAGES" in text
+    assert read_config(home)["model"] == str((home / "models" / "big.gguf").resolve())
+    # nothing fits: installed without a model, said plainly
+    verdicts.update({"big.gguf": "PAGES", "small.gguf": "PAGES"})
+    home2 = tmp_path / "home2"
+    (home2 / ".codex").mkdir(parents=True)
+    (home2 / "models").mkdir()
+    (home2 / "models" / "small.gguf").write_bytes(b"0" * 10)
+    assert main(["install", "--home", str(home2), "--yes"]) == 0
+    text = capsys.readouterr().out
+    assert "no model for offloading yet: none of the GGUF files found fits" in text
+    assert read_config(home2) == {}
+    # the verdict parser reads the runner's own line
+    monkeypatch.setattr(inst.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(
+        a[0], 0, "fit: x\n  weights 1 GiB\n  verdict       FITS — 2.37 GiB to spare at ctx 8192\n", ""))
+    assert fit_verdict("runner", Path("x.gguf"), 8192) == "FITS"
+    assert Candidate(Path("x"), 1, "FITS WITH --kv q8").fits and not Candidate(Path("x"), 1, "PAGES").fits


### PR DESCRIPTION
## What

- \`shadow adapt\`: the ledger's own commits as verified-SFT data at the function unit, self-checked, seeded held-out slice, base and adapter evaluated with the protected tests, adapter kept only on a held-out verified rise (a training-slice rise alone is memorization). Runs recorded under \`~/.xyntetik/shadow/adapters/\`; a kept adapter is served by \`delegate\` through \`--lora\`. Template family read from the GGUF header (ChatML, Llama 3).
- \`--shadow-mode\` without \`-m\` proposes the largest GGUF on disk that \`--fit\` says fits, and prints what it looked at.
- Skill and prompt: an explicit, confirmed adapt action that shows its plan first.
- Tests: synthetic GGUF header, two function-only fix repositories, end-to-end adapt with a scripted endpoint and a stand-in trainer, the model pick. Client 111 green, mypy strict clean.

Filed as R14.5.6 and R15.2.2; the live probe (R15.2.1) is the first real run of this shape.