### PR TITLE
shadow: tandem, background local attempts where the evidence allows, surfaced through the hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ names that were true when they were written.
 
 ## Unreleased
 
+- **Tandem: the local model works beside the harness, in the background,
+  where the evidence says it can.** In a repository where the ledger
+  holds verified successes for the configured model (the same route rule
+  as offloading, per repository), the prompt hook starts a bounded
+  delegation on a scratch copy while the frontier model works, and tells
+  the harness so through the hook's own channel; a verified result is
+  surfaced once, at the end of the turn or the start of the next, as a
+  patch to offer, never applied. Every delegation joins the ledger with
+  the class its own diff had, under its own verifier id (the repository's
+  tests at HEAD; verified only when they passed and no test file was
+  touched), so the funnel widens by evidence alone and an adapter that
+  raised the held-out count raises these counts too. One delegation at a
+  time; never where the ledger is silent; `shadow tandem off` stops it,
+  `shadow delegations` lists them, `delegate --background` is the same
+  gate for Codex, which has no hooks. Nothing runs where no model is
+  configured.
+
 - **The harnesses are told what Runner can do.** A coding assistant that
   does not know the runner is installed reaches for another local
   inference tool, or a hosted API, for a job the runner already does on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@ names that were true when they were written.
   tests at HEAD; verified only when they passed and no test file was
   touched), so the funnel widens by evidence alone and an adapter that
   raised the held-out count raises these counts too. One delegation at a
-  time; never where the ledger is silent; `shadow tandem off` stops it,
+  time; never where the ledger is silent. Where the record is strong (at
+  least 5 attempts, at least 4 in 5 verified) the hook says "runner
+  first": the harness waits for the local result (`shadow delegations
+  --wait ID`) and does the work itself only if that result is not
+  verified. `shadow tandem off` stops it,
   `shadow delegations` lists them, `delegate --background` is the same
   gate for Codex, which has no hooks. Nothing runs where no model is
   configured.

--- a/README.md
+++ b/README.md
@@ -1818,6 +1818,15 @@ verdict for you to apply with `git apply`; the working tree is never
 touched and nothing is applied silently. You keep your harness and your
 frontier model; the runner takes what the evidence says it can.
 
+Once the ledger holds verified successes for a repository, the local
+model works in tandem: each request that is work also starts a bounded
+attempt on a scratch copy in the background while your assistant works
+on it, and a verified result is offered to you as a patch, once, never
+applied. Every such attempt joins the ledger with the class its diff had,
+so the more the local model proves, and the more an adapter raises what
+it proves, the more requests are funneled to it. `shadow tandem off`
+stops it; `shadow delegations` lists them.
+
 The ledger fills through `sync`, which `/shadow` runs on every status:
 it imports what the hooks captured since last time, admits the tasks
 that can be replayed, and says how many wait for the local model. When

--- a/python/README.md
+++ b/python/README.md
@@ -95,6 +95,9 @@ The negative controls that prove the verifier can fail live in
   --request ...`: one bounded attempt on a detached worktree at HEAD, the
   repository's tests on the copy, the diff as a patch file, the verdict; starts
   the configured runner when no `--endpoint` is given.
+- `tandem on|off`, `delegations`, `delegate --background`: the background attempt the
+  prompt hook starts where the ledger shows verified successes for the repository;
+  a verified patch is surfaced once through the hooks, never applied.
 - `sync`: import what the hooks captured, admit the replayable tasks, count what
   waits for the configured model, `--replay N` runs the next N; `server`: the
   warm runner shadow mode keeps between commands (`--stop` ends it).

--- a/python/src/xyntetik_runner/shadow/cli.py
+++ b/python/src/xyntetik_runner/shadow/cli.py
@@ -38,8 +38,10 @@ from xyntetik_runner.shadow.evidence import (
 )
 from xyntetik_runner.shadow.importer import CAPTURE_FILE, Episode, read_episodes, scan_all, write_episodes
 from xyntetik_runner.shadow import adapt
+from xyntetik_runner.shadow import tandem
 from xyntetik_runner.shadow.install import (harness_present, install, read_config, render_candidates,
-                                            set_config_adapter, suggest_model, uninstall)
+                                            set_config_adapter, set_config_key, suggest_model, uninstall)
+from xyntetik_runner.process import spawn_detached
 from xyntetik_runner.shadow.routes import delegate, render_routes, route_table
 from xyntetik_runner.shadow.server import (DEFAULT_TTL, render_status as server_status, served_runner,
                                            stop_server)
@@ -605,7 +607,58 @@ def cmd_capture(args: argparse.Namespace) -> int:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(rec, sort_keys=True) + "\n")
+    # tandem: a background attempt where the evidence allows it, and the
+    # harness told; every failure here is swallowed, a hook never blocks
+    try:
+        home = Path(args.home) if args.home else Path.home()
+        cfg = read_config(home)
+        model = str(cfg.get("model") or "")
+        if cfg.get("tandem", True) and model and Path(model).is_file():
+            out = str(Path(str(cfg.get("out") or DEFAULT_OUT)).expanduser())
+            if args.event == "prompt":
+                repo_or_none = _repo_of(Path(cwd))
+                records = _read_records(Path(out) / "evidence.jsonl")
+                tandem.emit(tandem.hook_prompt(home, session_id=rec["session_id"], cwd=cwd,
+                                               prompt=rec["prompt"], repo=repo_or_none, records=records,
+                                               model=model, model_sha256=_model_sha(model),
+                                               python=args.python or sys.executable, out=out))
+            else:
+                tandem.emit(tandem.hook_stop(home, session_id=rec["session_id"]))
+    except Exception:  # noqa: BLE001 - a hook must never fail the prompt
+        pass
     return 0
+
+
+def _repo_of(cwd: Path) -> Path | None:
+    top = subprocess.run(["git", "-C", str(cwd), "rev-parse", "--show-toplevel"], capture_output=True,
+                         text=True).stdout.strip()
+    return Path(top) if top else None
+
+
+_MODEL_SHA_CACHE: dict[str, tuple[float, str]] = {}
+
+
+def _model_sha(model: str) -> str:
+    """sha256 of the model file, cached on mtime so a hook does not hash
+    gigabytes on every prompt."""
+    try:
+        mtime = Path(model).stat().st_mtime
+    except OSError:
+        return ""
+    cache = Path.home() / ".xyntetik" / "shadow" / "model-sha.json"
+    try:
+        d = json.loads(cache.read_text(encoding="utf-8"))
+        if d.get("model") == model and d.get("mtime") == mtime:
+            return str(d.get("sha256") or "")
+    except (OSError, ValueError):
+        pass
+    sha = file_sha256(Path(model))
+    try:
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        cache.write_text(json.dumps({"model": model, "mtime": mtime, "sha256": sha}), encoding="utf-8")
+    except OSError:
+        pass
+    return sha
 
 
 def cmd_install(args: argparse.Namespace) -> int:
@@ -630,6 +683,10 @@ def cmd_install(args: argparse.Namespace) -> int:
     if codex:
         plan.append(f"Codex: a /shadow prompt under {home / '.codex' / 'prompts'} and a marked note in "
                     f"{home / '.codex' / 'AGENTS.md'} saying Runner is here and what it can do")
