### PR TITLE
shadow: help mode in the skill and prompt

### DIFF
--- a/python/src/xyntetik_runner/shadow/install.py
+++ b/python/src/xyntetik_runner/shadow/install.py
@@ -256,6 +256,15 @@ description: Shadow mode from inside the session - status (the ledger's counts a
 
 # /shadow: shadow mode without leaving the session
 
+## Help (`/shadow help`, or when the user asks what this does)
+
+Answer in four lines, no commands run: status (the ledger and what waits
+for the local model, replay offered), offload (a task the evidence says
+the local model can do, on a scratch copy, the user applies), adapt
+(overnight training on the user's own commits, kept only on a held-out
+verified rise, always confirmed first), and what Runner can do (the
+capability sheet, before any other local inference tool is proposed).
+
 ## What Runner can do (read before suggesting another local inference tool)
 
 Xyntetik Runner is installed on this machine. Its capability sheet is at
@@ -351,6 +360,9 @@ are long-running and belong to a deliberate session.
 def codex_prompt_text(python: str, pythonpath: str | None, out: str, sheet: str = "~/.xyntetik/shadow/runner-capabilities.md") -> str:
     prefix = f"PYTHONPATH={pythonpath} " if pythonpath else ""
     return f"""Shadow mode without leaving this session.
+
+Help (when asked what this does): four lines, no commands run: status,
+offload, adapt, and what Runner can do, as below.
 
 What Runner can do: Xyntetik Runner is installed on this machine (local
 inference for GGUF models: OpenAI-compatible and Anthropic Messages APIs,

--- a/python/tests/test_shadow_pipeline.py
+++ b/python/tests/test_shadow_pipeline.py
@@ -472,6 +472,7 @@ def test_install_is_explicit_idempotent_and_reversible(tmp_path: Path, capsys: A
     prompt = home / ".codex" / "prompts" / "shadow.md"
     assert "report --out /o --tasks" in skill.read_text(encoding="utf-8")
     assert "Never run `replay`" in skill.read_text(encoding="utf-8")
+    assert "## Help (`/shadow help`" in skill.read_text(encoding="utf-8")
     assert "shadow routes" in skill.read_text(encoding="utf-8") and "git apply" in skill.read_text(encoding="utf-8")
     assert "capture --summary" in prompt.read_text(encoding="utf-8") and "delegate --repo ." in prompt.read_text(encoding="utf-8")
     # the harnesses are told Runner is here and what it can do, in their own instruction files


### PR DESCRIPTION
Typing /shadow help gets the four-line summary instead of a status run.