### PR TITLE
shadow: first-run guidance, hook launcher file, function-class tasks first in a limited replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ names that were true when they were written.
 
 ## Unreleased
 
+- **Shadow mode, three rough edges for a first-time user.** (1) `install`
+  ends with "what happens next": what the hooks note, when to ask
+  `/shadow`, and what it will offer. (2) The capture hooks now run a
+  small stdlib launcher written under `~/.xyntetik/shadow/` instead of a
+  shell line, so the same hook works under sh, cmd and PowerShell, a
+  Python path with spaces is quoted once, and a hook can never fail a
+  prompt (every error is swallowed, exit code always 0); hooks written by
+  the previous form are still recognised and removed by `uninstall`. (3)
+  A limited replay (`sync --replay N`, `replay --limit N`) spends its
+  wall clock where a verified success is likeliest and shortest:
+  function-class tasks first, then file, then multi-file, fewest failing
+  tests first; `sync` says the waiting count per class.
+
 - **`shadow sync` and a warm runner: the loop the hooks feed now
   closes.** `sync` imports what the capture hooks recorded, admits the
   replayable tasks, says how many wait for the configured model, and

--- a/README.md
+++ b/README.md
@@ -1798,7 +1798,10 @@ That one command finds the stdlib-only Python client beside the binary (it
 ships in the release archive), tells you exactly what it will write, and
 asks before writing: the two capture hooks and a `/shadow` skill for Claude
 Code, a `/shadow` prompt for Codex, whichever of the two is on the machine,
-and the model the `/shadow` offload will serve. `--yes` skips the question
+and the model the `/shadow` offload will serve. It ends by saying what
+happens next. The hooks run a small launcher file, not a shell line, so
+they work the same under sh, cmd and PowerShell and can never fail a
+prompt: every error is swallowed and the exit code is always zero. `--yes` skips the question
 for scripts. Inside either harness, `/shadow` then shows the ledger, and
 when you ask it to offload a task, reads where the local model has verified
 successes (`shadow routes`), runs the task on a scratch worktree with the

--- a/python/src/xyntetik_runner/shadow/cli.py
+++ b/python/src/xyntetik_runner/shadow/cli.py
@@ -243,6 +243,17 @@ class ReplayOptions:
     endpoint_label: str = ""
 
 