+    if not args.no_tandem:
+        plan.append("tandem: in a repository where the local model has verified successes on record, "
+                    "each request also gets a background local attempt on a scratch copy; a verified "
+                    "patch is offered, never applied ('shadow tandem off' stops it)")
     plan.append(f"a capability sheet at {home / '.xyntetik' / 'shadow' / 'runner-capabilities.md'} "
                 "(from 'runner --help', '--caps' and the README) the assistants read before "
                 "proposing another local inference tool")
@@ -669,6 +726,8 @@ def cmd_install(args: argparse.Namespace) -> int:
                    claude=claude, codex=codex, model=args.model or picked, runner=args.runner, ctx=args.ctx,
                    gpu=args.gpu, threads=args.threads)
     if done.config:
+        if args.no_tandem:
+            set_config_key(home, "tandem", False)
         print(f"config: {done.config}")
     if done.settings:
         print(f"claude code: {done.hooks_added} hook(s) added to {done.settings} "
@@ -707,6 +766,39 @@ def cmd_routes(args: argparse.Namespace) -> int:
 def cmd_delegate(args: argparse.Namespace) -> int:
     home = Path(args.home) if args.home else Path.home()
     cfg = read_config(home)
+    out = str(Path(args.out or str(cfg.get("out") or DEFAULT_OUT)).expanduser())
+    if args.background:
+        model = str(args.model or cfg.get("model") or "")
+        if not model:
+            print("error: no model in the shadow config", file=sys.stderr)
+            return 2
+        repo = _repo_of(Path(args.repo).resolve())
+        if repo is None:
+            print(f"error: {args.repo} is not inside a git repository", file=sys.stderr)
+            return 2
+        records = _read_records(Path(out) / "evidence.jsonl")
+        route = tandem.qualifies(records, repo.name, _model_sha(model))
+        if route is None:
+            print(f"not started: no task class qualifies for {repo.name} with {Path(model).name} yet "
+                  "('shadow routes' shows the counts)")
+            return 1
+        if any(st.running for st in tandem.states(home)):
+            print("not started: a delegation is already running ('shadow delegations')")
+            return 1
+        bg = tandem.DelegationState(id=tandem.new_id(), session_id=args.session, request=args.request,
+                                    repo=str(repo), started_at=__import__("time").time(), model=model)
+        bg.save(home)
+        spawn_detached([args.python, "-m", "xyntetik_runner.shadow", "delegate", "--repo", str(repo),
+                        "--request", args.request, "--home", str(home), "--python", args.python,
+                        "--out", out, "--record", bg.id])
+        print(f"started delegation {bg.id} in the background ({route.task_class}: {route.verified} verified "
+              f"of {route.attempted} on record); 'shadow delegations' shows it")
+        return 0
+    state: tandem.DelegationState | None = None
+    if args.record:
+        for st in tandem.states(home):
+            if st.id == args.record:
+                state = st
     try:
         if args.endpoint:
             endpoint = RunnerEndpoint(args.endpoint, timeout=args.request_timeout)
@@ -726,7 +818,17 @@ def cmd_delegate(args: argparse.Namespace) -> int:
                      python=args.python, budget=budget)
     except RuntimeError as e:
         print(f"error: {e}", file=sys.stderr)
+        if state is not None:
+            state.status, state.error, state.ended_at = "error", str(e), __import__("time").time()
+            state.save(home)
         return 2
+    _record_delegation(Path(out), d, model_path=str(cfg.get("model") or ""), caps=caps,
+                       endpoint_label=endpoint.base_url)
+    if state is not None:
+        state.status, state.verdict, state.patch_path = "done", d.verdict, d.patch_path
+        state.changed_paths, state.tests_exit, state.task_class = d.changed_paths, d.tests_exit, d.task_class
+        state.ended_at = __import__("time").time()
+        state.save(home)
     if args.json:
         print(d.to_json())
         return 0
@@ -932,6 +1034,61 @@ def cmd_server(args: argparse.Namespace) -> int:
     return 0
 
 
+def _record_delegation(out: Path, d: Any, *, model_path: str, caps: dict[str, Any],
+                       endpoint_label: str) -> None:
+    """A delegation is an attempt with a verdict on the user's own request:
+    it joins the ledger under its own verifier id (the repository's tests
+    at HEAD, not frozen tests), verified only when they passed and no test
+    file was touched, so the funnel widens on evidence and never on a
+    weakened test."""
+    passed = d.tests_exit == 0 if d.tests_exit is not None else None
+    tamper = tuple(d.test_files_changed)
+    verifier: VerifierOutcome | None
+    if not d.changed_paths or passed is None:
+        disposition, verifier = Disposition.VERIFIER_INCONCLUSIVE, None
+    elif passed and not tamper:
+        disposition = Disposition.VERIFIED_LOCAL_ATTEMPT
+        verifier = VerifierOutcome("repo-tests", True, 0, 0, 0, 0, 0, reasons=("repository tests passed at HEAD",))
+    else:
+        disposition = Disposition.LOCAL_FAILED
+        verifier = VerifierOutcome("repo-tests", passed, 0, 0, 0 if passed else 1, 0, 0, tamper=tamper,
+                                   reasons=(("test files changed by the attempt",) if tamper else ("repository tests failed",)))
+    sha = _model_sha(model_path) if model_path else f"unknown:{d.model}"
+    ident = Identity(project=Path(d.repo).name, task_class=d.task_class, context_band=_band(len(d.request)),
+                     tool_set=("list_files", "read_file", "write_file", "edit_file", "run_tests"),
+                     verifier_id="repo-tests", environment_id=f"{platform.node()}|{endpoint_label}",
+                     model_sha256=sha, quant=_quant_from_name(Path(model_path).name) if model_path else "unknown",
+                     template_sha256="unknown", runner_build=str(caps.get("version") or "unknown"),
+                     backend=str(caps.get("backend") or "unknown"), harness_version=HARNESS_VERSION,
+                     scaffold_sha256="base")
+    rec = EpisodeEvidence(episode_id=f"delegation:{Path(d.patch_path).stem}", source="delegation",
+                          observed_at=_now(), disposition=disposition, identity=ident, baseline_sha256="",
+                          patch_sha256=None, changed_paths=d.changed_paths, verifier=verifier,
+                          wall_s=d.wall_s, resources={"turns": float(d.attempt.turns),
+                                                      "tool_calls": float(d.attempt.tool_calls)},
+                          reasons=(f"attempt: {d.attempt.stop_reason}", d.verdict))
+    out.mkdir(parents=True, exist_ok=True)
+    _append(out / "evidence.jsonl", rec)
+
+
+def cmd_delegations(args: argparse.Namespace) -> int:
+    home = Path(args.home) if args.home else Path.home()
+    print(tandem.render_delegations(home, session_id=args.session))
+    return 0
+
+
+def cmd_tandem(args: argparse.Namespace) -> int:
+    home = Path(args.home) if args.home else Path.home()
+    cfg = read_config(home)
+    if args.state in ("on", "off"):
+        set_config_key(home, "tandem", args.state == "on")
+        print(f"tandem {args.state}")
+        return 0
+    print("tandem " + ("on" if cfg.get("tandem", True) and cfg.get("model") else "off")
+          + ("" if cfg.get("model") else " (no model configured)"))
+    return 0
+
+
 def _served_model(endpoint: RunnerEndpoint) -> str:
     caps = endpoint.capabilities()
     models = [m.get("id") for m in caps.get("models", []) if isinstance(m, dict)]
