### PR TITLE
shadow: sync closes the loop the hooks feed; one warm runner shared across commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ names that were true when they were written.
 
 ## Unreleased
 
+- **`shadow sync` and a warm runner: the loop the hooks feed now
+  closes.** `sync` imports what the capture hooks recorded, admits the
+  replayable tasks, says how many wait for the configured model, and
+  with `--replay N` runs the next N against it; the `/shadow` skill and
+  prompt run it on every status and offer the replay as the user's to
+  start. `delegate`, `sync` and `adapt` share one runner that is started
+  detached with the runner's own idle unload and recorded in
+  `~/.xyntetik/shadow/server.json`; only a live runner whose pid and
+  model match is reused, `shadow server` lists it and `--stop` ends it,
+  and `uninstall` ends it too. `ServerLaunch.parent_pid` may now be
+  `None` for a child meant to outlive the process that started it.
+
 - **`shadow adapt`: overnight adaptation from the ledger, kept only on a
   held-out verified rise.** The data is the repository's own commits at
   the function unit (the prompt is the request, the visible tests and the

--- a/README.md
+++ b/README.md
@@ -1807,6 +1807,15 @@ verdict for you to apply with `git apply`; the working tree is never
 touched and nothing is applied silently. You keep your harness and your
 frontier model; the runner takes what the evidence says it can.
 
+The ledger fills through `sync`, which `/shadow` runs on every status:
+it imports what the hooks captured since last time, admits the tasks
+that can be replayed, and says how many wait for the local model. When
+you say so, `sync --replay N` runs the next N of them against the local
+model; nothing replays by itself. The runner these commands use stays
+warm between them, unloads by itself when idle, and is listed and ended
+by `shadow server`, so a second delegation a minute after the first does
+not pay the model load again.
+
 Without `-m`, `--shadow-mode` looks for GGUF files under the usual
 directories, asks the runner's own `--fit` about each, and proposes the
 largest that fits at the offload context; the list it looked at is

--- a/python/README.md
+++ b/python/README.md
@@ -95,6 +95,9 @@ The negative controls that prove the verifier can fail live in
   --request ...`: one bounded attempt on a detached worktree at HEAD, the
   repository's tests on the copy, the diff as a patch file, the verdict; starts
   the configured runner when no `--endpoint` is given.
+- `sync`: import what the hooks captured, admit the replayable tasks, count what
+  waits for the configured model, `--replay N` runs the next N; `server`: the
+  warm runner shadow mode keeps between commands (`--stop` ends it).
 - `adapt`: overnight adaptation from the ledger's own commits at the function
   unit; base and adapter evaluated on a held-out slice with the protected
   tests, the adapter kept only on a held-out verified rise; `--dry-run` shows

--- a/python/src/xyntetik_runner/process.py
+++ b/python/src/xyntetik_runner/process.py
@@ -114,7 +114,8 @@ class ServerLaunch:
     reserve_pct: int = 0
     threads: int | None = None
     gpu: str = "auto"
-    parent_pid: int = field(default_factory=os.getpid)
+    parent_pid: int | None = field(default_factory=os.getpid)
+    """None: no parent watch; the child outlives the process that started it."""
     ttl: int | None = None
     extra_args: tuple[str, ...] = ()
 
@@ -132,8 +133,9 @@ def build_server_args(launch: ServerLaunch) -> list[str]:
         "--port", str(launch.port),
         "-c", "0" if launch.reserve_pct > 0 else str(launch.context_size),
         "-m", model,
-        "--parent-pid", str(launch.parent_pid),
     ]
+    if launch.parent_pid is not None:
+        args += ["--parent-pid", str(launch.parent_pid)]
     if launch.reserve_pct > 0:
         args += ["--reserve", str(launch.reserve_pct)]
     if launch.threads is not None:

--- a/python/src/xyntetik_runner/shadow/cli.py
+++ b/python/src/xyntetik_runner/shadow/cli.py
@@ -41,6 +41,8 @@ from xyntetik_runner.shadow import adapt
 from xyntetik_runner.shadow.install import (harness_present, install, read_config, render_candidates,
                                             set_config_adapter, suggest_model, uninstall)
 from xyntetik_runner.shadow.routes import delegate, render_routes, route_table
+from xyntetik_runner.shadow.server import (DEFAULT_TTL, render_status as server_status, served_runner,
+                                           stop_server)
 from xyntetik_runner.shadow.bank import build_bank
 from xyntetik_runner.shadow.optimize import (
     TaskOutcome,
@@ -128,12 +130,20 @@ def _read_records(path: Path) -> list[EpisodeEvidence]:
 
 
 def cmd_import(args: argparse.Namespace) -> int:
-    out = Path(args.out)
+    do_import(Path(args.out), home=Path(args.home) if args.home else None, source=args.source,
+              python=args.python, timeout=args.timeout)
+    return 0
+
+
+def do_import(out: Path, *, home: Path | None, source: str = "", python: str = sys.executable,
+              timeout: float = 600.0) -> int:
+    """Scan the harness traces and the capture file, pair, choose, build the
+    tasks; returns how many were admitted this time."""
     out.mkdir(parents=True, exist_ok=True)
     tasks_dir = out / "tasks"
     tasks_dir.mkdir(exist_ok=True)
-    report = scan_all(Path(args.home) if args.home else None)
-    episodes = [e for e in report.episodes if not args.source or e.source == args.source]
+    report = scan_all(home)
+    episodes = [e for e in report.episodes if not source or e.source == source]
     n = write_episodes(episodes, out / "episodes.jsonl")
     print(f"scanned {report.files_read} trace files ({len(report.files_skipped)} unreadable), "
           f"{n} episodes", flush=True)
@@ -177,7 +187,7 @@ def cmd_import(args: argparse.Namespace) -> int:
             continue
         built.add(c.episode.episode_id)
         result = build_task(c.episode, c.repo, list(c.shas), out_dir=tasks_dir,
-                            python=args.python, timeout_s=args.timeout)
+                            python=python, timeout_s=timeout)
         if isinstance(result, RepairTask):
             admitted += 1
             counts["admitted"] = counts.get("admitted", 0) + 1
@@ -192,7 +202,7 @@ def cmd_import(args: argparse.Namespace) -> int:
         record(c.episode, result)
     print("dispositions at import:", json.dumps(counts, sort_keys=True), flush=True)
     print(f"{admitted} task(s) admitted under {tasks_dir}", flush=True)
-    return 0
+    return admitted
 
 
 def _tasks(out: Path, only: str | None) -> list[RepairTask]:
@@ -668,32 +678,17 @@ def cmd_routes(args: argparse.Namespace) -> int:
 def cmd_delegate(args: argparse.Namespace) -> int:
     home = Path(args.home) if args.home else Path.home()
     cfg = read_config(home)
-    managed: ManagedRunner | None = None
     try:
         if args.endpoint:
             endpoint = RunnerEndpoint(args.endpoint, timeout=args.request_timeout)
         else:
-            model_path = str(args.model or cfg.get("model") or "")
-            if not model_path:
-                print("error: no --endpoint and no model in the shadow config; run "
-                      "'runner --shadow-mode -m MODEL.gguf' first", file=sys.stderr)
-                return 2
-            ctx = int(str(cfg.get("ctx") or 8192))
-            threads = int(str(cfg.get("threads") or 0))
-            adapter = str(cfg.get("adapter") or "")
-            extra = ("--lora", adapter) if adapter and Path(adapter).is_file() else ()
-            launch = ServerLaunch(executable=str(cfg.get("runner") or "runner"), model=model_path,
-                                  port=_free_port(), context_size=ctx,
-                                  gpu=str(cfg.get("gpu") or "auto"), threads=threads or None,
-                                  extra_args=extra)
-            managed = ManagedRunner(launch)
-            print(f"starting {launch.executable} with {Path(model_path).name}"
-                  f"{' + adapter ' + Path(adapter).name if extra else ''} ...", flush=True)
-            if not managed.start(timeout=args.start_timeout):
-                print("error: the runner did not start; check the model path and 'runner --fit'",
-                      file=sys.stderr)
-                return 2
-            endpoint = RunnerEndpoint(managed.base_url, timeout=args.request_timeout)
+            endpoint, started = served_runner(home, cfg, model=args.model,
+                                              start_timeout=args.start_timeout,
+                                              request_timeout=args.request_timeout,
+                                              managed_factory=ManagedRunner,
+                                              endpoint_factory=RunnerEndpoint)
+            print(f"{'started' if started else 'reusing'} the runner at {endpoint.base_url} "
+                  f"(warm for {DEFAULT_TTL}s; 'shadow server --stop' ends it)", flush=True)
         caps = endpoint.capabilities()
         models = [m.get("id") for m in caps.get("models", []) if isinstance(m, dict)]
         model = str(models[0]) if models else "model"
@@ -703,9 +698,6 @@ def cmd_delegate(args: argparse.Namespace) -> int:
     except RuntimeError as e:
         print(f"error: {e}", file=sys.stderr)
         return 2
-    finally:
-        if managed is not None:
-            managed.stop()
     if args.json:
         print(d.to_json())
         return 0
@@ -797,6 +789,7 @@ def cmd_adapt(args: argparse.Namespace) -> int:
         if input("Start the adaptation run now? [y/N] ").strip().lower() not in ("y", "yes"):
             print("not started")
             return 1
+    stop_server(home)  # the warm runner holds the device the training needs
     stamp = _now().replace(":", "").replace("-", "")[:15]
     run_dir = adapt.adapters_dir(home) / stamp
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -853,6 +846,58 @@ def cmd_adapt(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_sync(args: argparse.Namespace) -> int:
+    """The loop the hooks feed: import what was captured, say how many tasks
+    wait for the configured model, and replay some of them when told to."""
+    home = Path(args.home) if args.home else Path.home()
+    out = Path(args.out).expanduser()
+    cfg = read_config(home)
+    model_path = str(args.model or cfg.get("model") or "")
+    admitted = do_import(out, home=home if args.home else None, python=args.python, timeout=args.timeout)
+    evidence = out / "evidence.jsonl"
+    records = _read_records(evidence)
+    sha = file_sha256(Path(model_path)) if model_path and Path(model_path).is_file() else ""
+    done = {r.episode_id for r in records if r.verifier is not None and r.identity.model_sha256 == sha}
+    waiting = [t for t in _tasks(out, None) if t.episode_id not in done]
+    name = Path(model_path).name if model_path else "(no model configured)"
+    print(f"sync: {admitted} task(s) admitted now; {len(waiting)} waiting for a replay with {name}")
+    if not args.replay or not waiting:
+        if waiting and model_path:
+            print(f"  'shadow sync --replay {min(len(waiting), 5)}' runs the next ones; each takes up to "
+                  f"{int(args.wall)}s and the fit probe runs first")
+        elif waiting:
+            print("  no model configured: run 'runner --shadow-mode -m MODEL.gguf' first")
+        print(render_routes(route_table(records)))
+        return 0
+    try:
+        endpoint, started = served_runner(home, cfg, model=args.model, start_timeout=args.start_timeout,
+                                          request_timeout=args.request_timeout,
+                                          managed_factory=ManagedRunner, endpoint_factory=RunnerEndpoint)
+        print(f"{'started' if started else 'reusing'} the runner at {endpoint.base_url}", flush=True)
+        opts = ReplayOptions(python=args.python, timeout=args.timeout, wall=args.wall,
+                             min_tps=args.min_tps, model_sha256=sha,
+                             quant=_quant_from_name(Path(model_path).name), limit=args.replay,
+                             endpoint_label=endpoint.base_url)
+        ran, _tps, _model = run_replay(out, endpoint, opts)
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    records = _read_records(evidence)
+    left = len(waiting) - ran
+    print(f"sync: {ran} replayed, {max(left, 0)} still waiting")
+    print(render_routes(route_table(records)))
+    return 0
+
+
+def cmd_server(args: argparse.Namespace) -> int:
+    home = Path(args.home) if args.home else Path.home()
+    if args.stop:
+        print("warm runner stopped" if stop_server(home) else "no warm runner was running")
+        return 0
+    print(server_status(home))
+    return 0
+
+
 def _served_model(endpoint: RunnerEndpoint) -> str:
     caps = endpoint.capabilities()
     models = [m.get("id") for m in caps.get("models", []) if isinstance(m, dict)]
@@ -861,6 +906,8 @@ def _served_model(endpoint: RunnerEndpoint) -> str:
 
 def cmd_uninstall(args: argparse.Namespace) -> int:
     home = Path(args.home) if args.home else Path.home()
+    if stop_server(home):
+        print("warm runner stopped")
     done = uninstall(home)
     print(f"removed {-done.hooks_added} hook(s), the /shadow skill and the codex prompt")
     return 0
@@ -1058,6 +1105,23 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
     p.add_argument("--status", action="store_true", help="list the recorded runs and their verdicts")
     p.set_defaults(fn=cmd_adapt)
+    p = sub.add_parser("sync", help="import what the hooks captured, count the tasks waiting for the "
+                                    "configured model, replay some when asked")
+    p.add_argument("--out", default=str(DEFAULT_OUT))
+    p.add_argument("--home", default="")
+    p.add_argument("--model", default="", help="default: the shadow config's model")
+    p.add_argument("--replay", type=int, default=0, help="replay up to N waiting tasks now")
+    p.add_argument("--python", default=sys.executable)
+    p.add_argument("--timeout", type=float, default=600.0)
+    p.add_argument("--wall", type=float, default=900.0)
+    p.add_argument("--min-tps", type=float, default=15.0)
+    p.add_argument("--start-timeout", type=float, default=600.0)
+    p.add_argument("--request-timeout", type=float, default=900.0)
+    p.set_defaults(fn=cmd_sync)
+    p = sub.add_parser("server", help="the warm runner shadow mode keeps for delegations")
+    p.add_argument("--home", default="")
+    p.add_argument("--stop", action="store_true")
+    p.set_defaults(fn=cmd_server)
     p = sub.add_parser("uninstall", help="remove exactly what install wrote")
     p.add_argument("--home", default="")
     p.set_defaults(fn=cmd_uninstall)

--- a/python/src/xyntetik_runner/shadow/install.py
+++ b/python/src/xyntetik_runner/shadow/install.py
@@ -217,9 +217,17 @@ sentences of reading. Counts before rates; never invent a percentage the
 report withholds.
 
 ```
+{prefix}{python} -m xyntetik_runner.shadow sync --out {out}
 {prefix}{python} -m xyntetik_runner.shadow report --out {out} --tasks
 {prefix}{python} -m xyntetik_runner.shadow capture --summary
 ```
+
+`sync` imports what the hooks captured since last time, admits the tasks
+that can be replayed, and says how many wait for the local model. If any
+wait, offer to replay them now: `sync --replay N` runs up to N of them
+against the local model (up to 15 minutes each, the fit probe first) and
+it is the user's to start, in their own words. That is how the ledger
+fills; nothing replays by itself.
 
 ## Offload a task to the local model (when the user asks for it)
 
@@ -239,9 +247,11 @@ and never applied silently.
    ```
    {prefix}{python} -m xyntetik_runner.shadow delegate --repo . --request "<the user's request, verbatim>"
    ```
-   It starts the runner with the configured model if none is running,
-   runs the bounded attempt, runs the repository's tests on the scratch
-   copy, and prints the verdict, the diff and a patch path.
+   It reuses the warm runner shadow mode keeps (or starts one, which
+   then stays warm and unloads by itself when idle; `shadow server`
+   shows it, `shadow server --stop` ends it), runs the bounded attempt,
+   runs the repository's tests on the scratch copy, and prints the
+   verdict, the diff and a patch path.
 3. Show the diff and the test verdict. If the tests passed, offer
    `git apply <patch>`; the user applies it, you do not. If they failed,
    say so and continue with the frontier model as usual.
@@ -281,8 +291,13 @@ def codex_prompt_text(python: str, pythonpath: str | None, out: str) -> str:
 
 Status (default): run and show verbatim, counts before rates, never a
 percentage the report withholds:
+{prefix}{python} -m xyntetik_runner.shadow sync --out {out}
 {prefix}{python} -m xyntetik_runner.shadow report --out {out} --tasks
 {prefix}{python} -m xyntetik_runner.shadow capture --summary
+sync imports what the hooks captured, admits the replayable tasks and says
+how many wait for the local model; if any wait, offer `sync --replay N`
+(up to 15 minutes each) and let the user start it in their own words.
+Nothing replays by itself.
 
 Offload a task to the local model (only when the user asks): first
 {prefix}{python} -m xyntetik_runner.shadow routes --out {out}
@@ -290,8 +305,9 @@ which says per task class whether the local model has verified successes.
 If the task's class qualifies:
 {prefix}{python} -m xyntetik_runner.shadow delegate --repo . --request "<the request verbatim>"
 runs a bounded attempt on a scratch worktree (the working tree is never
-touched), runs the repository's tests there, and prints the verdict, the
-diff and a patch path. Show both; if the tests passed offer `git apply
+touched) against the warm runner shadow mode keeps (`shadow server` shows
+it, `--stop` ends it), runs the repository's tests there, and prints the
+verdict, the diff and a patch path. Show both; if the tests passed offer `git apply
 <patch>` and let the user apply it; if they failed, say so and continue
 with the frontier model. If no class qualifies, say so and offer the bench.
 