+_CLASS_RANK = {"function": 0, "file": 1, "multi-file": 2}
+
+
+def replay_order(tasks: list[RepairTask]) -> list[RepairTask]:
+    """Cheapest evidence first: the class a person delegates (function),
+    then file, then multi-file; within a class the fewest failing tests.
+    A limited replay therefore spends its wall clock where a verified
+    success is likeliest and shortest."""
+    return sorted(tasks, key=lambda t: (_CLASS_RANK.get(t.task_class, 3), t.baseline_failing, t.task_id))
+
+
 def run_replay(out: Path, endpoint: RunnerEndpoint, opts: ReplayOptions, *,
                model: str = "") -> tuple[int, float, str]:
     """Attempt every admitted task under ``out`` against ``endpoint`` and
@@ -278,7 +289,7 @@ def run_replay(out: Path, endpoint: RunnerEndpoint, opts: ReplayOptions, *,
     done = {(r.episode_id, r.identity.model_sha256, r.identity.scaffold_sha256)
             for r in _read_records(evidence) if r.verifier is not None}
     ran = 0
-    for task in _tasks(out, opts.task):
+    for task in replay_order(_tasks(out, opts.task)):
         if opts.limit and ran >= opts.limit:
             break
         ident = replace(base_identity, project=Path(task.repo).name, task_class=task.task_class,
@@ -661,6 +672,17 @@ def cmd_install(args: argparse.Namespace) -> int:
         print(f"codex: prompt {done.codex_prompt}")
     print("nothing runs until a prompt is submitted; the hooks never block one; "
           "'shadow uninstall' removes exactly this")
+    print()
+    print("what happens next:")
+    print("  1. keep working as you do; each prompt and each finished turn is noted with the")
+    print("     directory, the time and the repository's commit id, nothing else")
+    print("  2. after a few sessions, ask /shadow" + (" in Claude Code" if claude else "") +
+          (" (the shadow prompt in Codex)" if codex else "") + ": it imports what you did, says how")
+    print("     many tasks the local model can be tried on, and offers to run them; say yes")
+    print("  3. once a task class shows verified successes, /shadow can offload such a task to")
+    print("     the local model and show you the diff and the test verdict; you apply it")
+    if not (args.model or picked):
+        print("  the offload needs a model: 'runner --shadow-mode -m MODEL.gguf' when you have one")
     return 0
 
 
@@ -860,7 +882,12 @@ def cmd_sync(args: argparse.Namespace) -> int:
     done = {r.episode_id for r in records if r.verifier is not None and r.identity.model_sha256 == sha}
     waiting = [t for t in _tasks(out, None) if t.episode_id not in done]
     name = Path(model_path).name if model_path else "(no model configured)"
-    print(f"sync: {admitted} task(s) admitted now; {len(waiting)} waiting for a replay with {name}")
+    by_class: dict[str, int] = {}
+    for t in waiting:
+        by_class[t.task_class] = by_class.get(t.task_class, 0) + 1
+    detail = ", ".join(f"{n} {c}" for c, n in sorted(by_class.items(), key=lambda kv: _CLASS_RANK.get(kv[0], 3)))
+    print(f"sync: {admitted} task(s) admitted now; {len(waiting)} waiting for a replay with {name}"
+          + (f" ({detail}; function first)" if detail else ""))
     if not args.replay or not waiting:
         if waiting and model_path:
             print(f"  'shadow sync --replay {min(len(waiting), 5)}' runs the next ones; each takes up to "

--- a/python/src/xyntetik_runner/shadow/install.py
+++ b/python/src/xyntetik_runner/shadow/install.py
@@ -21,6 +21,9 @@ from pathlib import Path
 from typing import Sequence
 
 MARK = "xyntetik_runner.shadow capture"
+HOOK_NAME = "xyntetik-shadow-capture-hook.py"
+MARKS = (MARK, HOOK_NAME)  # ours, this version and the one before it
+HOOK_REL = Path(".xyntetik") / "shadow" / HOOK_NAME
 SKILL_NAME = "shadow"
 
 
@@ -145,19 +148,53 @@ def harness_present(home: Path) -> tuple[bool, bool]:
     return (home / ".claude").is_dir(), (home / ".codex").is_dir()
 
 
-def hook_command(event: str, python: str, pythonpath: str | None) -> str:
-    prefix = f"PYTHONPATH={pythonpath} " if pythonpath else ""
-    return (f"{prefix}{python} -m xyntetik_runner.shadow capture --event {event} "
-            f"2>/dev/null || true")
+def client_pythonpath() -> str:
+    """Where this client's package lives, for a process that does not
+    inherit our PYTHONPATH: the hooks, the skill's commands, the prompt."""
+    return str(Path(__file__).resolve().parents[2])
+
+
+def write_hook_launcher(home: Path, pythonpath: str | None) -> Path:
+    """The file the hooks run: a stdlib launcher that puts the client on the
+    path, runs the capture, and swallows everything else. No shell syntax
+    is needed, so the same hook line works under sh, cmd and PowerShell,
+    and a Python path with spaces is quoted once, here."""
+    path = home / HOOK_REL
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f'''# Written by `shadow install`; `shadow uninstall` removes it.
+# Records the request, directory, time and repository HEAD of a prompt or
+# stop event; never anything the assistant produced. It can never block a
+# prompt: every failure is swallowed and the exit code is always 0.
+import os
+import sys
+
+try:
+    sys.stdout = open(os.devnull, "w")
+    sys.stderr = open(os.devnull, "w")
+    if {pythonpath!r}:
+        sys.path.insert(0, {pythonpath!r})
+    from xyntetik_runner.shadow.cli import main
+    main(["capture", "--event", sys.argv[1]])
+except BaseException:
+    pass
+os._exit(0)
+''', encoding="utf-8")
+    return path
+
+
+def hook_command(event: str, python: str, launcher: Path) -> str:
+    return f'"{python}" "{launcher}" {event}'
 
 
 def _hook_entry(command: str) -> dict[str, object]:
     return {"hooks": [{"type": "command", "timeout": 10, "command": command}]}
 
 