@@ -1052,6 +1209,8 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--session", default="")
     p.add_argument("--prompt", default="")
     p.add_argument("--file", default="")
+    p.add_argument("--home", default="")
+    p.add_argument("--python", default="")
     p.set_defaults(fn=cmd_capture)
     p = sub.add_parser("bench", help="bank + fit probe + replay per model + the verified table, "
                                      "on your own repository")
@@ -1094,6 +1253,7 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--gpu", default="auto")
     p.add_argument("--threads", type=int, default=0)
     p.add_argument("--no-pick", action="store_true", help="without -m, do not look for a model on disk")
+    p.add_argument("--no-tandem", action="store_true", help="no background attempts on prompts")
     p.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
     p.add_argument("--dry-run", action="store_true", help="print what would be written")
     p.set_defaults(fn=cmd_install)
@@ -1114,7 +1274,20 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--request-timeout", type=float, default=900.0)
     p.add_argument("--start-timeout", type=float, default=600.0)
     p.add_argument("--json", action="store_true")
+    p.add_argument("--out", default="", help="ledger directory (default: the shadow config's)")
+    p.add_argument("--background", action="store_true",
+                   help="start detached where the evidence allows it and return at once")
+    p.add_argument("--session", default="", help="with --background: the harness session id")
+    p.add_argument("--record", default="", help=argparse.SUPPRESS)
     p.set_defaults(fn=cmd_delegate)
+    p = sub.add_parser("delegations", help="background delegations and their verdicts")
+    p.add_argument("--home", default="")
+    p.add_argument("--session", default="")
+    p.set_defaults(fn=cmd_delegations)
+    p = sub.add_parser("tandem", help="show or set whether prompts get a background local attempt")
+    p.add_argument("state", nargs="?", choices=("on", "off"), default="")
+    p.add_argument("--home", default="")
+    p.set_defaults(fn=cmd_tandem)
     p = sub.add_parser("adapt", help="overnight: train the configured model's adapter on the ledger's "
                                      "own commits, keep it only on a held-out verified rise")
     p.add_argument("--out", default=str(DEFAULT_OUT))

--- a/python/src/xyntetik_runner/shadow/cli.py
+++ b/python/src/xyntetik_runner/shadow/cli.py
@@ -792,7 +792,8 @@ def cmd_delegate(args: argparse.Namespace) -> int:
                         "--request", args.request, "--home", str(home), "--python", args.python,
                         "--out", out, "--record", bg.id])
         print(f"started delegation {bg.id} in the background ({route.task_class}: {route.verified} verified "
-              f"of {route.attempted} on record); 'shadow delegations' shows it")
+              f"of {route.attempted} on record{'; strong: wait for it first' if route.strong else ''}); "
+              f"'shadow delegations --wait {bg.id}' waits for it")
         return 0
     state: tandem.DelegationState | None = None
     if args.record:
@@ -1073,6 +1074,20 @@ def _record_delegation(out: Path, d: Any, *, model_path: str, caps: dict[str, An
 
 def cmd_delegations(args: argparse.Namespace) -> int:
     home = Path(args.home) if args.home else Path.home()
+    if args.wait:
+        st = tandem.wait_for(home, args.wait, timeout_s=args.timeout)
+        if st is None:
+            print(f"error: no delegation {args.wait}", file=sys.stderr)
+            return 2
+        if st.status == "running":
+            print(f"still running after {int(args.timeout)}s: do the work yourself; 'shadow delegations' later")
+            return 1
+        print(f"delegation {st.id}: {st.status}; verdict: {st.verdict or st.error}; class: {st.task_class}")
+        if st.verified:
+            print(f"verified: tests passed on the scratch copy; patch: {st.patch_path}")
+            print(f"apply with: git apply {st.patch_path}   (the user's call; the working tree is untouched)")
+            return 0
+        return 1
     print(tandem.render_delegations(home, session_id=args.session))
     return 0
 
@@ -1283,6 +1298,8 @@ def main(argv: list[str] | None = None) -> int:
     p = sub.add_parser("delegations", help="background delegations and their verdicts")
     p.add_argument("--home", default="")
     p.add_argument("--session", default="")
+    p.add_argument("--wait", default="", help="block until this delegation ends, then print its verdict")
+    p.add_argument("--timeout", type=float, default=tandem.RUNNING_WALL_S)
     p.set_defaults(fn=cmd_delegations)
     p = sub.add_parser("tandem", help="show or set whether prompts get a background local attempt")
     p.add_argument("state", nargs="?", choices=("on", "off"), default="")

--- a/python/src/xyntetik_runner/shadow/install.py
+++ b/python/src/xyntetik_runner/shadow/install.py
@@ -323,8 +323,14 @@ every request long enough to be work also starts a background attempt on
 a scratch copy while you work on it; the prompt hook tells you so, and a
 verified result is surfaced once at the end of a turn or the start of the
 next. Show it in one line and offer `git apply <patch>`; never apply it.
-`shadow delegations` lists them; `shadow tandem off` stops it. The funnel
-widens by evidence alone: every attempt is recorded in the ledger.
+Where the record is strong (at least 5 attempts, at least 4 in 5
+verified) the hook says "runner first": wait for the delegation with
+`shadow delegations --wait <id>` before doing the work yourself, and do
+it yourself only if the local result is not verified. `shadow
+delegations` lists them; `shadow tandem off` stops it. The funnel widens
+by evidence alone: every attempt is recorded in the ledger, so each
+cycle of adaptation that raises what the local model proves funnels
+more requests to it.
 
 ## Offload a task to the local model (when the user asks for it)
 
@@ -416,7 +422,9 @@ successes on record, run
 and before you finish run
 {prefix}{python} -m xyntetik_runner.shadow delegations
 ; a verified result is shown in one line with `git apply <patch>` offered,
-never applied. `shadow tandem off` stops this.
+never applied. When `delegate --background` says the record is strong,
+wait for it first (`delegations --wait <id>`) and do the work yourself
+only if the local result is not verified. `shadow tandem off` stops this.
 
 Offload a task to the local model (only when the user asks): first
 {prefix}{python} -m xyntetik_runner.shadow routes --out {out}

--- a/python/src/xyntetik_runner/shadow/install.py
+++ b/python/src/xyntetik_runner/shadow/install.py
@@ -50,8 +50,22 @@ def write_config(home: Path, *, model: str, runner: str, ctx: int, gpu: str,
     the serving knobs. Plain JSON the user can read and edit."""
     path = home / CONFIG_REL
     path.parent.mkdir(parents=True, exist_ok=True)
-    data = {"model": model, "runner": runner, "ctx": ctx, "gpu": gpu, "threads": threads,
-            "out": out}
+    data: dict[str, object] = {"model": model, "runner": runner, "ctx": ctx, "gpu": gpu,
+                               "threads": threads, "out": out}
+    old = read_config(home)
+    for key in ("adapter", "tandem"):
+        if key in old:
+            data[key] = old[key]
+    data.setdefault("tandem", True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def set_config_key(home: Path, key: str, value: object) -> Path:
+    path = home / CONFIG_REL
+    data = read_config(home)
+    data[key] = value
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return path
 
@@ -173,7 +187,8 @@ import os
 import sys
 
 try:
-    sys.stdout = open(os.devnull, "w")
+    # stdout is the hook's channel back to the harness (one JSON line at
+    # most); stderr is noise the user must never see
     sys.stderr = open(os.devnull, "w")
     if {pythonpath!r}:
         sys.path.insert(0, {pythonpath!r})
@@ -301,6 +316,16 @@ against the local model (up to 15 minutes each, the fit probe first) and
 it is the user's to start, in their own words. That is how the ledger
 fills; nothing replays by itself.
 
+## Tandem (automatic, in the background, evidence-gated)
+
+In a repository where the local model has verified successes on record,
+every request long enough to be work also starts a background attempt on
+a scratch copy while you work on it; the prompt hook tells you so, and a
+verified result is surfaced once at the end of a turn or the start of the
+next. Show it in one line and offer `git apply <patch>`; never apply it.
+`shadow delegations` lists them; `shadow tandem off` stops it. The funnel
+widens by evidence alone: every attempt is recorded in the ledger.
+
 ## Offload a task to the local model (when the user asks for it)
 
 The harness routes; the runner proves. Offloading is explicit, evidence-gated
@@ -382,6 +407,16 @@ sync imports what the hooks captured, admits the replayable tasks and says
 how many wait for the local model; if any wait, offer `sync --replay N`
 (up to 15 minutes each) and let the user start it in their own words.
 Nothing replays by itself.
+
+Tandem (Codex has no hooks, so this is yours to do): at the start of a
+request that is work, in a repository where the local model has verified
+successes on record, run
+{prefix}{python} -m xyntetik_runner.shadow delegate --repo . --request "<the request verbatim>" --background
+(it returns at once with an id, or says the repository does not qualify)
+and before you finish run
+{prefix}{python} -m xyntetik_runner.shadow delegations
+; a verified result is shown in one line with `git apply <patch>` offered,
+never applied. `shadow tandem off` stops this.
 
 Offload a task to the local model (only when the user asks): first
 {prefix}{python} -m xyntetik_runner.shadow routes --out {out}

--- a/python/src/xyntetik_runner/shadow/routes.py
+++ b/python/src/xyntetik_runner/shadow/routes.py
@@ -1,8 +1,10 @@
 """Where the local model has verified successes (the route table), and
 delegation of one request on a scratch worktree.
 
-The route table is the bench and the ledger read per task class: attempted
-and verified counts for the model stacks recorded, and a qualification rule
+The route table is the bench, the ledger and the recorded delegations read
+per task class: attempted and verified counts for the model stacks recorded
+(a delegation counts as verified only when the repository's tests passed
+and no test file was touched), and a qualification rule
 that is deliberately plain and printed with the numbers, never applied
 silently: a class qualifies when it has at least three attempts and at
 least one verified success, and verified over attempted is at least one
@@ -29,7 +31,7 @@ from xyntetik_runner.shadow.attempt import AttemptResult, Budget, Workspace, att
 from xyntetik_runner.shadow.baseline import Baseline
 from xyntetik_runner.shadow.evidence import Disposition, EpisodeEvidence
 from xyntetik_runner.shadow.scaffold import Scaffold
-from xyntetik_runner.shadow.tasks import import_roots
+from xyntetik_runner.shadow.tasks import class_from_diff, classify, import_roots
 
 MIN_ATTEMPTS = 3
 MIN_VERIFIED = 1
@@ -93,6 +95,8 @@ class Delegation:
     attempt: AttemptResult
     model: str
     wall_s: float
+    task_class: str = "file"
+    test_files_changed: tuple[str, ...] = ()
 
     @property
     def verdict(self) -> str:
@@ -143,6 +147,16 @@ def delegate(repo: Path, request: str, post_json: Any, model: str, *, python: st
             tests_exit = int(first.split()[-1]) if first.startswith("exit code") else None
         diff = subprocess.run(["git", "-C", str(ws_dir), "diff"], capture_output=True,
                               text=True).stdout
+        _tests, src, _other = classify(changes.paths)
+        task_class, _n = ("multi-file" if len(src) > 1 else "file", 0)
+        if len(src) == 1:
+            u0 = subprocess.run(["git", "-C", str(ws_dir), "diff", "-U0", "--", src[0]],
+                                capture_output=True, text=True).stdout
+            try:
+                post = (ws_dir / src[0]).read_text(encoding="utf-8")
+            except OSError:
+                post = ""
+            task_class, _n = class_from_diff(u0, post)
         out_dir = out_dir or (Path.home() / ".xyntetik" / "shadow" / "delegations")
         out_dir.mkdir(parents=True, exist_ok=True)
         stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
@@ -151,7 +165,8 @@ def delegate(repo: Path, request: str, post_json: Any, model: str, *, python: st
         return Delegation(request=request, repo=str(repo), head=head, patch_path=str(patch),
                           changed_paths=changes.paths, tests_exit=tests_exit,
                           tests_tail=tail[-2000:], attempt=result, model=model,
-                          wall_s=round(time.monotonic() - t0, 1))
+                          wall_s=round(time.monotonic() - t0, 1), task_class=task_class,
+                          test_files_changed=tuple(_tests))
     finally:
         subprocess.run(["git", "-C", str(repo), "worktree", "remove", "--force", str(ws_dir)],
                        capture_output=True)

--- a/python/src/xyntetik_runner/shadow/routes.py
+++ b/python/src/xyntetik_runner/shadow/routes.py
@@ -36,6 +36,8 @@ from xyntetik_runner.shadow.tasks import class_from_diff, classify, import_roots
 MIN_ATTEMPTS = 3
 MIN_VERIFIED = 1
 MIN_FRACTION = 0.5
+STRONG_ATTEMPTS = 5
+STRONG_FRACTION = 0.8
 
 
 @dataclass(frozen=True)
@@ -49,6 +51,15 @@ class Route:
     def qualifies(self) -> bool:
         return (self.attempted >= MIN_ATTEMPTS and self.verified >= MIN_VERIFIED
                 and self.verified / self.attempted >= MIN_FRACTION)
+
+    @property
+    def strong(self) -> bool:
+        """Runner first: enough attempts and a high enough verified share
+        that the harness should wait for the local result before doing the
+        work itself. The rule is printed with the numbers, never applied
+        silently."""
+        return (self.qualifies and self.attempted >= STRONG_ATTEMPTS
+                and self.verified / self.attempted >= STRONG_FRACTION)
 
 
 def route_table(records: Iterable[EpisodeEvidence]) -> list[Route]:

--- a/python/src/xyntetik_runner/shadow/tandem.py
+++ b/python/src/xyntetik_runner/shadow/tandem.py
@@ -152,11 +152,20 @@ def hook_prompt(home: Path, *, session_id: str, cwd: str, prompt: str, repo: Pat
                 state.ended_at = time.time()
                 state.save(home)
             else:
-                notes.append(f"shadow: the local model ({Path(model).name}) is attempting this request in "
-                             f"the background on a scratch copy of {repo.name}, because it has "
-                             f"{route.verified} verified of {route.attempted} attempts on record for "
-                             f"{route.task_class} tasks here (delegation {state.id}). Work as usual; if "
-                             f"it ends verified you will be told. `shadow delegations` shows it.")
+                if route.strong:
+                    notes.append(f"shadow: runner first. The local model ({Path(model).name}) has "
+                                 f"{route.verified} verified of {route.attempted} attempts on record for "
+                                 f"{route.task_class} tasks in {repo.name}, so it is attempting this request now "
+                                 f"on a scratch copy (delegation {state.id}). Before doing the work yourself, "
+                                 f"wait for it: run `{python} -m xyntetik_runner.shadow delegations --wait {state.id}`. "
+                                 "If it ends verified, show the patch in one line, offer `git apply <patch>` and "
+                                 "stop; if not, do the work as usual.")
+                else:
+                    notes.append(f"shadow: the local model ({Path(model).name}) is attempting this request in "
+                                 f"the background on a scratch copy of {repo.name}, because it has "
+                                 f"{route.verified} verified of {route.attempted} attempts on record for "
+                                 f"{route.task_class} tasks here (delegation {state.id}). Work as usual; if "
+                                 f"it ends verified you will be told. `shadow delegations` shows it.")
     if not notes:
         return None
     return {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit",
@@ -176,6 +185,24 @@ def hook_stop(home: Path, *, session_id: str) -> dict[str, Any] | None:
                                    f"Patch: {s.patch_path}. Tell the user in one line and offer "
                                    f"`git apply {s.patch_path}`; never apply it yourself. Then stop.")}
     return None
+
+
+def wait_for(home: Path, delegation_id: str, *, timeout_s: float = RUNNING_WALL_S,
+             poll_s: float = 5.0, sleep: Callable[[float], None] = time.sleep) -> DelegationState | None:
+    """Block until the delegation ends or the wall passes; the ended state,
+    or the running one when the wall passed, or None if unknown."""
+    deadline = time.time() + timeout_s
+    while True:
+        found = [s for s in states(home) if s.id == delegation_id]
+        if not found:
+            return None
+        s = found[0]
+        if s.status != "running" or time.time() >= deadline or not s.running:
+            if s.status != "running":
+                s.surfaced = True
+                s.save(home)
+            return s
+        sleep(poll_s)
 
 
 def render_delegations(home: Path, *, session_id: str = "") -> str:

--- a/python/src/xyntetik_runner/shadow/tandem.py
+++ b/python/src/xyntetik_runner/shadow/tandem.py
@@ -1,0 +1,197 @@
+"""Tandem: the local model works beside the harness, in the background,
+where the evidence says it can.
+
+The prompt hook decides in a few milliseconds: is this a request typed in
+a repository where the local model has verified successes on record? If
+so, a bounded delegation starts detached on a scratch worktree while the
+frontier model works in the foreground, and the harness is told so. When
+the local attempt ends verified, the stop hook surfaces the patch once:
+the user sees both results and applies or not. Nothing is applied for
+them, nothing blocks their prompt, and no attempt starts where the ledger
+holds no evidence.
+
+The funnel widens by evidence alone. Every delegation is recorded in the
+ledger with the class its own diff had, so a repository where the local
+model keeps producing verified patches qualifies in more classes, and an
+adapter that raised the held-out count raises the counts here too.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from xyntetik_runner.process import spawn_detached
+from xyntetik_runner.shadow.evidence import EpisodeEvidence
+from xyntetik_runner.shadow.routes import Route, route_table
+
+STATE_DIR_REL = Path(".xyntetik") / "shadow" / "delegations"
+RUNNING_WALL_S = 1200.0  # a delegation older than this without an end is treated as dead
+MIN_REQUEST_CHARS = 24
+
+
+@dataclass
+class DelegationState:
+    id: str
+    session_id: str
+    request: str
+    repo: str
+    started_at: float
+    status: str = "running"  # running | done | error
+    verdict: str = ""
+    patch_path: str = ""
+    changed_paths: tuple[str, ...] = ()
+    tests_exit: int | None = None
+    task_class: str = ""
+    model: str = ""
+    surfaced: bool = False
+    ended_at: float | None = None
+    error: str = ""
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def verified(self) -> bool:
+        return self.status == "done" and self.tests_exit == 0 and bool(self.changed_paths)
+
+    @property
+    def running(self) -> bool:
+        return self.status == "running" and time.time() - self.started_at < RUNNING_WALL_S
+
+    def save(self, home: Path) -> Path:
+        d = home / STATE_DIR_REL
+        d.mkdir(parents=True, exist_ok=True)
+        path = d / f"{self.id}.json"
+        path.write_text(json.dumps(asdict(self), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return path
+
+    @classmethod
+    def load(cls, path: Path) -> DelegationState | None:
+        try:
+            d = json.loads(path.read_text(encoding="utf-8"))
+            d["changed_paths"] = tuple(d.get("changed_paths") or ())
+            return cls(**d)
+        except (ValueError, TypeError, OSError):
+            return None
+
+
+def states(home: Path) -> list[DelegationState]:
+    d = home / STATE_DIR_REL
+    if not d.is_dir():
+        return []
+    out = [s for p in sorted(d.glob("*.json")) if (s := DelegationState.load(p)) is not None]
+    return sorted(out, key=lambda s: s.started_at)
+
+
+def new_id() -> str:
+    return time.strftime("%Y%m%dT%H%M%SZ", time.gmtime()) + f"-{os.getpid() % 10000:04d}"
+
+
+# ---------------------------------------------------------------- the gate
+
+def project_routes(records: Sequence[EpisodeEvidence], project: str, model_sha256: str) -> list[Route]:
+    """The route table restricted to one repository and one model."""
+    return route_table(r for r in records
+                       if r.identity.project == project and r.identity.model_sha256 == model_sha256)
+
+
+def qualifies(records: Sequence[EpisodeEvidence], project: str, model_sha256: str) -> Route | None:
+    """The best qualifying route for this repository and model, or None.
+    Any qualifying class opens the funnel: the verifier decides per attempt."""
+    good = [r for r in project_routes(records, project, model_sha256) if r.qualifies]
+    if not good:
+        return None
+    return max(good, key=lambda r: (r.verified / r.attempted, r.verified))
+
+
+def looks_like_a_task(prompt: str) -> bool:
+    """Cheap and stated: a request long enough to be work, not a slash
+    command, not a one-word answer. The verifier judges the rest."""
+    p = prompt.strip()
+    if len(p) < MIN_REQUEST_CHARS or p.startswith("/"):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------- hooks
+
+def hook_prompt(home: Path, *, session_id: str, cwd: str, prompt: str, repo: Path | None,
+                records: Sequence[EpisodeEvidence], model: str, model_sha256: str, python: str,
+                out: str, spawn: Callable[[list[str]], Any] | None = None) -> dict[str, Any] | None:
+    """Decide and start; return the hook's JSON for the harness, or None."""
+    spawn = spawn or spawn_detached  # resolved at call time, so a test can stand in
+    notes: list[str] = []
+    # a finished attempt from an earlier turn of this session, not yet shown
+    for s in states(home):
+        if s.session_id == session_id and s.status != "running" and not s.surfaced:
+            s.surfaced = True
+            s.save(home)
+            if s.verified:
+                notes.append(f"shadow: the local model's background attempt at an earlier request "
+                             f"(\"{s.request[:80]}\") ended verified: its tests passed on a scratch copy. "
+                             f"Patch: {s.patch_path}. Tell the user in one line and offer "
+                             f"`git apply {s.patch_path}`; never apply it yourself.")
+    if repo is not None and model and looks_like_a_task(prompt):
+        route = qualifies(records, repo.name, model_sha256)
+        busy = any(s.running for s in states(home))
+        if route is not None and not busy:
+            state = DelegationState(id=new_id(), session_id=session_id, request=prompt, repo=str(repo),
+                                    started_at=time.time(), model=model)
+            state.save(home)
+            argv = [python, "-m", "xyntetik_runner.shadow", "delegate", "--repo", str(repo),
+                    "--request", prompt, "--home", str(home), "--python", python, "--out", out,
+                    "--record", state.id]
+            try:
+                spawn(argv)
+            except OSError as e:
+                state.status = "error"
+                state.error = str(e)
+                state.ended_at = time.time()
+                state.save(home)
+            else:
+                notes.append(f"shadow: the local model ({Path(model).name}) is attempting this request in "
+                             f"the background on a scratch copy of {repo.name}, because it has "
+                             f"{route.verified} verified of {route.attempted} attempts on record for "
+                             f"{route.task_class} tasks here (delegation {state.id}). Work as usual; if "
+                             f"it ends verified you will be told. `shadow delegations` shows it.")
+    if not notes:
+        return None
+    return {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit",
+                                   "additionalContext": "\n".join(notes)}}
+
+
+def hook_stop(home: Path, *, session_id: str) -> dict[str, Any] | None:
+    """Surface a verified background result once, at the end of the turn."""
+    for s in states(home):
+        if s.session_id == session_id and s.status != "running" and not s.surfaced:
+            s.surfaced = True
+            s.save(home)
+            if s.verified:
+                return {"decision": "block",
+                        "reason": (f"shadow: the local model's background attempt at \"{s.request[:80]}\" "
+                                   f"ended verified: its tests passed on a scratch copy of {Path(s.repo).name}. "
+                                   f"Patch: {s.patch_path}. Tell the user in one line and offer "
+                                   f"`git apply {s.patch_path}`; never apply it yourself. Then stop.")}
+    return None
+
+
+def render_delegations(home: Path, *, session_id: str = "") -> str:
+    rows = [s for s in states(home) if not session_id or s.session_id == session_id]
+    if not rows:
+        return "no background delegations recorded"
+    lines = ["| started | repo | request | status | verdict | class | patch |", "|---|---|---|---|---|---|---|"]
+    for s in rows[-20:]:
+        status = "running" if s.running else ("stale" if s.status == "running" else s.status)
+        lines.append(f"| {time.strftime('%Y-%m-%d %H:%M', time.gmtime(s.started_at))} | {Path(s.repo).name} | "
+                     f"{s.request[:40]} | {status} | {s.verdict or s.error} | {s.task_class} | {s.patch_path} |")
+    return "\n".join(lines)
+
+
+def emit(payload: dict[str, Any] | None) -> None:
+    """The hook's JSON on stdout, nothing else, so the harness can parse it."""
+    if payload is not None:
+        sys.stdout.write(json.dumps(payload) + "\n")
+        sys.stdout.flush()

--- a/python/src/xyntetik_runner/shadow/tasks.py
+++ b/python/src/xyntetik_runner/shadow/tasks.py
@@ -220,6 +220,13 @@ def change_class(repo: Path, base: str, solution: str, src: Sequence[str]) -> tu
         return ("multi-file" if len(src) > 1 else "file", 0)
     rel = src[0]
     diff = _git(str(repo), "diff", "-U0", base, solution, "--", rel)
+    return class_from_diff(diff, _git(str(repo), "show", f"{solution}:{rel}"))
+
+
+def class_from_diff(diff: str, post_text: str) -> tuple[str, int]:
+    """The class of one file's change from its unified diff (zero context)
+    and the file's post-state text; shared by the committed range and the
+    uncommitted scratch worktree of a delegation."""
     ranges: list[tuple[int, int]] = []
     changed = 0
     for line in diff.split("\n"):
@@ -232,9 +239,8 @@ def change_class(repo: Path, base: str, solution: str, src: Sequence[str]) -> tu
         ranges.append((start, start + max(count, 1) - 1))
     if not ranges:
         return ("file", 0)
-    text = _git(str(repo), "show", f"{solution}:{rel}")
     try:
-        tree = ast.parse(text)
+        tree = ast.parse(post_text)
     except SyntaxError:
         return ("file", changed)
     spans: list[tuple[int, int, str]] = []

--- a/python/tests/test_shadow_pipeline.py
+++ b/python/tests/test_shadow_pipeline.py
@@ -553,7 +553,7 @@ def test_install_confirms_detects_harnesses_and_records_the_model(tmp_path: Path
     rc = main(["install", "--home", str(home), "--python", "py", "--model", str(model), "--runner", "/bin/runner", "--yes"])
     assert rc == 0
     assert (home / ".codex" / "prompts" / "shadow.md").exists() and not (home / ".claude" / "settings.json").exists()
-    assert read_config(home) == {"model": str(model), "runner": "/bin/runner", "ctx": 8192, "gpu": "auto", "threads": 0, "out": "~/.xyntetik/shadow"}
+    assert read_config(home) == {"model": str(model), "runner": "/bin/runner", "ctx": 8192, "gpu": "auto", "threads": 0, "out": "~/.xyntetik/shadow", "tandem": True}
     # nothing at all present and nothing forced: a clear refusal
     empty = tmp_path / "empty"
     empty.mkdir()

--- a/python/tests/test_shadow_tandem.py
+++ b/python/tests/test_shadow_tandem.py
@@ -78,6 +78,33 @@ def test_gate_opens_only_on_this_repository_and_model() -> None:
     assert tandem.looks_like_a_task("fix parse_amount so thousands separators work")
 
 
+def test_strong_record_asks_for_runner_first_and_wait_returns_the_verdict(repo: Path, tmp_path: Path) -> None:
+    from xyntetik_runner.shadow.routes import Route
+    assert Route("function", "m", 5, 4).strong and not Route("function", "m", 5, 3).strong
+    assert not Route("function", "m", 4, 4).strong and Route("function", "m", 4, 4).qualifies
+    home = tmp_path / "home"
+    spawned: list[list[str]] = []
+    recs = [record("proj", "sha1", True)] * 4 + [record("proj", "sha1", False)]
+    out = tandem.hook_prompt(home, session_id="s1", cwd=str(repo), prompt="make parse_amount handle currency",
+                             repo=repo, records=recs, model="/m/coder.gguf", model_sha256="sha1", python="py",
+                             out=str(tmp_path / "out"), spawn=spawned.append)
+    assert out is not None
+    ctx = out["hookSpecificOutput"]["additionalContext"]
+    assert "runner first" in ctx and "delegations --wait" in ctx and "4 verified of 5" in ctx
+    st = tandem.states(home)[0]
+    # wait: the delegation ends while waiting; the verdict comes back and counts as surfaced
+    ticks: list[float] = []
+
+    def sleep(sec: float) -> None:
+        ticks.append(sec)
+        st.status, st.tests_exit, st.changed_paths, st.patch_path = "done", 0, ("calc/money.py",), "/p/y.patch"
+        st.save(home)
+    done = tandem.wait_for(home, st.id, sleep=sleep)
+    assert done is not None and done.verified and done.surfaced and len(ticks) == 1
+    assert tandem.wait_for(home, "nope") is None
+    assert tandem.hook_stop(home, session_id="s1") is None, "already surfaced by the wait"
+
+
 def test_prompt_hook_starts_a_background_attempt_and_the_stop_hook_surfaces_it_once(repo: Path, tmp_path: Path) -> None:
     home = tmp_path / "home"
     spawned: list[list[str]] = []
@@ -205,3 +232,6 @@ def test_recorded_delegation_joins_the_ledger_with_its_class(repo: Path, tmp_pat
     assert "started delegation" in capsys.readouterr().out and len(spawned) == 1 and "--record" in spawned[0]
     assert main(["delegations", "--home", str(home), "--session", "s9"]) == 0
     assert "| running |" in capsys.readouterr().out
+    assert main(["delegations", "--home", str(home), "--wait", "d1"]) == 0
+    assert "git apply" in capsys.readouterr().out
+    assert main(["delegations", "--home", str(home), "--wait", "missing"]) == 2

--- a/python/tests/test_shadow_tandem.py
+++ b/python/tests/test_shadow_tandem.py
@@ -1,0 +1,207 @@
+"""Tandem: the prompt hook starts a background delegation only where the
+ledger shows verified successes for this repository and model, the harness
+is told, the stop hook surfaces a verified result once, and every
+delegation joins the ledger with the class its diff had."""
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from xyntetik_runner.shadow import tandem
+from xyntetik_runner.shadow.cli import main
+from xyntetik_runner.shadow.evidence import Disposition, EpisodeEvidence
+from xyntetik_runner.shadow.install import read_config, write_config
+
+FIXTURE = Path(__file__).parent / "fixtures" / "repair_task_v1"
+BUGGY = (FIXTURE / "workspace" / "calc" / "money.py").read_text(encoding="utf-8")
+VISIBLE = (FIXTURE / "workspace" / "tests" / "test_money.py").read_text(encoding="utf-8")
+CORRECT_FN = '''def parse_amount(text: str) -> int:
+    """Return the amount in integer cents for a decimal money string."""
+    cleaned = "".join(ch for ch in text if ch.isdigit() or ch in "-.")
+    whole, _, frac = cleaned.partition(".")
+    sign = -1 if whole.startswith("-") else 1
+    whole = whole.lstrip("-") or "0"
+    return sign * (int(whole) * 100 + int((frac + "00")[:2]))'''
+CORRECT = '"""Money parsing for the ledger importer."""\n\n\n' + CORRECT_FN + "\n"
+
+
+def git(repo: Path, *args: str) -> str:
+    env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@x", "GIT_COMMITTER_NAME": "t",
+           "GIT_COMMITTER_EMAIL": "t@x"}
+    return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True, env=env,
+                          check=True).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "proj"
+    (r / "calc").mkdir(parents=True)
+    (r / "tests").mkdir()
+    git(tmp_path, "init", "-q", "-b", "main", str(r))
+    (r / "calc" / "__init__.py").write_text("", encoding="utf-8")
+    (r / "calc" / "money.py").write_text(BUGGY, encoding="utf-8")
+    (r / "tests" / "test_money.py").write_text(VISIBLE, encoding="utf-8")
+    git(r, "add", "-A")
+    git(r, "commit", "-q", "-m", "buggy")
+    return r
+
+
+def record(project: str, sha: str, verified: bool, task_class: str = "function") -> EpisodeEvidence:
+    from xyntetik_runner.shadow.evidence import Identity, VerifierOutcome
+    ident = Identity(project=project, task_class=task_class, context_band="s", tool_set=(), verifier_id="v",
+                     environment_id="e", model_sha256=sha, quant="q4", template_sha256="t", runner_build="b",
+                     backend="cpu", harness_version="h", scaffold_sha256="base")
+    v = VerifierOutcome("v", verified, 3, 3 if verified else 2, 0 if verified else 1, 0, 0)
+    return EpisodeEvidence(episode_id=f"e{time.time_ns()}", source="capture", observed_at="now",
+                           disposition=Disposition.VERIFIED_LOCAL_ATTEMPT if verified else Disposition.LOCAL_FAILED,
+                           identity=ident, baseline_sha256="", patch_sha256=None, changed_paths=("x",),
+                           verifier=v, wall_s=1.0)
+
+
+def test_gate_opens_only_on_this_repository_and_model() -> None:
+    recs = [record("proj", "m1", True), record("proj", "m1", True), record("proj", "m1", False),
+            record("other", "m1", True), record("other", "m1", True), record("other", "m1", True),
+            record("proj", "m2", True), record("proj", "m2", True), record("proj", "m2", True)]
+    r = tandem.qualifies(recs, "proj", "m1")
+    assert r is not None and (r.attempted, r.verified) == (3, 2)
+    assert tandem.qualifies(recs, "proj", "m3") is None
+    assert tandem.qualifies(recs[:2], "proj", "m1") is None, "two attempts are not evidence"
+    assert not tandem.looks_like_a_task("/shadow") and not tandem.looks_like_a_task("yes")
+    assert tandem.looks_like_a_task("fix parse_amount so thousands separators work")
+
+
+def test_prompt_hook_starts_a_background_attempt_and_the_stop_hook_surfaces_it_once(repo: Path, tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    spawned: list[list[str]] = []
+    recs = [record("proj", "sha1", True)] * 3
+    common = dict(session_id="s1", cwd=str(repo), repo=repo, records=recs, model="/m/coder.gguf",
+                  model_sha256="sha1", python="py", out=str(tmp_path / "out"), spawn=spawned.append)
+    # a short or slash prompt starts nothing
+    assert tandem.hook_prompt(home, prompt="/shadow", **common) is None and not spawned
+    # a task in a qualifying repository starts one and tells the harness
+    out = tandem.hook_prompt(home, prompt="make parse_amount handle thousands separators", **common)
+    assert out is not None and out["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+    ctx = out["hookSpecificOutput"]["additionalContext"]
+    assert "attempting this request in the background" in ctx and "3 verified of 3" in ctx
+    assert len(spawned) == 1 and spawned[0][:4] == ["py", "-m", "xyntetik_runner.shadow", "delegate"]
+    assert "--record" in spawned[0] and "--background" not in spawned[0]
+    st = tandem.states(home)
+    assert len(st) == 1 and st[0].running and st[0].session_id == "s1"
+    # while one runs, a second prompt starts nothing more; the stop hook says nothing
+    assert tandem.hook_prompt(home, prompt="and also handle currency prefixes please", **common) is None
+    assert len(spawned) == 1
+    assert tandem.hook_stop(home, session_id="s1") is None
+    # the delegation ends verified: the stop hook surfaces it exactly once
+    st[0].status, st[0].tests_exit, st[0].changed_paths = "done", 0, ("calc/money.py",)
+    st[0].patch_path, st[0].verdict, st[0].ended_at = "/p/x.patch", "tests passed on the scratch copy", time.time()
+    st[0].save(home)
+    stop = tandem.hook_stop(home, session_id="s1")
+    assert stop is not None and stop["decision"] == "block" and "git apply /p/x.patch" in stop["reason"]
+    assert tandem.hook_stop(home, session_id="s1") is None, "surfaced once"
+    nxt = tandem.hook_prompt(home, prompt="next request, long enough to count", **common) or {}
+    assert "ended verified" not in nxt.get("hookSpecificOutput", {}).get("additionalContext", ""), "not surfaced twice"
+    # a failed one is never surfaced as a block, and another session's result is not this session's
+    st2 = tandem.DelegationState(id="b", session_id="s2", request="r", repo=str(repo), started_at=time.time() - 5,
+                                 status="done", tests_exit=1, changed_paths=("x",), verdict="tests failed")
+    st2.save(home)
+    assert tandem.hook_stop(home, session_id="s1") is None
+    assert tandem.hook_stop(home, session_id="s2") is None
+    assert "| done | tests failed |" in tandem.render_delegations(home)
+
+
+def test_capture_hook_emits_json_only_when_tandem_applies(repo: Path, tmp_path: Path, capsys: Any, monkeypatch: Any) -> None:
+    from xyntetik_runner.shadow import cli
+    home = tmp_path / "home"
+    out = tmp_path / "out"
+    out.mkdir()
+    model = tmp_path / "coder.gguf"
+    model.write_bytes(b"GGUF")
+    write_config(home, model=str(model), runner="r", ctx=4096, gpu="auto", threads=0, out=str(out))
+    cap = home / ".xyntetik" / "shadow" / "capture.jsonl"
+    spawned: list[list[str]] = []
+    monkeypatch.setattr(tandem, "spawn_detached", spawned.append)
+    monkeypatch.setattr(cli, "_model_sha", lambda m: "sha1")
+    stdin = lambda d: monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(d)))  # noqa: E731
+    # no evidence yet: the hook records and prints nothing
+    stdin({"session_id": "s1", "cwd": str(repo), "prompt": "make parse_amount handle thousands separators"})
+    assert main(["capture", "--event", "prompt", "--file", str(cap), "--home", str(home)]) == 0
+    assert capsys.readouterr().out == "" and not spawned
+    # with evidence for this repository and model: starts, and prints one JSON line
+    with (out / "evidence.jsonl").open("w", encoding="utf-8") as f:
+        for r in [record("proj", "sha1", True)] * 3:
+            f.write(r.to_json() + "\n")
+    stdin({"session_id": "s1", "cwd": str(repo), "prompt": "make parse_amount handle thousands separators"})
+    assert main(["capture", "--event", "prompt", "--file", str(cap), "--home", str(home)]) == 0
+    line = capsys.readouterr().out.strip()
+    assert line and json.loads(line)["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+    assert len(spawned) == 1
+    # tandem off: nothing starts
+    assert main(["tandem", "off", "--home", str(home)]) == 0
+    assert capsys.readouterr().out.strip() == "tandem off"
+    assert read_config(home)["tandem"] is False
+    stdin({"session_id": "s1", "cwd": str(repo), "prompt": "another request that is long enough"})
+    assert main(["capture", "--event", "prompt", "--file", str(cap), "--home", str(home)]) == 0
+    assert capsys.readouterr().out == "" and len(spawned) == 1
+
+
+def test_recorded_delegation_joins_the_ledger_with_its_class(repo: Path, tmp_path: Path, capsys: Any, monkeypatch: Any) -> None:
+    from xyntetik_runner.shadow import cli
+    home = tmp_path / "home"
+    out = tmp_path / "out"
+    model = tmp_path / "coder.gguf"
+    model.write_bytes(b"GGUF")
+    write_config(home, model=str(model), runner="r", ctx=4096, gpu="auto", threads=0, out=str(out))
+
+    class Fixer:
+        def __init__(self, url: str, **k: Any) -> None:
+            self.base_url = url
+            self.n = 0
+
+        def capabilities(self, **k: Any) -> dict[str, Any]:
+            return {"models": [{"id": "coder.gguf"}], "version": "t", "backend": "cpu"}
+
+        def post_json(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+            self.n += 1
+            if self.n == 1:
+                return {"choices": [{"message": {"content": "", "tool_calls": [
+                    {"id": "1", "function": {"name": "write_file", "arguments": json.dumps(
+                        {"path": "calc/money.py", "content": CORRECT})}}]}}]}
+            return {"choices": [{"message": {"content": "", "tool_calls": [
+                {"id": "2", "function": {"name": "finish", "arguments": "{}"}}]}}]}
+    monkeypatch.setattr(cli, "RunnerEndpoint", Fixer)
+    st = tandem.DelegationState(id="d1", session_id="s1", request="fix parse_amount", repo=str(repo),
+                                started_at=time.time())
+    st.save(home)
+    rc = main(["delegate", "--repo", str(repo), "--request", "fix parse_amount", "--endpoint", "http://x",
+               "--python", sys.executable, "--home", str(home), "--out", str(out), "--record", "d1"])
+    text = capsys.readouterr().out
+    assert rc == 0, text
+    done = tandem.states(home)[0]
+    assert done.status == "done" and done.verified and done.task_class == "function"
+    recs = [EpisodeEvidence.from_json(l) for l in (out / "evidence.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert len(recs) == 1 and recs[0].disposition is Disposition.VERIFIED_LOCAL_ATTEMPT
+    assert recs[0].identity.project == "proj" and recs[0].identity.task_class == "function"
+    assert recs[0].identity.verifier_id == "repo-tests" and recs[0].source == "delegation"
+    # the background entry point refuses without evidence, and starts when it has some
+    monkeypatch.setattr(cli, "_model_sha", lambda m: recs[0].identity.model_sha256)
+    spawned: list[list[str]] = []
+    monkeypatch.setattr(cli, "spawn_detached", spawned.append)
+    assert main(["delegate", "--repo", str(repo), "--request", "another change, long enough to count",
+                 "--home", str(home), "--out", str(out), "--background", "--python", "py"]) == 1
+    assert "not started: no task class qualifies" in capsys.readouterr().out
+    with (out / "evidence.jsonl").open("a", encoding="utf-8") as f:
+        for r in [record("proj", recs[0].identity.model_sha256, True)] * 2:
+            f.write(r.to_json() + "\n")
+    assert main(["delegate", "--repo", str(repo), "--request", "another change, long enough to count",
+                 "--home", str(home), "--out", str(out), "--background", "--python", "py", "--session", "s9"]) == 0
+    assert "started delegation" in capsys.readouterr().out and len(spawned) == 1 and "--record" in spawned[0]
+    assert main(["delegations", "--home", str(home), "--session", "s9"]) == 0
+    assert "| running |" in capsys.readouterr().out


### PR DESCRIPTION
## What

- The prompt hook starts a background delegation on a scratch copy when the repository qualifies for the configured model (same route rule as offloading, per repository) and the request is work; the harness is told via \`additionalContext\`. A verified result is surfaced once via a Stop decision or the next prompt's context: offer \`git apply\`, never apply.
- Every delegation joins the ledger with the class of its own diff (\`class_from_diff\`), verifier id \`repo-tests\`, verified only when tests passed and no test file changed. The funnel widens on evidence alone.
- \`shadow tandem on|off\`, \`shadow delegations\`, \`delegate --background --session\` (Codex path, written into its prompt), \`install --no-tandem\`.
- Tests: gate per repository and model, prompt and stop hooks with a stand-in spawn, the capture hook's JSON line and tandem off, a recorded delegation joining the ledger with class \`function\` on a real worktree. Client 118 green, mypy strict clean.