--- a/python/src/xyntetik_runner/shadow/server.py
+++ b/python/src/xyntetik_runner/shadow/server.py
@@ -1,0 +1,158 @@
+"""One warm runner for shadow mode, shared by every command that needs the
+configured model: `delegate`, `sync`, and the base half of `adapt`.
+
+Starting a runner costs a model load every time; a second delegation a
+minute after the first should not pay it again. The first command that
+needs the model starts a runner detached, with the runner's own idle
+unload (`--ttl`) and without a parent watch, and records where it is in
+``~/.xyntetik/shadow/server.json``. The next command asks that port for
+its capabilities; only a live runner whose pid and model match is reused,
+anything else is replaced. `shadow server --stop` ends it; so does
+`uninstall`. The user can always see what is running with `shadow server`.
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from xyntetik_runner.endpoint import RunnerEndpoint
+from xyntetik_runner.process import ManagedRunner, ServerLaunch
+
+STATE_REL = Path(".xyntetik") / "shadow" / "server.json"
+DEFAULT_TTL = 900
+
+
+@dataclass(frozen=True)
+class ServerState:
+    port: int
+    pid: int
+    model: str
+    adapter: str
+    runner: str
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+
+def read_state(home: Path) -> ServerState | None:
+    path = home / STATE_REL
+    if not path.is_file():
+        return None
+    try:
+        d = json.loads(path.read_text(encoding="utf-8"))
+        return ServerState(int(d["port"]), int(d["pid"]), str(d.get("model") or ""),
+                           str(d.get("adapter") or ""), str(d.get("runner") or ""))
+    except (ValueError, KeyError, TypeError):
+        return None
+
+
+def write_state(home: Path, state: ServerState) -> Path:
+    path = home / STATE_REL
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state.__dict__, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def clear_state(home: Path) -> None:
+    path = home / STATE_REL
+    if path.is_file():
+        path.unlink()
+
+
+def alive(state: ServerState, *, endpoint_factory: Any = None, timeout: float = 3.0) -> bool:
+    """True when the recorded runner answers on its port with its own pid
+    and the recorded model; a different process on that port is not ours."""
+    factory = endpoint_factory or RunnerEndpoint
+    try:
+        caps = factory(state.base_url).capabilities(timeout=timeout)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    if caps.get("pid") != state.pid:
+        return False
+    models = [m.get("id") for m in caps.get("models", []) if isinstance(m, dict)]
+    return bool(models) and str(models[0]) == Path(state.model).name
+
+
+def _free_port() -> int:
+    import socket
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def served_runner(home: Path, cfg: dict[str, object], *, runner: str = "", model: str = "",
+                  adapter: str | None = None, ttl: int = DEFAULT_TTL, start_timeout: float = 600.0,
+                  request_timeout: float = 900.0, managed_factory: Any = ManagedRunner,
+                  endpoint_factory: Any = RunnerEndpoint) -> tuple[RunnerEndpoint, bool]:
+    """An endpoint for the configured model: the warm runner when it is
+    alive and serving the same model and adapter, else a fresh one, started
+    detached and recorded. Returns (endpoint, started_now). Raises
+    RuntimeError when nothing can be served."""
+    model = model or str(cfg.get("model") or "")
+    runner = runner or str(cfg.get("runner") or "runner")
+    if adapter is None:
+        adapter = str(cfg.get("adapter") or "")
+        if adapter and not Path(adapter).is_file():
+            adapter = ""
+    if not model:
+        raise RuntimeError("no model in the shadow config; run 'runner --shadow-mode -m MODEL.gguf' first")
+    state = read_state(home)
+    if state is not None:
+        if (state.model == model and state.adapter == adapter
+                and alive(state, endpoint_factory=endpoint_factory)):
+            return endpoint_factory(state.base_url, timeout=request_timeout), False
+        stop_server(home)
+    extra = ("--lora", adapter) if adapter else ()
+    launch = ServerLaunch(executable=runner, model=model, port=_free_port(),
+                          context_size=int(str(cfg.get("ctx") or 8192)),
+                          gpu=str(cfg.get("gpu") or "auto"),
+                          threads=int(str(cfg.get("threads") or 0)) or None,
+                          parent_pid=None, ttl=ttl, extra_args=extra)
+    managed = managed_factory(launch)
+    if not managed.start(timeout=start_timeout):
+        raise RuntimeError("the runner did not start; check the model path and 'runner --fit'")
+    pid = int(getattr(getattr(managed, "process", None), "pid", 0) or 0)
+    write_state(home, ServerState(launch.port, pid, model, adapter, runner))
+    # the process object is dropped on purpose: the runner outlives this
+    # command and unloads by itself after ttl seconds idle
+    if hasattr(managed, "process"):
+        managed.process = None
+    return endpoint_factory(managed.base_url, timeout=request_timeout), True
+
+
+def stop_server(home: Path) -> bool:
+    """End the recorded runner if it is ours, and forget it either way."""
+    state = read_state(home)
+    clear_state(home)
+    if state is None or state.pid <= 0:
+        return False
+    if not alive(state):
+        return False
+    try:
+        if os.name == "nt":
+            subprocess.run(["taskkill", "/pid", str(state.pid), "/f"], capture_output=True)
+        else:
+            os.kill(state.pid, signal.SIGTERM)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return True
+
+
+def render_status(home: Path) -> str:
+    state = read_state(home)
+    if state is None:
+        return "no warm runner recorded"
+    live = alive(state)
+    return (f"runner {state.runner} on {state.base_url} (pid {state.pid}): "
+            f"{'alive' if live else 'gone'}; model {Path(state.model).name}"
+            f"{' + adapter ' + Path(state.adapter).name if state.adapter else ''}")
+
+
+__all__ = ["ServerState", "read_state", "write_state", "clear_state", "alive", "served_runner",
+           "stop_server", "render_status", "DEFAULT_TTL", "STATE_REL"]

--- a/python/tests/test_shadow_adapt.py
+++ b/python/tests/test_shadow_adapt.py
@@ -171,7 +171,7 @@ def test_adapt_end_to_end_keeps_the_adapter_only_on_a_held_out_rise(tmp_path: Pa
 
     class FakeEndpoint:
         def __init__(self, url: str, **k: Any) -> None:
-            pass
+            self.base_url = url
 
         def capabilities(self, **k: Any) -> dict[str, Any]:
             return {"models": [{"id": "coder.gguf"}]}

--- a/python/tests/test_shadow_sync.py
+++ b/python/tests/test_shadow_sync.py
@@ -1,0 +1,194 @@
+"""`shadow sync` closes the loop the hooks feed (import, count what waits,
+replay when told to), and the warm runner is reused across commands. No
+model: the served endpoint is scripted; the verifier and the worktrees are
+real."""
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from xyntetik_runner.shadow import server
+from xyntetik_runner.shadow.cli import main
+from xyntetik_runner.shadow.install import read_config, write_config
+
+FIXTURE = Path(__file__).parent / "fixtures" / "repair_task_v1"
+BUGGY = (FIXTURE / "workspace" / "calc" / "money.py").read_text(encoding="utf-8")
+VISIBLE = (FIXTURE / "workspace" / "tests" / "test_money.py").read_text(encoding="utf-8")
+SOLUTION_TESTS = (FIXTURE / "protected" / "tests" / "test_money.py").read_text(encoding="utf-8")
+CORRECT = '''"""Money parsing for the ledger importer."""
+from decimal import ROUND_HALF_UP, Decimal
+
+
+def parse_amount(text: str) -> int:
+    cleaned = "".join(ch for ch in text if ch.isdigit() or ch in "-.")
+    return int((Decimal(cleaned) * 100).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+'''
+
+
+def git(repo: Path, *args: str, date: str = "2026-09-01T12:00:00+00:00") -> str:
+    env = {**os.environ, "GIT_AUTHOR_DATE": date, "GIT_COMMITTER_DATE": date,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@x", "GIT_COMMITTER_NAME": "t",
+           "GIT_COMMITTER_EMAIL": "t@x"}
+    return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True,
+                          env=env, check=True).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "proj"
+    (r / "calc").mkdir(parents=True)
+    (r / "tests").mkdir()
+    git(tmp_path, "init", "-q", "-b", "main", str(r))
+    (r / "calc" / "__init__.py").write_text("", encoding="utf-8")
+    (r / "calc" / "money.py").write_text(BUGGY, encoding="utf-8")
+    (r / "tests" / "test_money.py").write_text(VISIBLE, encoding="utf-8")
+    git(r, "add", "-A")
+    git(r, "commit", "-q", "-m", "buggy", date="2026-09-01T11:00:00+00:00")
+    (r / "calc" / "money.py").write_text(CORRECT, encoding="utf-8")
+    (r / "tests" / "test_money.py").write_text(SOLUTION_TESTS, encoding="utf-8")
+    git(r, "add", "-A")
+    git(r, "commit", "-q", "-m", "fix", date="2026-09-01T12:00:00+00:00")
+    return r
+
+
+class FakeManaged:
+    started: list[Any] = []
+
+    def __init__(self, launch: Any, **k: Any) -> None:
+        self.launch = launch
+        self.base_url = f"http://127.0.0.1:{launch.port}"
+        self.process: Any = type("P", (), {"pid": 4242})()
+
+    def start(self, **k: Any) -> bool:
+        FakeManaged.started.append(self.launch)
+        return True
+
+    def stop(self, **k: Any) -> None:
+        pass
+
+
+class Fixer:
+    """Answers the fit probe, then fixes the file in two tool calls."""
+    live_pids: dict[str, int] = {}
+
+    def __init__(self, url: str, **k: Any) -> None:
+        self.base_url = url
+        self.n = 0
+
+    def capabilities(self, **k: Any) -> dict[str, Any]:
+        return {"object": "runner.capabilities", "models": [{"id": "coder.gguf"}],
+                "pid": Fixer.live_pids.get(self.base_url, 4242), "version": "t"}
+
+    def post_json(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        if payload.get("temperature") == 0 and not payload.get("tools"):
+            return {"choices": [{"message": {"content": "one, two"}}], "usage": {"completion_tokens": 64}}
+        self.n += 1
+        if self.n == 1:
+            return {"choices": [{"message": {"content": "", "tool_calls": [
+                {"id": "1", "function": {"name": "write_file", "arguments": json.dumps(
+                    {"path": "calc/money.py", "content": CORRECT})}}]}}]}
+        return {"choices": [{"message": {"content": "", "tool_calls": [
+            {"id": "2", "function": {"name": "finish", "arguments": "{}"}}]}}]}
+
+
+def capture(repo: Path, cap: Path, monkeypatch: Any, base: str, fix: str) -> None:
+    git(repo, "checkout", "-q", base)
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(
+        {"session_id": "cap1", "cwd": str(repo), "prompt": "fix parse_amount"})))
+    assert main(["capture", "--event", "prompt", "--file", str(cap)]) == 0
+    git(repo, "checkout", "-q", fix)
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"session_id": "cap1", "cwd": str(repo)})))
+    assert main(["capture", "--event", "stop", "--file", str(cap)]) == 0
+
+
+def test_sync_imports_counts_and_replays_when_told(repo: Path, tmp_path: Path, capsys: Any, monkeypatch: Any) -> None:
+    from xyntetik_runner.shadow import cli
+    home = tmp_path / "home"
+    out = home / ".xyntetik" / "shadow"
+    cap = home / ".xyntetik" / "shadow" / "capture.jsonl"
+    cap.parent.mkdir(parents=True)
+    base = git(repo, "rev-parse", "HEAD^")
+    fix = git(repo, "rev-parse", "HEAD")
+    capture(repo, cap, monkeypatch, base, fix)
+    model = tmp_path / "coder.gguf"
+    model.write_bytes(b"GGUF")
+    write_config(home, model=str(model), runner="fake-runner", ctx=4096, gpu="auto", threads=0, out=str(out))
+    monkeypatch.setattr(cli, "ManagedRunner", FakeManaged)
+    monkeypatch.setattr(cli, "RunnerEndpoint", Fixer)
+    FakeManaged.started.clear()
+    common = ["sync", "--out", str(out), "--home", str(home), "--python", sys.executable]
+    # import only: one task admitted, one waiting, nothing served
+    assert main(common) == 0
+    text = capsys.readouterr().out
+    assert "sync: 1 task(s) admitted now; 1 waiting for a replay with coder.gguf" in text, text
+    assert "sync --replay 1" in text and not FakeManaged.started
+    assert server.read_state(home) is None
+    # replay when told: the runner is started warm, the attempt is verified, the state is recorded
+    assert main(common + ["--replay", "1"]) == 0
+    text = capsys.readouterr().out
+    assert "started the runner" in text and "verified_local_attempt" in text, text
+    assert "sync: 1 replayed, 0 still waiting" in text
+    assert "| repair |" in text or "qualif" in text
+    assert len(FakeManaged.started) == 1
+    launch = FakeManaged.started[0]
+    assert launch.parent_pid is None and launch.ttl == server.DEFAULT_TTL and launch.extra_args == ()
+    state = server.read_state(home)
+    assert state is not None and state.pid == 4242 and state.model == str(model)
+    # the next sync has nothing new and nothing waiting; the warm runner is reused, not restarted
+    Fixer.live_pids[state.base_url] = 4242
+    assert main(common + ["--replay", "1"]) == 0
+    text = capsys.readouterr().out
+    assert "0 waiting" in text and len(FakeManaged.started) == 1, text
+    # delegate reuses it too, with the same state
+    git(repo, "checkout", "-q", base)
+    assert main(["delegate", "--repo", str(repo), "--request", "fix parse_amount", "--home", str(home),
+                 "--python", sys.executable]) == 0
+    text = capsys.readouterr().out
+    assert "reusing the runner" in text and "git apply" in text, text
+    assert len(FakeManaged.started) == 1
+    # server status and stop (status asks the port itself)
+    monkeypatch.setattr(server, "RunnerEndpoint", Fixer)
+    assert main(["server", "--home", str(home)]) == 0
+    assert "alive" in capsys.readouterr().out
+    monkeypatch.setattr(server, "alive", lambda *a, **k: False)  # nothing real to kill here
+    assert main(["server", "--home", str(home), "--stop"]) == 0
+    assert server.read_state(home) is None
+
+
+def test_warm_runner_is_replaced_when_stale_or_serving_another_model(tmp_path: Path, monkeypatch: Any) -> None:
+    home = tmp_path / "home"
+    cfg = {"model": str(tmp_path / "coder.gguf"), "runner": "r", "ctx": 4096, "gpu": "auto", "threads": 0}
+    FakeManaged.started.clear()
+    stopped: list[Path] = []
+    monkeypatch.setattr(server, "stop_server", lambda h: stopped.append(h) or server.clear_state(h) or True)
+    ep, started = server.served_runner(home, cfg, managed_factory=FakeManaged, endpoint_factory=Fixer)
+    assert started and len(FakeManaged.started) == 1
+    state = server.read_state(home)
+    assert state is not None
+    # a recorded runner that does not answer with its pid is stale: replaced
+    Fixer.live_pids[state.base_url] = 1
+    ep, started = server.served_runner(home, cfg, managed_factory=FakeManaged, endpoint_factory=Fixer)
+    assert started and len(FakeManaged.started) == 2 and stopped == [home]
+    state2 = server.read_state(home)
+    assert state2 is not None
+    Fixer.live_pids[state2.base_url] = 4242
+    # alive and same model: reused
+    ep, started = server.served_runner(home, cfg, managed_factory=FakeManaged, endpoint_factory=Fixer)
+    assert not started and len(FakeManaged.started) == 2
+    # a promoted adapter changes what must be served: replaced with --lora
+    adapter = tmp_path / "adapter.gguf"
+    adapter.write_bytes(b"A")
+    ep, started = server.served_runner(home, {**cfg, "adapter": str(adapter)}, managed_factory=FakeManaged,
+                                       endpoint_factory=Fixer)
+    assert started and FakeManaged.started[-1].extra_args == ("--lora", str(adapter))
+    assert "no warm runner" not in server.render_status(home)
+    with pytest.raises(RuntimeError):
+        server.served_runner(home, {}, managed_factory=FakeManaged, endpoint_factory=Fixer)
+    assert read_config(home) == {}


### PR DESCRIPTION
## What

- \`shadow sync\`: import captured work, admit replayable tasks, count what waits for the configured model, \`--replay N\` runs the next N. The skill and prompt run it on every status and offer the replay as the user's to start.
- One warm runner (\`shadow/server.py\`): started detached with \`--ttl\` and no parent watch, recorded in \`server.json\`, reused only when pid and model match; \`shadow server\` / \`--stop\`; \`uninstall\` ends it. \`delegate\`, \`sync\` and \`adapt\` use it.
- \`ServerLaunch.parent_pid: int | None\` (None: no parent watch).
- Tests: capture to sync to replay to delegate on real worktrees with a scripted endpoint; warm-runner reuse, staleness and adapter change. Client 113 green, mypy strict clean.