-def install_claude_hooks(settings: Path, *, python: str, pythonpath: str | None) -> int:
+def install_claude_hooks(settings: Path, *, python: str, pythonpath: str | None,
+                         home: Path | None = None) -> int:
     """Merge the two hooks into ``settings`` (created if absent); idempotent.
     Returns how many hooks were added. A backup sits beside the file."""
+    launcher = write_hook_launcher(home if home is not None else settings.parent.parent, pythonpath)
     data: dict[str, object] = {}
     if settings.is_file():
         data = json.loads(settings.read_text(encoding="utf-8") or "{}")
@@ -168,10 +205,15 @@ def install_claude_hooks(settings: Path, *, python: str, pythonpath: str | None)
     for event, name in (("prompt", "UserPromptSubmit"), ("stop", "Stop")):
         entries = hooks.setdefault(name, [])
         assert isinstance(entries, list)
-        present = any(MARK in json.dumps(e) for e in entries)
+        # an entry in the previous shell-line form is replaced by the launcher
+        # form; one in the launcher form is left alone
+        kept = [e for e in entries if not (MARK in json.dumps(e) and HOOK_NAME not in json.dumps(e))]
+        upgraded = len(entries) - len(kept)
+        entries[:] = kept
+        present = any(HOOK_NAME in json.dumps(e) for e in entries)
         if not present:
-            entries.append(_hook_entry(hook_command(event, python, pythonpath)))
-            added += 1
+            entries.append(_hook_entry(hook_command(event, python, launcher)))
+            added += 1 if not upgraded else 0
     settings.parent.mkdir(parents=True, exist_ok=True)
     settings.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return added
@@ -189,7 +231,7 @@ def uninstall_claude_hooks(settings: Path) -> int:
         entries = hooks.get(name)
         if not isinstance(entries, list):
             continue
-        kept = [e for e in entries if MARK not in json.dumps(e)]
+        kept = [e for e in entries if not any(m in json.dumps(e) for m in MARKS)]
         removed += len(entries) - len(kept)
         if kept:
             hooks[name] = kept
@@ -331,6 +373,9 @@ def install(home: Path, *, python: str = sys.executable, pythonpath: str | None 
             out: str = "~/.xyntetik/shadow", claude: bool = True, codex: bool = True,
             model: str = "", runner: str = "runner", ctx: int = 8192, gpu: str = "auto",
             threads: int = 0) -> Installed:
+    # the hooks and the skill run in processes that do not inherit this
+    # one's PYTHONPATH; they always get the client's own location
+    pythonpath = pythonpath or client_pythonpath()
     settings = skill = prompt = config = None
     added = 0
     if model:
@@ -338,7 +383,7 @@ def install(home: Path, *, python: str = sys.executable, pythonpath: str | None 
                               threads=threads, out=out)
     if claude:
         settings = home / ".claude" / "settings.json"
-        added = install_claude_hooks(settings, python=python, pythonpath=pythonpath)
+        added = install_claude_hooks(settings, python=python, pythonpath=pythonpath, home=home)
         skill = home / ".claude" / "skills" / SKILL_NAME / "SKILL.md"
         skill.parent.mkdir(parents=True, exist_ok=True)
         skill.write_text(skill_text(python, pythonpath, out), encoding="utf-8")
@@ -355,7 +400,7 @@ def uninstall(home: Path) -> Installed:
     removed = uninstall_claude_hooks(settings)
     skill = home / ".claude" / "skills" / SKILL_NAME / "SKILL.md"
     prompt = home / ".codex" / "prompts" / f"{SKILL_NAME}.md"
-    for p in (skill, prompt):
+    for p in (skill, prompt, home / HOOK_REL):
         if p.is_file():
             p.unlink()
     if skill.parent.is_dir() and not any(skill.parent.iterdir()):

--- a/python/tests/test_shadow_pipeline.py
+++ b/python/tests/test_shadow_pipeline.py
@@ -436,8 +436,36 @@ def test_install_is_explicit_idempotent_and_reversible(tmp_path: Path, capsys: A
     assert data["model"] == "x", "existing settings survive"
     stop = data["hooks"]["Stop"]
     assert stop[0]["hooks"][0]["command"] == "echo mine", "existing hooks survive"
-    assert "capture --event stop 2>/dev/null || true" in stop[1]["hooks"][0]["command"]
-    assert "PYTHONPATH=/src py -m" in data["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"]
+    launcher = home / ".xyntetik" / "shadow" / "xyntetik-shadow-capture-hook.py"
+    assert stop[1]["hooks"][0]["command"] == f'"py" "{launcher}" stop'
+    assert data["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"] == f'"py" "{launcher}" prompt'
+    assert "sys.path.insert(0, '/src')" in launcher.read_text(encoding="utf-8")
+    # without --pythonpath the launcher and the skill carry the client's own location
+    from xyntetik_runner.shadow.install import client_pythonpath
+    home_b = tmp_path / "home_b"
+    (home_b / ".claude").mkdir(parents=True)
+    assert main(["install", "--home", str(home_b), "--python", "py", "--yes"]) == 0
+    launcher_b = home_b / ".xyntetik" / "shadow" / "xyntetik-shadow-capture-hook.py"
+    assert f"sys.path.insert(0, {client_pythonpath()!r})" in launcher_b.read_text(encoding="utf-8")
+    assert f"PYTHONPATH={client_pythonpath()} py -m" in (home_b / ".claude" / "skills" / "shadow" / "SKILL.md").read_text(encoding="utf-8")
+    assert (Path(client_pythonpath()) / "xyntetik_runner" / "shadow" / "cli.py").is_file()
+    # the launcher records a prompt through the real capture, exits 0, prints nothing
+    import subprocess as sp
+    from xyntetik_runner.shadow import cli as _cli
+    real = home / ".xyntetik" / "shadow" / "xyntetik-shadow-capture-hook.py"
+    from xyntetik_runner.shadow.install import write_hook_launcher
+    write_hook_launcher(home, str(Path(_cli.__file__).resolve().parents[2]))
+    env = {**os.environ, "HOME": str(home), "USERPROFILE": str(home)}
+    env.pop("PYTHONPATH", None)
+    proc = sp.run([sys.executable, str(real), "prompt"], input=json.dumps(
+        {"session_id": "s", "cwd": str(tmp_path), "prompt": "hi"}), capture_output=True, text=True, env=env)
+    assert proc.returncode == 0 and proc.stdout == "" and proc.stderr == ""
+    cap = home / ".xyntetik" / "shadow" / "capture.jsonl"
+    assert cap.is_file() and '"prompt": "hi"' in cap.read_text(encoding="utf-8")
+    # ... and never fails a prompt, whatever it is fed
+    proc = sp.run([sys.executable, str(real), "prompt"], input="not json", capture_output=True, text=True, env=env)
+    assert proc.returncode == 0 and proc.stdout == ""
+    write_hook_launcher(home, "/src")
     assert settings.with_suffix(".json.bak-shadow").is_file()
     skill = home / ".claude" / "skills" / "shadow" / "SKILL.md"
     prompt = home / ".codex" / "prompts" / "shadow.md"
@@ -454,9 +482,18 @@ def test_install_is_explicit_idempotent_and_reversible(tmp_path: Path, capsys: A
     assert main(["uninstall", "--home", str(home)]) == 0
     data = json.loads(settings.read_text(encoding="utf-8"))
     assert data["hooks"] == {"Stop": [{"hooks": [{"type": "command", "command": "echo mine"}]}]}
-    assert not skill.exists() and not prompt.exists()
+    assert not skill.exists() and not prompt.exists() and not launcher.exists()
     out = capsys.readouterr().out
     assert "2 hook(s) added" in out and "removed 2 hook(s)" in out
+    assert "what happens next:" in out and "ask /shadow in Claude Code (the shadow prompt in Codex)" in out
+    # hooks written by the previous version are still recognised and removed
+    settings.write_text(json.dumps({"hooks": {"Stop": [{"hooks": [{"type": "command",
+        "command": "PYTHONPATH=/x py -m xyntetik_runner.shadow capture --event stop 2>/dev/null || true"}]}]}}), encoding="utf-8")
+    assert main(["install", "--home", str(home), "--python", "py", "--yes"]) == 0
+    stop = json.loads(settings.read_text(encoding="utf-8"))["hooks"]["Stop"]
+    assert len(stop) == 1 and stop[0]["hooks"][0]["command"] == f'"py" "{launcher}" stop', "upgraded in place"
+    assert main(["uninstall", "--home", str(home)]) == 0
+    assert "hooks" not in json.loads(settings.read_text(encoding="utf-8"))
 
 
 def test_capture_summary_counts_the_file(tmp_path: Path, capsys: Any) -> None:

--- a/python/tests/test_shadow_sync.py
+++ b/python/tests/test_shadow_sync.py
@@ -162,6 +162,21 @@ def test_sync_imports_counts_and_replays_when_told(repo: Path, tmp_path: Path, c
     assert server.read_state(home) is None
 
 
+def test_replay_order_spends_the_budget_on_function_tasks_first() -> None:
+    from dataclasses import replace as _replace
+    from xyntetik_runner.shadow.cli import replay_order
+    from xyntetik_runner.shadow.tasks import RepairTask
+    base = RepairTask(task_id="t", episode_id="e", repo="r", base_sha="a", solution_sha="b", request="q",
+                      request_sha256="0" * 64, context=(), test_files=(), visible_test_files=(), src_files=1,
+                      pythonpath=(), protected_dir="p", expected_tests=3, baseline_failing=1)
+    tasks = [_replace(base, task_id="multi", task_class="multi-file", src_files=3),
+             _replace(base, task_id="file-hard", task_class="file", baseline_failing=5),
+             _replace(base, task_id="fn-b", task_class="function", baseline_failing=2),
+             _replace(base, task_id="file-easy", task_class="file", baseline_failing=1),
+             _replace(base, task_id="fn-a", task_class="function", baseline_failing=1)]
+    assert [t.task_id for t in replay_order(tasks)] == ["fn-a", "fn-b", "file-easy", "file-hard", "multi"]
+
+
 def test_warm_runner_is_replaced_when_stale_or_serving_another_model(tmp_path: Path, monkeypatch: Any) -> None:
     home = tmp_path / "home"
     cfg = {"model": str(tmp_path / "coder.gguf"), "runner": "r", "ctx": 4096, "gpu": "auto", "threads": 0}


### PR DESCRIPTION
## What

- \`install\` ends with "what happens next" for a first-time user.
- The capture hooks run a stdlib launcher file (no shell syntax: sh, cmd and PowerShell alike; quoted Python path; can never fail a prompt); the launcher and the skill carry the client's own location; previous-form hooks are upgraded in place and still removed by \`uninstall\`.
- \`replay --limit\` and \`sync --replay N\` order tasks function, file, multi-file, fewest failing tests first; \`sync\` reports the waiting count per class.
- Tests run the real launcher through the real capture (records a prompt, exits 0 on garbage input), pin the upgrade path and the ordering. Client 114 green, mypy strict clean.

Filed under R14.5.7's follow-ups (a), (b), (c).